### PR TITLE
Reduce memory leak #30

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -128,7 +128,7 @@ public class App
             } else {
                 LOGGER.warn("No instance could be initiated. Retrying initialization.");
                 config.status.flush();
-                init(config, true);       
+                init(config, false);
             }
             long length = System.currentTimeMillis() - start;
             LOGGER.debug("Iteration ran in " + length  + " ms");


### PR DESCRIPTION
Create a new connection only if needed. Creating too many connection
is causing too many threads to be created. This reduces the memory
leak significantly but is not the sole reason for the memory leak.
