### PR TITLE
Update RemoteConnection.java

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -16,6 +16,7 @@ public class RemoteConnection extends Connection {
     private Integer port;
     private String user;
     private String password;
+    private String path = "jmxrmi";
     private static final String TRUST_STORE_PATH_KEY = "trust_store_path";
     private static final String TRUST_STORE_PASSWORD_KEY = "trust_store_password";
     private final static Logger LOGGER = Logger.getLogger(Connection.class.getName());
@@ -26,6 +27,9 @@ public class RemoteConnection extends Connection {
         port = (Integer) connectionParams.get("port");
         user = (String) connectionParams.get("user");
         password = (String) connectionParams.get("password");
+        if (connectionParams.containsKey("path")){
+            path = (String) connectionParams.get("path");
+        }
         env = getEnv(connectionParams);
         address = getAddress(connectionParams);
         
@@ -57,7 +61,7 @@ public class RemoteConnection extends Connection {
 
     private JMXServiceURL getAddress(
             LinkedHashMap<String, Object> connectionParams) throws MalformedURLException {
-        return new JMXServiceURL("service:jmx:rmi:///jndi/rmi://" + this.host + ":" + this.port +"/jmxrmi"); 
+        return new JMXServiceURL("service:jmx:rmi:///jndi/rmi://" + this.host + ":" + this.port +"/" + this.path); 
     }
 
 


### PR DESCRIPTION
Path at the end of the JMXServiceURL needs to be configurable
While the path in the vast majority of cases is "jmxrmi", this is not always the case:
http://karaf.apache.org/manual/latest/users-guide/monitoring.html
This change allows integration with Apache Karaf containers, while maintaining "jmxrmi" as a default value.