### PR TITLE
fix bad regression with `Status` type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 Changes
 =======
 
-# 0.5.0 / Unreleased
+# 0.5.1 / 04-02-2015
+* [BUGFIX] Fix bad regression with `Status` type. See [#49][]
+
+# 0.5.0 / 03-16-2015
 * [FEATURE] Send service checks for JMX integrations
 * [FEATURE] Support list of filters instead of simple filters: See [#20][]
 
@@ -26,4 +29,5 @@ Changes
 [#26]: https://github.com/DataDog/jmxfetch/issues/26
 [#28]: https://github.com/DataDog/jmxfetch/issues/28
 [#30]: https://github.com/DataDog/jmxfetch/issues/30
+[#49]: https://github.com/DataDog/jmxfetch/issues/49
 [@coupacooke]: https://github.com/coupacooke

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>datadog</groupId>
 	<artifactId>jmxfetch</artifactId>
-	<version>0.5.0</version>
+	<version>0.5.1</version>
 	<packaging>jar</packaging>
 
 	<name>jmxfetch</name>

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -166,7 +166,7 @@ public class App {
         while (it.hasNext()) {
             Instance instance = it.next();
             LinkedList<HashMap<String, Object>> metrics;
-            int instanceStatus = Status.STATUS_OK;
+            String instanceStatus = Status.STATUS_OK;
             String instanceMessage = null;
             try {
                 metrics = instance.getMetrics();
@@ -282,7 +282,7 @@ public class App {
     }
 
     private void reportStatus(AppConfig appConfig, Reporter reporter, Instance instance,
-                              int metricCount, String message, int status) {
+                              int metricCount, String message, String status) {
         String checkName = instance.getCheckName();
         appConfig.getStatus().addInstanceStats(checkName, instance.getName(),
                                                metricCount, message, status);

--- a/src/main/java/org/datadog/jmxfetch/Status.java
+++ b/src/main/java/org/datadog/jmxfetch/Status.java
@@ -10,9 +10,9 @@ import org.yaml.snakeyaml.Yaml;
 
 public class Status {
 
-    public final static int STATUS_WARNING = 1;
-    public final static int STATUS_OK = 0;
-    public final static int STATUS_ERROR = 2;
+    public final static String STATUS_WARNING = "WARNING";
+    public final static String STATUS_OK = "OK";
+    public final static String STATUS_ERROR = "ERROR";
     private final static Logger LOGGER = Logger.getLogger(Status.class.getName());
     private final static String INITIALIZED_CHECKS = "initialized_checks";
     private final static String FAILED_CHECKS = "failed_checks";
@@ -40,12 +40,12 @@ public class Status {
         instanceStats.put(FAILED_CHECKS, new HashMap<String, Object>());
     }
 
-    public void addInstanceStats(String checkName, String instance, int metricCount, String message, int status) {
+    public void addInstanceStats(String checkName, String instance, int metricCount, String message, String status) {
         addStats(checkName, instance, metricCount, message, status, INITIALIZED_CHECKS);
     }
 
     @SuppressWarnings("unchecked")
-    private void addStats(String checkName, String instance, int metricCount, String message, int status, String key) {
+    private void addStats(String checkName, String instance, int metricCount, String message, String status, String key) {
         LinkedList<HashMap<String, Object>> checkStats;
         HashMap<String, Object> initializedChecks;
         initializedChecks = (HashMap<String, Object>) this.instanceStats.get(key);
@@ -70,7 +70,7 @@ public class Status {
         this.instanceStats.put(key, initializedChecks);
     }
 
-    public void addInitFailedCheck(String checkName, String message, int status) {
+    public void addInitFailedCheck(String checkName, String message, String status) {
         addStats(checkName, null, -1, message, status, FAILED_CHECKS);
     }
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
@@ -34,7 +34,7 @@ public class ConsoleReporter extends Reporter {
         return returnedMetrics;
     }
 
-    public void sendServiceCheck(String checkName, int status, String message, String hostname, String[] tags) {
+    public void sendServiceCheck(String checkName, String status, String message, String hostname, String[] tags) {
         String tagString = "";
         if (tags != null && tags.length > 0) {
             tagString = "[" + Joiner.on(",").join(tags) + "]";
@@ -43,7 +43,7 @@ public class ConsoleReporter extends Reporter {
 
         HashMap<String, Object> sc = new HashMap<String, Object>();
         sc.put("name", checkName);
-        sc.put("status", Integer.toString(status));
+        sc.put("status", status);
         sc.put("message", message);
         sc.put("hostname", hostname);
         sc.put("tags", tags);

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -108,7 +108,7 @@ public abstract class Reporter {
 
     protected abstract void sendMetricPoint(String metricName, double value, String[] tags);
 
-    public abstract void sendServiceCheck(String checkName, int status, String message, String hostname, String[] tags);
+    public abstract void sendServiceCheck(String checkName, String status, String message, String hostname, String[] tags);
 
     public abstract void displayMetricReached();
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -31,7 +31,19 @@ public class StatsdReporter extends Reporter {
         statsDClient.gauge(metricName, value, tags);
     }
 
-    public void sendServiceCheck(String checkName, int status, String message,
+    private int statusToInt(String status) {
+        if (status == Status.STATUS_OK) {
+            return 0;
+        } else if (status == Status.STATUS_WARNING) {
+            return 1;
+        } else if (status == Status.STATUS_ERROR) {
+            // critical
+            return 2;
+        }
+        return 3;
+    }
+
+    public void sendServiceCheck(String checkName, String status, String message,
                                  String hostname, String[] tags) {
         if (System.currentTimeMillis() - this.initializationTime > 300 * 1000) {
             this.statsDClient.stop();
@@ -39,7 +51,7 @@ public class StatsdReporter extends Reporter {
         }
 
         ServiceCheck sc = new ServiceCheck(String.format("%s.can_connect", checkName),
-            status, message, hostname, tags);
+            this.statusToInt(status), message, hostname, tags);
         statsDClient.serviceCheck(sc);
     }
 

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -271,7 +271,7 @@ public class TestApp {
         assertNotNull(sc.get("tags"));
 
         String scName = (String) (sc.get("name"));
-        int scStatus = Integer.parseInt((String) (sc.get("status")));
+        String scStatus = (String) (sc.get("status"));
         String[] scTags = (String[]) (sc.get("tags"));
 
         assertEquals("jmx", scName);
@@ -318,7 +318,7 @@ public class TestApp {
         assertNotNull(sc.get("tags"));
 
         String scName = (String) (sc.get("name"));
-        int scStatus = Integer.parseInt((String) (sc.get("status")));
+        String scStatus = (String) (sc.get("status"));
         String[] scTags = (String[]) (sc.get("tags"));
 
         assertEquals("too_many_metrics", scName);
@@ -355,7 +355,7 @@ public class TestApp {
         assertNotNull(sc.get("tags"));
 
         String scName = (String) (sc.get("name"));
-        int scStatus = Integer.parseInt((String) (sc.get("status")));
+        String scStatus = (String) (sc.get("status"));
         String scMessage = (String) (sc.get("message"));
         String[] scTags = (String[]) (sc.get("tags"));
 
@@ -381,7 +381,7 @@ public class TestApp {
         assertNotNull(sc.get("tags"));
 
         scName = (String) (sc.get("name"));
-        scStatus = Integer.parseInt((String) (sc.get("status")));
+        scStatus = (String) (sc.get("status"));
         scMessage = (String) (sc.get("message"));
         scTags = (String[]) (sc.get("tags"));
 


### PR DESCRIPTION
Switching `Status` type from `String` to `int` introduced a bad regression in Datadog agent. 
```
2015-04-01 15:08:57,849 | ERROR | dd.collector | checks.check_status(check_status.py:776) | Couldn't load latest jmx status
> Traceback (most recent call last):
>  File "/home/vagrant/workspace/dd-agent/checks/check_status.py", line 759, in get_jmx_status
>    check_data[check_name]['statuses'].append(get_jmx_instance_status(instance_name, status, message, metric_count))
>  File "/home/vagrant/workspace/dd-agent/checks/check_status.py", line 688, in get_jmx_instance_status
>    return instance_status
> UnboundLocalError: local variable 'instance_status' referenced before assignment
```

This PR reverts the change introduced in: 
https://github.com/DataDog/jmxfetch/pull/38/files#diff-c6d094e1c3c4dcd3b460b535995a43ccR14

@wang-arthur @remh 

