### PR TITLE
Seth/cassandra metrics update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ target/*
 .classpath
 .project
 /target
+.idea
+*.iml
 
 *.ucls
 

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -308,4 +308,8 @@ public abstract class JMXAttribute {
     protected String getDomain() {
         return domain;
     }
+
+    protected HashMap<String, String> getBeanParameters() {
+        return beanParameters;
+    }
 }

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -301,11 +301,11 @@ public abstract class JMXAttribute {
         return tags;
     }
 
-    String getBeanName() {
-        return beanName;
-    }
-
     String getAttributeName() {
         return attributeName;
+    }
+
+    protected String getDomain() {
+        return domain;
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -55,29 +55,33 @@ public abstract class JMXAttribute {
         String[] splitBeanName = this.beanName.split(":");
         String domain = splitBeanName[0];
         String beanParameters = splitBeanName[1];
-        LinkedList<String> defaultTags = getBeanTags(instanceName, domain, beanParameters, instanceTags);
-        HashMap<String, String> beanParametersHash = getBeanParametersHash(defaultTags);
+        HashMap<String, String> beanParametersHash = getBeanParametersHash(beanParameters);
+        LinkedList<String> defaultTags = getBeanTags(instanceName, domain, beanParametersHash, instanceTags);
 
         this.domain = domain;
         this.beanParameters = beanParametersHash;
         this.defaultTagsList = defaultTags;
     }
 
-    private static HashMap<String, String> getBeanParametersHash(LinkedList<String> beanParameters) {
-        HashMap<String, String> beanParams = new HashMap<String, String>();
+    private static HashMap<String, String> getBeanParametersHash(String beanParametersString) {
+        String[] beanParameters = beanParametersString.split(",");
+        HashMap<String, String> beanParamsMap = new HashMap<String, String>(beanParameters.length);
         for (String param : beanParameters) {
-            String[] paramSplit = param.split(":");
-            beanParams.put(new String(paramSplit[0]), new String(paramSplit[1]));
+            String[] paramSplit = param.split("=");
+            beanParamsMap.put(new String(paramSplit[0]), new String(paramSplit[1]));
         }
 
-        return beanParams;
+        return beanParamsMap;
     }
 
 
-    private static LinkedList<String> getBeanTags(String instanceName, String domain, String beanParameters, HashMap<String, String> instanceTags) {
-        LinkedList<String> beanTags = new LinkedList<String>(Arrays.asList(new String(beanParameters).replace("=", ":").split(",")));
+    private static LinkedList<String> getBeanTags(String instanceName, String domain, Map<String, String> beanParameters, Map<String, String> instanceTags) {
+        LinkedList<String> beanTags = new LinkedList<String>();
         beanTags.add("instance:" + instanceName);
         beanTags.add("jmx_domain:" + domain);
+        for (Map.Entry<String, String> param : beanParameters.entrySet()) {
+            beanTags.add(param.getKey() + ":" + param.getValue());
+        }
 
         if (instanceTags != null) {
             for (Map.Entry<String, String> tag : instanceTags.entrySet()) {

--- a/src/main/java/org/datadog/jmxfetch/JMXComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXComplexAttribute.java
@@ -118,9 +118,9 @@ public class JMXComplexAttribute extends JMXAttribute {
         if (include.getAttribute() instanceof LinkedHashMap<?, ?>) {
             return ((LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute())).get(subAttributeName).get("alias");
         } else if (conf.get("metric_prefix") != null) {
-            return conf.get("metric_prefix") + "." + getBeanName().split(":")[0] + "." + subAttributeName;
+            return conf.get("metric_prefix") + "." + getDomain() + "." + subAttributeName;
         }
-        return "jmx." + getBeanName().split(":")[0] + "." + subAttributeName;
+        return "jmx." + getDomain() + "." + subAttributeName;
     }
 
 

--- a/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
@@ -102,7 +102,7 @@ public class JMXSimpleAttribute extends JMXAttribute {
     }
 
     private String getCassandraAlias() {
-        if (getDomain().equals("org.apache.cassandra.metrics")) {
+        if (getDomain().equals(CASSANDRA_DOMAIN)) {
             Map<String, String> beanParameters = getBeanParameters();
             String type = beanParameters.get("type");
             String metricName = beanParameters.get("name");

--- a/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
@@ -91,11 +91,17 @@ public class JMXSimpleAttribute extends JMXAttribute {
             alias = attribute.get(getAttribute().getName()).get("alias");
         } else if (conf.get("metric_prefix") != null) {
             alias = conf.get("metric_prefix") + "." + getDomain() + "." + getAttributeName();
+        } else if (getDomain().startsWith("org.apache.cassandra")) {
+            alias = getCassandraAlias();
         } else {
             alias = "jmx." + getDomain() + "." + getAttributeName();
         }
         alias = convertMetricName(alias);
         return alias;
+    }
+
+    private String getCassandraAlias() {
+        return getDomain().replace("org.apache.", "") + "." + getAttributeName();
     }
 
     private String getMetricType() {

--- a/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
@@ -90,9 +90,9 @@ public class JMXSimpleAttribute extends JMXAttribute {
             LinkedHashMap<String, LinkedHashMap<String, String>> attribute = (LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute());
             alias = attribute.get(getAttribute().getName()).get("alias");
         } else if (conf.get("metric_prefix") != null) {
-            alias = conf.get("metric_prefix") + "." + getBeanName().split(":")[0] + "." + getAttributeName();
+            alias = conf.get("metric_prefix") + "." + getDomain() + "." + getAttributeName();
         } else {
-            alias = "jmx." + getBeanName().split(":")[0] + "." + getAttributeName();
+            alias = "jmx." + getDomain() + "." + getAttributeName();
         }
         alias = convertMetricName(alias);
         return alias;

--- a/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.Map;
 
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
@@ -101,6 +102,17 @@ public class JMXSimpleAttribute extends JMXAttribute {
     }
 
     private String getCassandraAlias() {
+        if (getDomain().equals("org.apache.cassandra.metrics")) {
+            Map<String, String> beanParameters = getBeanParameters();
+            String type = beanParameters.get("type");
+            String metricName = beanParameters.get("name");
+            String attributeName = getAttributeName();
+            if (attributeName.equals("Value")) {
+                return "cassandra." + metricName;
+            }
+            return "cassandra." + metricName + "." + attributeName;
+        }
+        //Deprecated Cassandra metric.  Remove domain prefix.
         return getDomain().replace("org.apache.", "") + "." + getAttributeName();
     }
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -60,8 +60,6 @@ public abstract class Reporter {
             // We need to edit metrics for legacy reasons (rename metrics, etc)
             HashMap<String, Object> metric = new HashMap<String, Object>(m);
 
-            postProcess(metric);
-
             Double currentValue = (Double) metric.get("value");
             if (currentValue.isNaN() || currentValue.isInfinite()) {
                 continue;
@@ -129,7 +127,7 @@ public abstract class Reporter {
         Integer scCount = this.serviceCheckCount.get(checkName);
         return (scCount == null) ? 0 : scCount.intValue();
     }
-    
+
     public void resetServiceCheckCount(String checkName){
         this.serviceCheckCount.put(checkName, new Integer(0));
     }

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -84,6 +84,49 @@ public class TestApp {
     }
 
     @Test
+    public void testCassandraBean() throws Exception {
+        // We expose a few metrics through JMX
+        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        ObjectName objectName = new ObjectName("org.apache.cassandra.metrics:keyspace=MyKeySpace,type=ColumnFamily,scope=MyColumnFamily,name=PendingTasks");
+        SimpleTestJavaApp testApp = new SimpleTestJavaApp();
+        mbs.registerMBean(testApp, objectName);
+
+        // Initializing application
+        AppConfig appConfig = new AppConfig();
+        App app = initApp("jmx_cassandra.yaml", appConfig);
+
+        // Collecting metrics
+        app.doIteration();
+        LinkedList<HashMap<String, Object>> metrics = ((ConsoleReporter) appConfig.getReporter()).getMetrics();
+
+        // 14 = 13 metrics from java.lang + 1 metric explicitly defined in the yaml config file
+        assertEquals(14, metrics.size());
+
+
+        // Fetching our 'defined' metric tags
+        Boolean foundCassandraBean = false;
+        for (HashMap<String, Object> m : metrics) {
+            String name = (String) (m.get("name"));
+            if(!name.equals("cassandra.pending_tasks.should_be100")){
+                continue;
+            }
+            foundCassandraBean = true;
+            String[] tags = (String[]) (m.get("tags"));
+            Set<String> tagsSet = new HashSet<String>(Arrays.asList(tags));
+
+            // We should find bean parameters as tags
+            assertEquals(5, tags.length);
+            assertTrue(tagsSet.contains("type:ColumnFamily"));
+            assertTrue(tagsSet.contains("keyspace:MyKeySpace"));
+            assertTrue(tagsSet.contains("ColumnFamily:MyColumnFamily"));
+            assertTrue(tagsSet.contains("jmx_domain:org.apache.cassandra.metrics"));
+            assertTrue(tagsSet.contains("instance:jmx_test_instance"));
+        }
+        assertTrue(foundCassandraBean);
+        mbs.unregisterMBean(objectName);
+    }
+
+    @Test
     public void testDomainInclude() throws Exception {
         // We expose a few metrics through JMX
         MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();

--- a/src/test/resources/jmx_cassandra.yaml
+++ b/src/test/resources/jmx_cassandra.yaml
@@ -1,0 +1,10 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        conf:
+            - include:
+               bean: org.apache.cassandra.metrics:keyspace=MyKeySpace,type=ColumnFamily,scope=MyColumnFamily,name=PendingTasks
+               attribute:
+                    - ShouldBe100

--- a/src/test/resources/jmx_cassandra_deprecated.yaml
+++ b/src/test/resources/jmx_cassandra_deprecated.yaml
@@ -1,0 +1,10 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        conf:
+            - include:
+               bean: org.apache.cassandra.db:type=ColumnFamilies,keyspace=MyKeySpace,columnfamily=MyColumnFamily
+               attribute:
+                    - ShouldBe100


### PR DESCRIPTION
This allows jmxfetch to properly map the new metrics structure from Cassandra to something more usable.  This is intended to fix #6.

[Cassandra Metrics Reference](http://wiki.apache.org/cassandra/Metrics)

This change does several things:
* Maintains parity for the deprecated Cassandra namespaces
* Remaps metric names to `cassandra.$metric` or `cassandra.$metric.$attribute`
* Drops `name:$name` tag because of redundancy
* Renames `scope:$scope` to `$type:$scope` so users can continue to use 'columnfamily:mytable`, for instance

I also did some refactoring around moving post processing back into the processing of a metric and reusing domain.  I can break that into a separate Pull Request if that's preferable.