### PR TITLE
[activemq58] Proper prefix on service check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 
 	<properties>
 		<commons-io.version>2.4</commons-io.version>
+		<commons-lang.version>2.6</commons-lang.version>
 		<guava.version>17.0</guava.version>
 		<java-dogstatsd-client.version>2.1.0</java-dogstatsd-client.version>
 		<jcommander.version>1.35</jcommander.version>
@@ -51,6 +52,11 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>${commons-io.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<version>${commons-lang.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.datadoghq</groupId>

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -4,6 +4,7 @@ import org.apache.log4j.Logger;
 import org.datadog.jmxfetch.App;
 import org.datadog.jmxfetch.Instance;
 import org.datadog.jmxfetch.JMXAttribute;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -104,6 +105,16 @@ public abstract class Reporter {
 
     private void postProcessCassandra(HashMap<String, Object> metric) {
         metric.put("alias", ((String) metric.get("alias")).replace("jmx.org.apache.", ""));
+    }
+
+    public static String formatDataName(String name){
+        String[] chunks = name.split("\\.");
+        
+        // Escaping the prefix name 
+        chunks[0] = chunks[0].replaceAll("[A-Z0-9:_\\-]", "");
+
+        // Putting the chunks together
+        return StringUtils.join(chunks, ".");
     }
 
     protected abstract void sendMetricPoint(String metricName, double value, String[] tags);

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -50,8 +50,9 @@ public class StatsdReporter extends Reporter {
             init();
         }
 
-        ServiceCheck sc = new ServiceCheck(String.format("%s.can_connect", checkName),
-            this.statusToInt(status), message, hostname, tags);
+        String dataName = Reporter.formatDataName(String.format("%s.can_connect", checkName));
+        ServiceCheck sc = new ServiceCheck(dataName, this.statusToInt(status), message, hostname, tags);
+
         statsDClient.serviceCheck(sc);
     }
 

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -4,6 +4,7 @@ import com.beust.jcommander.JCommander;
 
 import org.apache.log4j.Level;
 import org.datadog.jmxfetch.reporter.ConsoleReporter;
+import org.datadog.jmxfetch.reporter.Reporter;
 import org.datadog.jmxfetch.util.CustomLogger;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -386,6 +387,20 @@ public class TestApp {
         assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
 
         mbs.unregisterMBean(objectName);
+    }
+
+    @Test
+    public void testPrefixFormatter() throws Exception {
+        // Let's get a list of Strings to test (add real versionned check names
+        // here when you add  new versionned check)
+        String[][] data = {
+            {"activemq_58.foo.bar12", "activemq.foo.bar12"},
+            {"test_package-X86_64-VER1:0.weird.metric_name", "testpackage.weird.metric_name" }
+        };
+
+        // Let's test them all
+        for(int i=0; i<data.length; ++i)
+            assertEquals(data[i][1], Reporter.formatDataName(data[i][0]));
     }
 
     @Test


### PR DESCRIPTION
I hacked the StatsDReporter to send the status of activemq.can_connect
instead of activemq_58.can_connect. Hope it was the right place to do
so.