### PR TITLE
[service-checks] JMX Serv. checks sent to dd-agent

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -284,11 +284,13 @@ public class App {
     private void reportStatus(AppConfig appConfig, Reporter reporter, Instance instance,
                               int metricCount, String message, String status) {
         String checkName = instance.getCheckName();
-        appConfig.getStatus().addInstanceStats(checkName, instance.getName(),
-                                               metricCount, message, status);
-
         reporter.sendServiceCheck(checkName, status, message, instance.getHostname(),
                                   instance.getServiceCheckTags());
+
+        appConfig.getStatus().addInstanceStats(checkName, instance.getName(),
+                                               metricCount, reporter.getServiceCheckCount(checkName), 
+                                               message, status);
+        reporter.resetServiceCheckCount(checkName);
     }
 
     public void init(boolean forceNewConnection) {

--- a/src/main/java/org/datadog/jmxfetch/Status.java
+++ b/src/main/java/org/datadog/jmxfetch/Status.java
@@ -4,9 +4,9 @@ import java.io.File;
 import java.util.HashMap;
 import java.util.LinkedList;
 
-import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.yaml.snakeyaml.Yaml;
+import org.apache.commons.io.FileUtils;
 
 public class Status {
 
@@ -40,12 +40,14 @@ public class Status {
         instanceStats.put(FAILED_CHECKS, new HashMap<String, Object>());
     }
 
-    public void addInstanceStats(String checkName, String instance, int metricCount, String message, String status) {
-        addStats(checkName, instance, metricCount, message, status, INITIALIZED_CHECKS);
+    public void addInstanceStats(String checkName, String instance, int metricCount, 
+                                 int serviceCheckCount, String message, String status) {
+        addStats(checkName, instance, metricCount, serviceCheckCount, message, 
+                 status, INITIALIZED_CHECKS);
     }
 
     @SuppressWarnings("unchecked")
-    private void addStats(String checkName, String instance, int metricCount, String message, String status, String key) {
+    private void addStats(String checkName, String instance, int metricCount, int serviceCheckCount, String message, String status, String key) {
         LinkedList<HashMap<String, Object>> checkStats;
         HashMap<String, Object> initializedChecks;
         initializedChecks = (HashMap<String, Object>) this.instanceStats.get(key);
@@ -63,6 +65,9 @@ public class Status {
         if (metricCount != -1) {
             instStats.put("metric_count", metricCount);
         }
+        if(serviceCheckCount != -1){
+            instStats.put("service_check_count", serviceCheckCount);
+        }
         instStats.put("message", message);
         instStats.put("status", status);
         checkStats.add(instStats);
@@ -71,7 +76,7 @@ public class Status {
     }
 
     public void addInitFailedCheck(String checkName, String message, String status) {
-        addStats(checkName, null, -1, message, status, FAILED_CHECKS);
+        addStats(checkName, null, -1, -1, message, status, FAILED_CHECKS);
     }
 
     private String generateYaml() {
@@ -80,7 +85,6 @@ public class Status {
         status.put("timestamp", System.currentTimeMillis());
         status.put("checks", this.instanceStats);
         return yaml.dump(status);
-
     }
 
     public void flush() {

--- a/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
@@ -35,6 +35,8 @@ public class ConsoleReporter extends Reporter {
     }
 
     public void sendServiceCheck(String checkName, String status, String message, String hostname, String[] tags) {
+        this.incrementServiceCheckCount(checkName); 
+	    
         String tagString = "";
         if (tags != null && tags.length > 0) {
             tagString = "[" + Joiner.on(",").join(tags) + "]";

--- a/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
@@ -34,9 +34,7 @@ public class ConsoleReporter extends Reporter {
         return returnedMetrics;
     }
 
-    public void sendServiceCheck(String checkName, String status, String message, String hostname, String[] tags) {
-        this.incrementServiceCheckCount(checkName); 
-	    
+    public void doSendServiceCheck(String checkName, String status, String message, String hostname, String[] tags) {
         String tagString = "";
         if (tags != null && tags.length > 0) {
             tagString = "[" + Joiner.on(",").join(tags) + "]";

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -7,6 +7,7 @@ import org.datadog.jmxfetch.JMXAttribute;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.lang.Integer;
 import java.util.LinkedList;
 
 
@@ -14,7 +15,12 @@ public abstract class Reporter {
 
     private final static Logger LOGGER = Logger.getLogger(App.class.getName());
 
+    private HashMap<String, Integer> serviceCheckCount;
     private HashMap<String, HashMap<String, HashMap<String, Object>>> ratesAggregator = new HashMap<String, HashMap<String, HashMap<String, Object>>>();
+
+    public Reporter() {
+        this.serviceCheckCount = new HashMap<String, Integer>();
+    }
 
     String generateId(HashMap<String, Object> metric) {
         String key = (String) metric.get("alias");
@@ -104,6 +110,24 @@ public abstract class Reporter {
 
     private void postProcessCassandra(HashMap<String, Object> metric) {
         metric.put("alias", ((String) metric.get("alias")).replace("jmx.org.apache.", ""));
+    }
+
+    public void incrementServiceCheckCount(String checkName){
+        int scCount = this.getServiceCheckCount(checkName);
+        this.getServiceCheckCountMap().put(checkName, new Integer(scCount+1));
+    }
+
+    public int getServiceCheckCount(String checkName){
+        Integer scCount = this.serviceCheckCount.get(checkName);
+        return (scCount == null) ? 0 : scCount.intValue();
+    }
+    
+    public void resetServiceCheckCount(String checkName){
+        this.serviceCheckCount.put(checkName, new Integer(0));
+    }
+
+    protected HashMap<String, Integer> getServiceCheckCountMap(){
+        return this.serviceCheckCount;
     }
 
     protected abstract void sendMetricPoint(String metricName, double value, String[] tags);

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -108,6 +108,12 @@ public abstract class Reporter {
         }
     }
 
+    public void sendServiceCheck(String checkName, String status, String message, String hostname, String[] tags){
+        this.incrementServiceCheckCount(checkName);
+
+        this.doSendServiceCheck(checkName, status, message, hostname, tags);
+    }
+
     private void postProcessCassandra(HashMap<String, Object> metric) {
         metric.put("alias", ((String) metric.get("alias")).replace("jmx.org.apache.", ""));
     }
@@ -132,7 +138,7 @@ public abstract class Reporter {
 
     protected abstract void sendMetricPoint(String metricName, double value, String[] tags);
 
-    public abstract void sendServiceCheck(String checkName, String status, String message, String hostname, String[] tags);
+    protected abstract void doSendServiceCheck(String checkName, String status, String message, String hostname, String[] tags);
 
     public abstract void displayMetricReached();
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -43,14 +43,12 @@ public class StatsdReporter extends Reporter {
         return 3;
     }
 
-    public void sendServiceCheck(String checkName, String status, String message,
+    public void doSendServiceCheck(String checkName, String status, String message,
                                  String hostname, String[] tags) {
         if (System.currentTimeMillis() - this.initializationTime > 300 * 1000) {
             this.statsDClient.stop();
             init();
         }
-
-        this.incrementServiceCheckCount(checkName); 
 
         ServiceCheck sc = new ServiceCheck(String.format("%s.can_connect", checkName),
             this.statusToInt(status), message, hostname, tags);

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -50,6 +50,8 @@ public class StatsdReporter extends Reporter {
             init();
         }
 
+        this.incrementServiceCheckCount(checkName); 
+
         ServiceCheck sc = new ServiceCheck(String.format("%s.can_connect", checkName),
             this.statusToInt(status), message, hostname, tags);
         statsDClient.serviceCheck(sc);


### PR DESCRIPTION
The agents gets, through a jmx_status.yaml file, the service checks
sent for each checks. This value is the one displayed when running
datadog-agent info.