### PR TITLE
Added service check prefix formatter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,7 @@
 
 	<properties>
 		<commons-io.version>2.4</commons-io.version>
+		<commons-lang.version>2.6</commons-lang.version>
 		<guava.version>17.0</guava.version>
 		<java-dogstatsd-client.version>2.1.0</java-dogstatsd-client.version>
 		<jcommander.version>1.35</jcommander.version>
@@ -51,6 +52,11 @@
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
 			<version>${commons-io.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>commons-lang</groupId>
+			<artifactId>commons-lang</artifactId>
+			<version>${commons-lang.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.datadoghq</groupId>

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -4,6 +4,7 @@ import org.apache.log4j.Logger;
 import org.datadog.jmxfetch.App;
 import org.datadog.jmxfetch.Instance;
 import org.datadog.jmxfetch.JMXAttribute;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -110,8 +111,9 @@ public abstract class Reporter {
 
     public void sendServiceCheck(String checkName, String status, String message, String hostname, String[] tags){
         this.incrementServiceCheckCount(checkName);
+        String dataName = Reporter.formatServiceCheckPrefix(checkName);
 
-        this.doSendServiceCheck(checkName, status, message, hostname, tags);
+        this.doSendServiceCheck(dataName, status, message, hostname, tags);
     }
 
     private void postProcessCassandra(HashMap<String, Object> metric) {
@@ -134,6 +136,12 @@ public abstract class Reporter {
 
     protected HashMap<String, Integer> getServiceCheckCountMap(){
         return this.serviceCheckCount;
+    }
+
+    public static String formatServiceCheckPrefix(String fullname){
+        String[] chunks = fullname.split("\\.");
+        chunks[0] = chunks[0].replaceAll("[A-Z0-9:_\\-]", "");
+        return StringUtils.join(chunks, ".");
     }
 
     protected abstract void sendMetricPoint(String metricName, double value, String[] tags);

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -417,6 +417,20 @@ public class TestApp {
     }
 
     @Test
+    public void testPrefixFormatter() throws Exception {
+        // Let's get a list of Strings to test (add real versionned check names
+        // here when you add  new versionned check)
+        String[][] data = {
+            {"activemq_58.foo.bar12", "activemq.foo.bar12"},
+            {"test_package-X86_64-VER1:0.weird.metric_name", "testpackage.weird.metric_name" }
+        };
+
+        // Let's test them all
+        for(int i=0; i<data.length; ++i)
+            assertEquals(data[i][1], Reporter.formatServiceCheckPrefix(data[i][0]));
+    }
+
+    @Test
     public void testApp() throws Exception {
         // We expose a few metrics through JMX
         MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -276,7 +276,7 @@ public class TestApp {
         String scStatus = (String) (sc.get("status"));
         String[] scTags = (String[]) (sc.get("tags"));
 
-        assertEquals("jmx", scName);
+        assertEquals(Reporter.formatServiceCheckPrefix("jmx"), scName);
         assertEquals(Status.STATUS_OK, scStatus);
         assertEquals(scTags.length, 1);
         assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
@@ -321,7 +321,7 @@ public class TestApp {
         String scStatus = (String) (sc.get("status"));
         String[] scTags = (String[]) (sc.get("tags"));
 
-        assertEquals("too_many_metrics", scName);
+        assertEquals(Reporter.formatServiceCheckPrefix("too_many_metrics"), scName);
         // We should have a warning status
         assertEquals(Status.STATUS_WARNING, scStatus);
         assertEquals(scTags.length, 1);
@@ -357,7 +357,7 @@ public class TestApp {
         String scMessage = (String) (sc.get("message"));
         String[] scTags = (String[]) (sc.get("tags"));
 
-        assertEquals("non_running_process", scName);
+        assertEquals(Reporter.formatServiceCheckPrefix("non_running_process"), scName);
         assertEquals(Status.STATUS_ERROR, scStatus);
         assertEquals("Cannot connect to instance process_regex: .*non_running_process_test.* Cannot find JVM matching regex: .*non_running_process_test.*", scMessage);
         assertEquals(scTags.length, 1);
@@ -381,7 +381,7 @@ public class TestApp {
         scMessage = (String) (sc.get("message"));
         scTags = (String[]) (sc.get("tags"));
 
-        assertEquals("non_running_process", scName);
+        assertEquals(Reporter.formatServiceCheckPrefix("non_running_process"), scName);
         assertEquals(Status.STATUS_ERROR, scStatus);
         assertEquals("Cannot connect to instance process_regex: .*non_running_process_test.*. Is a JMX Server running at this address?", scMessage);
         assertEquals(scTags.length, 1);


### PR DESCRIPTION
**ATTENTION PLEASE : this PR must be merged  right after this one https://github.com/DataDog/jmxfetch/pull/54 (or the PR 54 must not be merged at all since this one contains everything included in PR 54)**

Indeed, the branch `etienne/sc_prefix_formatter` has been created from `etienne/service_check_count_fix` because it needed a feature from that branch.