### PR TITLE
Wildcard support on domains

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Filter.java
+++ b/src/main/java/org/datadog/jmxfetch/Filter.java
@@ -4,16 +4,19 @@ import java.util.LinkedHashMap;
 import java.util.ArrayList;
 import java.util.Set;
 import java.lang.ClassCastException;
+import java.util.regex.Pattern;
 
 
 class Filter {
     LinkedHashMap<String, Object> filter;
+    Pattern domainRegex;
+    ArrayList<Pattern> beanRegexes = null;
 
     /**
      * A simple class to manipulate include/exclude filter elements more easily
      * A filter may contain:
-     * - A domain (key: 'domain')
-     * - Bean names (key: 'bean' or 'bean_name')
+     * - A domain (key: 'domain') or a domain regex (key: 'domain_regex')
+     * - Bean names (key: 'bean' or 'bean_name') or bean regexes (key: 'bean_regex')
      * - Attributes (key: 'attribute')
      * - Additional bean parameters (other keys)
      */
@@ -23,7 +26,7 @@ class Filter {
         LinkedHashMap<String, Object> castFilter;
         if (filter != null) {
             castFilter = (LinkedHashMap<String, Object>) filter;
-        } else{
+        } else {
             castFilter = new LinkedHashMap<String, Object>();
         }
         this.filter = castFilter;
@@ -78,8 +81,46 @@ class Filter {
         return toStringArrayList(beanNames);
     }
 
+    private static ArrayList<Pattern> toPatternArrayList(final Object toCast) {
+        ArrayList<Pattern> patternArrayList = new ArrayList<Pattern>();
+        ArrayList<String> stringArrayList = toStringArrayList(toCast);
+        for (String string : stringArrayList) {
+            patternArrayList.add(Pattern.compile(string));
+        }
+
+        return patternArrayList;
+    }
+
+    public ArrayList<Pattern> getBeanRegexes() {
+        // Return bean regexes as an ArrayList of Pattern whether it's defined as
+        // a list or not
+
+        if (this.beanRegexes == null) {
+            if (filter.get("bean_regex") == null){
+                this.beanRegexes = new ArrayList<Pattern>();
+            } else {
+                final Object beanRegexNames = filter.get("bean_regex");
+                this.beanRegexes = toPatternArrayList(beanRegexNames);
+            }
+        }
+
+        return this.beanRegexes;
+    }
+
     public String getDomain() {
         return (String) filter.get("domain");
+    }
+
+    public Pattern getDomainRegex() {
+        if (this.filter.get("domain_regex") == null) {
+            return null;
+        }
+
+        if (this.domainRegex == null) {
+            this.domainRegex = Pattern.compile((String) this.filter.get("domain_regex"));
+        }
+
+        return this.domainRegex;
     }
 
     public Object getAttribute() {

--- a/src/test/resources/jmx_domain_regex.yaml
+++ b/src/test/resources/jmx_domain_regex.yaml
@@ -1,0 +1,14 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        conf:
+            - include:
+                domain_regex: .*includeme.*
+                attribute:
+                    ShouldBe100:
+                        metric_type: gauge
+                        alias: this.is.100
+              exclude:
+                domain_regex: .*\.me$

--- a/src/test/resources/jmx_list_beans_regex_exclude.yaml
+++ b/src/test/resources/jmx_list_beans_regex_exclude.yaml
@@ -1,0 +1,18 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        tags:
+            env: stage
+            newTag: test
+        conf:
+            - include:
+                attribute:
+                    ShouldBe100:
+                        metric_type: gauge
+                        alias: this.is.100
+              exclude:
+                bean_regex:
+                     - .*[,:]type=ExcludeMe.*
+                     - .*[,:]scope=Out.*

--- a/src/test/resources/jmx_list_beans_regex_include.yaml
+++ b/src/test/resources/jmx_list_beans_regex_include.yaml
@@ -1,0 +1,17 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        tags:
+            env: stage
+            newTag: test
+        conf:
+            - include:
+               bean_regex:
+                    - .*type=\w*WrongType
+                    - .*type=Include.*
+               attribute:
+                    ShouldBe100:
+                        metric_type: gauge
+                        alias: this.is.100


### PR DESCRIPTION
@yannmh 
Adds support for wildcards at the end of domain names.

For instance:
```
- include:
   domain: org.foo*
```
would match the domains `org.foo` and `org.foo.bar`, but not `org.foobar`.

I'll update https://github.com/DataDog/documentation accordingly if you're ok with this behaviour.