### PR TITLE
Rename 'host' bean parameter to 'bean_host' in tags

### DIFF
--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -48,7 +48,7 @@ public class TestApp {
     public void testBeanTags() throws Exception {
         // We expose a few metrics through JMX
         MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-        ObjectName objectName = new ObjectName("org.datadog.jmxfetch.test:type=SimpleTestJavaApp,scope=CoolScope");
+        ObjectName objectName = new ObjectName("org.datadog.jmxfetch.test:type=SimpleTestJavaApp,scope=CoolScope,host=localhost");
         SimpleTestJavaApp testApp = new SimpleTestJavaApp();
         mbs.registerMBean(testApp, objectName);
 
@@ -74,11 +74,13 @@ public class TestApp {
         	Set<String> tagsSet = new HashSet<String>(Arrays.asList(tags));
 
         	// We should find bean parameters as tags
-        	assertEquals(4, tags.length);
+            assertEquals(5, tags.length);
         	assertEquals(true, tagsSet.contains("type:SimpleTestJavaApp"));
         	assertEquals(true, tagsSet.contains("scope:CoolScope"));
         	assertEquals(true, tagsSet.contains("instance:jmx_test_instance"));
         	assertEquals(true, tagsSet.contains("jmx_domain:org.datadog.jmxfetch.test"));
+            // Special case of the 'host' parameter which tag is renamed to 'bean_host'
+            assertEquals(true, tagsSet.contains("bean_host:localhost"));
         }
         mbs.unregisterMBean(objectName);
     }

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -66,19 +66,19 @@ public class TestApp {
 
         // Fetching our 'defined' metric tags
         for (HashMap<String, Object> m : metrics) {
-        	String name = (String) (m.get("name"));
-        	if(!name.equals("this.is.100")){
-        		continue;
-        	}
-        	String[] tags = (String[]) (m.get("tags"));
-        	Set<String> tagsSet = new HashSet<String>(Arrays.asList(tags));
+            String name = (String) (m.get("name"));
+            if(!name.equals("this.is.100")){
+                continue;
+            }
+            String[] tags = (String[]) (m.get("tags"));
+            Set<String> tagsSet = new HashSet<String>(Arrays.asList(tags));
 
-        	// We should find bean parameters as tags
+            // We should find bean parameters as tags
             assertEquals(5, tags.length);
-        	assertEquals(true, tagsSet.contains("type:SimpleTestJavaApp"));
-        	assertEquals(true, tagsSet.contains("scope:CoolScope"));
-        	assertEquals(true, tagsSet.contains("instance:jmx_test_instance"));
-        	assertEquals(true, tagsSet.contains("jmx_domain:org.datadog.jmxfetch.test"));
+            assertEquals(true, tagsSet.contains("type:SimpleTestJavaApp"));
+            assertEquals(true, tagsSet.contains("scope:CoolScope"));
+            assertEquals(true, tagsSet.contains("instance:jmx_test_instance"));
+            assertEquals(true, tagsSet.contains("jmx_domain:org.datadog.jmxfetch.test"));
             // Special case of the 'host' parameter which tag is renamed to 'bean_host'
             assertEquals(true, tagsSet.contains("bean_host:localhost"));
         }
@@ -128,8 +128,8 @@ public class TestApp {
         // First filter 14 = 13 metrics from java.lang + 2 metrics explicitly define- 1 implicitly defined in the exclude section
         assertEquals(14, metrics.size());
 
-    	mbs.unregisterMBean(includeMe);
-    	mbs.unregisterMBean(excludeMe);
+        mbs.unregisterMBean(includeMe);
+        mbs.unregisterMBean(excludeMe);
     }
 
     @Test

--- a/src/test/resources/jmx_bean_tags.yaml
+++ b/src/test/resources/jmx_bean_tags.yaml
@@ -5,13 +5,13 @@ instances:
         name: jmx_test_instance
         conf:
             - include:
-               bean: org.datadog.jmxfetch.test:type=SimpleTestJavaApp,scope=CoolScope
+               bean: org.datadog.jmxfetch.test:type=SimpleTestJavaApp,scope=CoolScope,host=localhost
                attribute:
                     ShouldBe100:
                         metric_type: gauge
                         alias: this.is.100
             - include:
-               bean: org.datadog.jmxfetch.test:type=WrongType,scope=WrongScope
+               bean: org.datadog.jmxfetch.test:type=WrongType,scope=WrongScope,host=localhost
                attribute:
                     Hashmap.thisis0:
                         metric_type: gauge


### PR DESCRIPTION
@yannmh Fixes the case when a bean parameter named 'host' overrides the actual 'host' tag.