### PR TITLE
Support bean names that have an attribute with an empty value

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -67,7 +67,11 @@ public abstract class JMXAttribute {
         HashMap<String, String> beanParams = new HashMap<String, String>();
         for (String param : beanParameters) {
             String[] paramSplit = param.split(":");
-            beanParams.put(new String(paramSplit[0]), new String(paramSplit[1]));
+            if (paramSplit.length > 1) {
+                beanParams.put(new String(paramSplit[0]), new String(paramSplit[1]));
+            } else {
+                beanParams.put(new String(paramSplit[0]), "");
+            }
         }
 
         return beanParams;
@@ -94,6 +98,9 @@ public abstract class JMXAttribute {
             // the 'host' parameter is renamed to 'bean_host'
             if (beanParameter.startsWith("host:")) {
                 defaultTagsList.add("bean_host:" + beanParameter.substring("host:".length()));
+            } else if (beanParameter.endsWith(":")) {
+                // If the parameter's value is empty, remove the colon in the tag
+                defaultTagsList.add(beanParameter.substring(0, beanParameter.length() - 1));
             } else {
                 defaultTagsList.add(beanParameter);
             }

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -48,7 +48,7 @@ public class TestApp {
     public void testBeanTags() throws Exception {
         // We expose a few metrics through JMX
         MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-        ObjectName objectName = new ObjectName("org.datadog.jmxfetch.test:type=SimpleTestJavaApp,scope=CoolScope,host=localhost");
+        ObjectName objectName = new ObjectName("org.datadog.jmxfetch.test:type=SimpleTestJavaApp,scope=CoolScope,host=localhost,component=");
         SimpleTestJavaApp testApp = new SimpleTestJavaApp();
         mbs.registerMBean(testApp, objectName);
 
@@ -74,13 +74,15 @@ public class TestApp {
             Set<String> tagsSet = new HashSet<String>(Arrays.asList(tags));
 
             // We should find bean parameters as tags
-            assertEquals(5, tags.length);
+            assertEquals(6, tags.length);
             assertEquals(true, tagsSet.contains("type:SimpleTestJavaApp"));
             assertEquals(true, tagsSet.contains("scope:CoolScope"));
             assertEquals(true, tagsSet.contains("instance:jmx_test_instance"));
             assertEquals(true, tagsSet.contains("jmx_domain:org.datadog.jmxfetch.test"));
             // Special case of the 'host' parameter which tag is renamed to 'bean_host'
             assertEquals(true, tagsSet.contains("bean_host:localhost"));
+            // Empty values should also be added as tags, without the colon
+            assertEquals(true, tagsSet.contains("component"));
         }
         mbs.unregisterMBean(objectName);
     }

--- a/src/test/resources/jmx_bean_tags.yaml
+++ b/src/test/resources/jmx_bean_tags.yaml
@@ -5,13 +5,13 @@ instances:
         name: jmx_test_instance
         conf:
             - include:
-               bean: org.datadog.jmxfetch.test:type=SimpleTestJavaApp,scope=CoolScope,host=localhost
+               bean: org.datadog.jmxfetch.test:type=SimpleTestJavaApp,scope=CoolScope,host=localhost,component=
                attribute:
                     ShouldBe100:
                         metric_type: gauge
                         alias: this.is.100
             - include:
-               bean: org.datadog.jmxfetch.test:type=WrongType,scope=WrongScope,host=localhost
+               bean: org.datadog.jmxfetch.test:type=WrongType,scope=WrongScope,host=localhost,component=
                attribute:
                     Hashmap.thisis0:
                         metric_type: gauge


### PR DESCRIPTION
cc @remh 
The java docs allow MBean attributes to have empty values (see http://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html).
Before this fix JMXAttribute was assuming that values were not empty and would throw an unexpected exception upon parsing such a bean name (https://datadog.zendesk.com/agent/tickets/27140).

This fixes the issue. Attributes with empty values are filtered out of the default tags.