### PR TITLE
Limit MBeans query to certain scopes

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Configuration.java
+++ b/src/main/java/org/datadog/jmxfetch/Configuration.java
@@ -1,6 +1,14 @@
 package org.datadog.jmxfetch;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.Map.Entry;
+import java.util.Set;
 
 public class Configuration {
 
@@ -9,7 +17,9 @@ public class Configuration {
     private Filter exclude;
 
     /**
-     * A simple class to access configuration elements more easily
+     * Access configuration elements more easily
+     *
+     * Also provides helper methods to extract common information among filters.
      */
     public Configuration(LinkedHashMap<String, Object> conf) {
         this.conf = conf;
@@ -20,7 +30,6 @@ public class Configuration {
     public LinkedHashMap<String, Object> getConf() {
         return conf;
     }
-
     public Filter getInclude() {
         return include;
     }
@@ -31,6 +40,214 @@ public class Configuration {
 
     public String toString() {
         return "include: " + this.include + " - exclude: " + this.exclude;
+    }
+
+    private Boolean hasInclude(){
+        return getInclude() != null;
+    }
+
+    /**
+     * Filter a configuration list to keep the ones with `include` filters.
+     *
+     * @param configurationList         the configuration list to filter
+     *
+     * @return                          a configuration list
+     */
+    private static LinkedList<Configuration> getIncludeConfigurationList(LinkedList<Configuration> configurationList){
+        LinkedList<Configuration> includeConfigList = new LinkedList<Configuration>(configurationList);
+        Iterator<Configuration> confItr = includeConfigList.iterator();
+
+        while(confItr.hasNext()) {
+            Configuration conf = confItr.next();
+            if (!conf.hasInclude()) {
+                confItr.remove();
+            }
+        }
+        return includeConfigList;
+    }
+
+    /**
+     * Extract `include` filters from the configuration list and index then by domain name.
+     *
+     * @param configurationList         the configuration list to process
+     *
+     * @return                          filters by domain name
+     */
+    private static HashMap<String, LinkedList<Filter>> getIncludeFiltersByDomain(LinkedList<Configuration> configurationList){
+        HashMap<String, LinkedList<Filter>> includeFiltersByDomain = new HashMap<String, LinkedList<Filter>>();
+
+        for (Configuration conf : configurationList) {
+            Filter filter = conf.getInclude();
+            LinkedList<Filter> filters = new LinkedList<Filter>();
+
+            // Convert bean name, to a proper filter, i.e. a hash
+            if (!filter.isEmptyBeanName()) {
+                ArrayList<String> beanNames = filter.getBeanNames();
+
+                for (String beanName : beanNames) {
+                    String[] splitBeanName = beanName.split(":");
+                    String domain = splitBeanName[0];
+                    String rawBeanParameters = splitBeanName[1];
+                    LinkedList<String> beanParameters = new LinkedList<String>(Arrays.asList(new String(rawBeanParameters).replace("=", ":").split(",")));
+                    HashMap<String, String> beanParametersHash = JMXAttribute.getBeanParametersHash(beanParameters);
+                    beanParametersHash.put("domain", domain);
+                    filters.add(new Filter(beanParametersHash));
+                }
+            } else {
+                filters.add(filter);
+            }
+
+            for (Filter f: filters) {
+                //  Retrieve the existing filters for the domain, add the new filters
+                LinkedList<Filter> domainFilters;
+                String domainName = f.getDomain();
+
+                if (includeFiltersByDomain.containsKey(domainName)) {
+                    domainFilters = includeFiltersByDomain.get(domainName);
+                } else {
+                    domainFilters = new LinkedList<Filter>();
+                }
+
+                domainFilters.add(f);
+                includeFiltersByDomain.put(domainName, domainFilters);
+            }
+        }
+        return includeFiltersByDomain;
+   }
+
+    /**
+     * Extract, among filters, bean key parameters in common.
+     *
+     * @param filtersByDomain       filters by domain name
+     *
+     * @return                      common bean key parameters by domain name
+     */
+    private static HashMap<String, Set<String>> getCommonBeanKeysByDomain(HashMap<String, LinkedList<Filter>> filtersByDomain){
+        HashMap<String, Set<String>> beanKeysIntersectionByDomain = new HashMap<String,Set<String>>();
+
+        Iterator<Entry<String, LinkedList<Filter>>> filtersByDomainItr = filtersByDomain.entrySet().iterator();
+        while (filtersByDomainItr.hasNext()) {
+            Entry<String, LinkedList<Filter>> filtersEntry = filtersByDomainItr.next();
+            String domainName = (String) filtersEntry.getKey();
+            LinkedList<Filter> mFilters= (LinkedList<Filter>) filtersEntry.getValue();
+
+            // Compute keys intersection
+            Set<String> keysIntersection = new HashSet<String>(mFilters.getFirst().keySet());
+
+            for (Filter f: mFilters) {
+                keysIntersection.retainAll(f.keySet());
+            }
+
+            // Remove special parameters
+            for(String param : JMXAttribute.getExcludeBeanParams()){
+                keysIntersection.remove(param);
+            }
+
+            beanKeysIntersectionByDomain.put(domainName, keysIntersection);
+        }
+        return beanKeysIntersectionByDomain;
+    }
+
+    /**
+     * Build a map of common bean keys->values, with the specified bean keys, among the given filters.
+     *
+     * @param beanKeysByDomain      bean keys by domain name
+     * @param filtersByDomain       filters by domain name
+     *
+     * @return                      bean pattern (keys->values) by domain name
+     */
+    private static HashMap<String, LinkedHashMap<String, String>> getCommonScopeByDomain(HashMap<String, Set<String>> beanKeysByDomain, HashMap<String, LinkedList<Filter>> filtersByDomain){
+        // Compute a common scope a among filters by domain name
+        HashMap<String, LinkedHashMap<String, String>> commonScopeByDomain = new HashMap<String, LinkedHashMap<String, String>>();
+
+        Iterator<Entry<String, Set<String>>> commonParametersByDomainItr = beanKeysByDomain.entrySet().iterator();
+        while(commonParametersByDomainItr.hasNext()){
+           Entry<String, Set<String>> commonParametersByDomainEntry = commonParametersByDomainItr.next();
+           String domainName = (String) commonParametersByDomainEntry.getKey();
+           Set<String> commonParameters = (Set<String>) commonParametersByDomainEntry.getValue();
+           LinkedList<Filter> filters = filtersByDomain.get(domainName);
+           LinkedHashMap<String, String> commonScope = new LinkedHashMap<String, String>();
+
+           for (String parameter : commonParameters) {
+                // Check if all values associated with the parameters are the same
+                String commonValue = null;
+                Boolean hasCommonValue = true;
+                Iterator<Filter> filtersItr = filters.iterator();
+
+                while(filtersItr.hasNext() && hasCommonValue){
+                    Filter f = filtersItr.next();
+                    ArrayList<String> parameterValues = f.getParameterValues(parameter);
+
+                    if (parameterValues.size() != 1 || (commonValue != null && !commonValue.equals(parameterValues.get(0)))) {
+                        hasCommonValue = false;
+                        continue;
+                    }
+
+                    commonValue = parameterValues.get(0);
+
+                }
+                if (hasCommonValue) {
+                    commonScope.put(parameter, commonValue);
+                }
+           }
+           commonScopeByDomain.put(domainName, commonScope);
+       }
+       return commonScopeByDomain;
+    }
+
+    /**
+     * Stringify a bean pattern.
+     *
+     * @param domain                domain name
+     * @param beanScope             map of bean keys-> values
+     *
+     * @return                      string pattern identifying the bean scope
+     */
+    private static String beanScopeToString(String domain, LinkedHashMap<String, String> beanScope){
+        String result = "";
+
+        // Domain
+        domain = (domain != null) ? domain : "*";
+        result += domain + ":";
+
+        // Scope parameters
+        Iterator<Entry<String, String>> beanScopeItr = beanScope.entrySet().iterator();
+        while(beanScopeItr.hasNext()){
+            Entry<String, String> beanScopeEntry = beanScopeItr.next();
+            String param = (String) beanScopeEntry.getKey();
+            String value = (String) beanScopeEntry.getValue();
+
+            result += param + "=" + value + ",";
+        }
+        result += "*";
+
+        return result;
+    }
+
+    /**
+     * Find, among the configuration list, a potential common bean pattern by domain name.
+     *
+     * @param configurationList         the configuration list to process
+     *
+     * @return                          common bean pattern strings
+     */
+    public static LinkedList<String> getGreatestCommonScopes(LinkedList<Configuration> configurationList){
+        LinkedList<Configuration> includeConfigList = getIncludeConfigurationList(configurationList);
+        HashMap<String, LinkedList<Filter>> includeFiltersByDomain = getIncludeFiltersByDomain(includeConfigList);
+        HashMap<String, Set<String>> parametersIntersectionByDomain = getCommonBeanKeysByDomain(includeFiltersByDomain);
+        HashMap<String, LinkedHashMap<String, String>> commonBeanScopeByDomain = getCommonScopeByDomain(parametersIntersectionByDomain, includeFiltersByDomain);
+
+        LinkedList<String> result = new LinkedList<String>();
+        Iterator<Entry<String, LinkedHashMap<String, String>>> commonBeanScopeItr = commonBeanScopeByDomain.entrySet().iterator();
+        while(commonBeanScopeItr.hasNext()){
+            Entry<String, LinkedHashMap<String, String>> beanScopeEntry = commonBeanScopeItr.next();
+            String domain = (String) beanScopeEntry.getKey();
+            LinkedHashMap<String, String> beanScope = (LinkedHashMap<String, String>) beanScopeEntry.getValue();
+
+            result.add(beanScopeToString(domain, beanScope));
+        }
+
+        return result;
     }
 
 }

--- a/src/main/java/org/datadog/jmxfetch/Configuration.java
+++ b/src/main/java/org/datadog/jmxfetch/Configuration.java
@@ -113,7 +113,7 @@ public class Configuration {
             }
         }
         return includeFiltersByDomain;
-   }
+    }
 
     /**
      * Extract, among filters, bean key parameters in common.
@@ -125,11 +125,9 @@ public class Configuration {
     private static HashMap<String, Set<String>> getCommonBeanKeysByDomain(HashMap<String, LinkedList<Filter>> filtersByDomain){
         HashMap<String, Set<String>> beanKeysIntersectionByDomain = new HashMap<String,Set<String>>();
 
-        Iterator<Entry<String, LinkedList<Filter>>> filtersByDomainItr = filtersByDomain.entrySet().iterator();
-        while (filtersByDomainItr.hasNext()) {
-            Entry<String, LinkedList<Filter>> filtersEntry = filtersByDomainItr.next();
-            String domainName = (String) filtersEntry.getKey();
-            LinkedList<Filter> mFilters= (LinkedList<Filter>) filtersEntry.getValue();
+        for (Entry<String, LinkedList<Filter>> filtersEntry : filtersByDomain.entrySet()) {
+            String domainName = filtersEntry.getKey();
+            LinkedList<Filter> mFilters= filtersEntry.getValue();
 
             // Compute keys intersection
             Set<String> keysIntersection = new HashSet<String>(mFilters.getFirst().keySet());
@@ -139,12 +137,13 @@ public class Configuration {
             }
 
             // Remove special parameters
-            for(String param : JMXAttribute.getExcludeBeanParams()){
+            for(String param : JMXAttribute.getExcludedBeanParams()){
                 keysIntersection.remove(param);
             }
 
             beanKeysIntersectionByDomain.put(domainName, keysIntersection);
         }
+
         return beanKeysIntersectionByDomain;
     }
 
@@ -160,39 +159,36 @@ public class Configuration {
         // Compute a common scope a among filters by domain name
         HashMap<String, LinkedHashMap<String, String>> commonScopeByDomain = new HashMap<String, LinkedHashMap<String, String>>();
 
-        Iterator<Entry<String, Set<String>>> commonParametersByDomainItr = beanKeysByDomain.entrySet().iterator();
-        while(commonParametersByDomainItr.hasNext()){
-           Entry<String, Set<String>> commonParametersByDomainEntry = commonParametersByDomainItr.next();
-           String domainName = (String) commonParametersByDomainEntry.getKey();
-           Set<String> commonParameters = (Set<String>) commonParametersByDomainEntry.getValue();
-           LinkedList<Filter> filters = filtersByDomain.get(domainName);
-           LinkedHashMap<String, String> commonScope = new LinkedHashMap<String, String>();
+        for (Entry<String, Set<String>> commonParametersByDomainEntry : beanKeysByDomain.entrySet()) {
+            String domainName = commonParametersByDomainEntry.getKey();
+            Set<String> commonParameters = commonParametersByDomainEntry.getValue();
+            LinkedList<Filter> filters = filtersByDomain.get(domainName);
+            LinkedHashMap<String, String> commonScope = new LinkedHashMap<String, String>();
 
-           for (String parameter : commonParameters) {
+            for (String parameter : commonParameters) {
                 // Check if all values associated with the parameters are the same
                 String commonValue = null;
                 Boolean hasCommonValue = true;
-                Iterator<Filter> filtersItr = filters.iterator();
 
-                while(filtersItr.hasNext() && hasCommonValue){
-                    Filter f = filtersItr.next();
+                for (Filter f : filters) {
                     ArrayList<String> parameterValues = f.getParameterValues(parameter);
 
                     if (parameterValues.size() != 1 || (commonValue != null && !commonValue.equals(parameterValues.get(0)))) {
                         hasCommonValue = false;
-                        continue;
-                    }
+                        break;
+                 }
 
-                    commonValue = parameterValues.get(0);
+                commonValue = parameterValues.get(0);
 
-                }
-                if (hasCommonValue) {
-                    commonScope.put(parameter, commonValue);
-                }
-           }
-           commonScopeByDomain.put(domainName, commonScope);
-       }
-       return commonScopeByDomain;
+             }
+             if (hasCommonValue) {
+                commonScope.put(parameter, commonValue);
+             }
+         }
+        commonScopeByDomain.put(domainName, commonScope);
+     }
+
+    return commonScopeByDomain;
     }
 
     /**
@@ -211,11 +207,9 @@ public class Configuration {
         result += domain + ":";
 
         // Scope parameters
-        Iterator<Entry<String, String>> beanScopeItr = beanScope.entrySet().iterator();
-        while(beanScopeItr.hasNext()){
-            Entry<String, String> beanScopeEntry = beanScopeItr.next();
-            String param = (String) beanScopeEntry.getKey();
-            String value = (String) beanScopeEntry.getValue();
+        for (Entry<String, String> beanScopeEntry : beanScope.entrySet()) {
+            String param = beanScopeEntry.getKey();
+            String value = beanScopeEntry.getValue();
 
             result += param + "=" + value + ",";
         }
@@ -238,11 +232,10 @@ public class Configuration {
         HashMap<String, LinkedHashMap<String, String>> commonBeanScopeByDomain = getCommonScopeByDomain(parametersIntersectionByDomain, includeFiltersByDomain);
 
         LinkedList<String> result = new LinkedList<String>();
-        Iterator<Entry<String, LinkedHashMap<String, String>>> commonBeanScopeItr = commonBeanScopeByDomain.entrySet().iterator();
-        while(commonBeanScopeItr.hasNext()){
-            Entry<String, LinkedHashMap<String, String>> beanScopeEntry = commonBeanScopeItr.next();
-            String domain = (String) beanScopeEntry.getKey();
-            LinkedHashMap<String, String> beanScope = (LinkedHashMap<String, String>) beanScopeEntry.getValue();
+
+        for (Entry<String, LinkedHashMap<String, String>> beanScopeEntry: commonBeanScopeByDomain.entrySet()) {
+            String domain = beanScopeEntry.getKey();
+            LinkedHashMap<String, String> beanScope = beanScopeEntry.getValue();
 
             result.add(beanScopeToString(domain, beanScope));
         }

--- a/src/main/java/org/datadog/jmxfetch/Connection.java
+++ b/src/main/java/org/datadog/jmxfetch/Connection.java
@@ -48,8 +48,10 @@ public class Connection {
         return mbs.getMBeanInfo(bean_name).getAttributes();
     }
 
-    public Set<ObjectInstance> queryMBeans() throws IOException {
-        return mbs.queryMBeans(null, null);
+    public Set<ObjectInstance> queryMBeans(ObjectName name) throws IOException {
+        String scope = (name != null) ? name.toString() : "*:*";
+        LOGGER.debug("Querying beans on scope: " + scope);
+        return mbs.queryMBeans(name, null);
     }
 
     protected void createConnection() throws IOException {

--- a/src/main/java/org/datadog/jmxfetch/Filter.java
+++ b/src/main/java/org/datadog/jmxfetch/Filter.java
@@ -1,6 +1,6 @@
 package org.datadog.jmxfetch;
 
-import java.util.LinkedHashMap;
+import java.util.HashMap;
 import java.util.ArrayList;
 import java.util.Set;
 import java.lang.ClassCastException;
@@ -8,7 +8,7 @@ import java.util.regex.Pattern;
 
 
 class Filter {
-    LinkedHashMap<String, Object> filter;
+    HashMap<String, Object> filter;
     Pattern domainRegex;
     ArrayList<Pattern> beanRegexes = null;
 
@@ -23,11 +23,11 @@ class Filter {
 
     @SuppressWarnings("unchecked")
     public Filter(Object filter) {
-        LinkedHashMap<String, Object> castFilter;
+        HashMap<String, Object> castFilter;
         if (filter != null) {
-            castFilter = (LinkedHashMap<String, Object>) filter;
+            castFilter = (HashMap<String, Object>) filter;
         } else {
-            castFilter = new LinkedHashMap<String, Object>();
+            castFilter = new HashMap<String, Object>();
         }
         this.filter = castFilter;
     }
@@ -39,7 +39,6 @@ class Filter {
     public Set<String> keySet() {
         return filter.keySet();
     }
-
 
     @SuppressWarnings({ "unchecked", "serial" })
     private static ArrayList<String> toStringArrayList(final Object toCast) {

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -281,6 +281,7 @@ public class Instance {
         }
         catch (Exception e) {
             e.printStackTrace();
+            LOGGER.error("Unable to compute a common bean scope, querying all beans as a fallback");
             this.beans = connection.queryMBeans(null);
         }
         this.lastRefreshTime = System.currentTimeMillis();

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -356,7 +356,7 @@ public abstract class JMXAttribute {
         return attributeName;
     }
 
-    public static List<String> getExcludeBeanParams(){
+    public static List<String> getExcludedBeanParams(){
         return EXCLUDED_BEAN_PARAMS;
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -64,7 +64,7 @@ public abstract class JMXAttribute {
         this.defaultTagsList = renameConflictingParameters(beanParametersList);
     }
 
-    private static HashMap<String, String> getBeanParametersHash(LinkedList<String> beanParameters) {
+    public static HashMap<String, String> getBeanParametersHash(LinkedList<String> beanParameters) {
         HashMap<String, String> beanParams = new HashMap<String, String>();
         for (String param : beanParameters) {
             String[] paramSplit = param.split(":");
@@ -354,5 +354,9 @@ public abstract class JMXAttribute {
 
     String getAttributeName() {
         return attributeName;
+    }
+
+    public static List<String> getExcludeBeanParams(){
+        return EXCLUDED_BEAN_PARAMS;
     }
 }

--- a/src/test/java/org/datadog/jmxfetch/TestConfiguration.java
+++ b/src/test/java/org/datadog/jmxfetch/TestConfiguration.java
@@ -1,0 +1,172 @@
+package org.datadog.jmxfetch;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.Set;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class TestConfiguration {
+	static LinkedList<Configuration> configurations = new LinkedList<Configuration>();
+
+	/**
+	 * Setup Configuration tests
+	 * @throws FileNotFoundException
+	 */
+	@SuppressWarnings("unchecked")
+	@BeforeClass
+    public static void init() throws FileNotFoundException {
+		File f = new File("src/test/resources/", "jmx_bean_scope.yaml");
+		String yamlPath = f.getAbsolutePath();
+		FileInputStream yamlInputStream = new FileInputStream(yamlPath);
+		YamlParser fileConfig = new YamlParser(yamlInputStream);
+		ArrayList<LinkedHashMap<String, Object>> configInstances = ((ArrayList<LinkedHashMap<String, Object>>) fileConfig.getYamlInstances());
+
+		for (LinkedHashMap<String, Object> config : configInstances) {
+			Object yamlConf = config.get("conf");
+			for (LinkedHashMap<String, Object> conf : (ArrayList<LinkedHashMap<String, Object>>) (yamlConf)) {
+			    configurations.add(new Configuration(conf));
+			}
+		}
+    }
+
+	/**
+	 * Extract filters from the configuration list and index by domain name
+	 * @throws SecurityException
+	 * @throws NoSuchMethodException
+	 * @throws InvocationTargetException
+	 * @throws IllegalArgumentException
+	 * @throws IllegalAccessException
+	 */
+	@Test
+	public void testFiltersByDomain() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException{
+		// Private method reflection
+		Method getIncludeFiltersByDomain = Configuration.class.getDeclaredMethod("getIncludeFiltersByDomain", LinkedList.class);
+		getIncludeFiltersByDomain.setAccessible(true);
+
+		// Assert
+		HashMap<String, LinkedList<Filter>> filtersByDomain = (HashMap<String, LinkedList<Filter>>) getIncludeFiltersByDomain.invoke(null, configurations);
+
+		// Only contains 'org.datadog.jmxfetch.test' domain
+		assertEquals(filtersByDomain.size(), 1);
+		assertTrue(filtersByDomain.containsKey("org.datadog.jmxfetch.test"));
+
+		// 5 filters associated: 4 `include`s (but the last one is split in two)
+		assertEquals(filtersByDomain.get("org.datadog.jmxfetch.test").size(), 5);
+	}
+
+
+	/**
+	 * Extract common bean keys among a given list of filters.
+	 * @throws SecurityException
+	 * @throws NoSuchMethodException
+	 * @throws InvocationTargetException
+	 * @throws IllegalArgumentException
+	 * @throws IllegalAccessException
+	 */
+	@Test
+	public void testCommonBeanKeys() throws FileNotFoundException, NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException{
+		// Private method reflection
+		Method getIncludeFiltersByDomain = Configuration.class.getDeclaredMethod("getIncludeFiltersByDomain", LinkedList.class);
+		getIncludeFiltersByDomain.setAccessible(true);
+
+		Method getCommonBeanKeysByDomain = Configuration.class.getDeclaredMethod("getCommonBeanKeysByDomain", HashMap.class);
+		getCommonBeanKeysByDomain.setAccessible(true);
+
+		// Assert
+		HashMap<String, LinkedList<Filter>> filtersByDomain = (HashMap<String, LinkedList<Filter>>) getIncludeFiltersByDomain.invoke(null, configurations);
+		HashMap<String, Set<String>> parametersIntersectionByDomain = (HashMap<String, Set<String>>) getCommonBeanKeysByDomain.invoke(null, filtersByDomain);
+
+		// Only contains 'org.datadog.jmxfetch.test' domain
+		assertEquals(parametersIntersectionByDomain.size(), 1);
+		assertTrue(parametersIntersectionByDomain.containsKey("org.datadog.jmxfetch.test"));
+
+		// Parameters intersection should match: 'param', 'scope' and 'type'
+		Set<String> parameters = parametersIntersectionByDomain.get("org.datadog.jmxfetch.test");
+		assertEquals(parameters.size(), 3);
+		assertTrue(parameters.contains("param"));
+		assertTrue(parameters.contains("scope"));
+		assertTrue(parameters.contains("type"));
+	}
+
+	/**
+	 * Extract common bean keys among a given list of filters.
+	 * @throws SecurityException
+	 * @throws NoSuchMethodException
+	 * @throws InvocationTargetException
+	 * @throws IllegalArgumentException
+	 * @throws IllegalAccessException
+	 */
+	@Test
+	public void testCommonScope() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException{
+		// Private method reflection
+		Method getIncludeFiltersByDomain = Configuration.class.getDeclaredMethod("getIncludeFiltersByDomain", LinkedList.class);
+		getIncludeFiltersByDomain.setAccessible(true);
+
+		Method getCommonBeanKeysByDomain = Configuration.class.getDeclaredMethod("getCommonBeanKeysByDomain", HashMap.class);
+		getCommonBeanKeysByDomain.setAccessible(true);
+
+		Method getCommonScopeByDomain = Configuration.class.getDeclaredMethod("getCommonScopeByDomain", HashMap.class, HashMap.class);
+		getCommonScopeByDomain.setAccessible(true);
+
+		// Assert
+		HashMap<String, LinkedList<Filter>> filtersByDomain = (HashMap<String, LinkedList<Filter>>) getIncludeFiltersByDomain.invoke(null, configurations);
+		HashMap<String, Set<String>> parametersIntersectionByDomain = (HashMap<String, Set<String>>) getCommonBeanKeysByDomain.invoke(null, filtersByDomain);
+		HashMap<String, LinkedHashMap<String, String>> commonBeanScopeByDomain = (HashMap<String, LinkedHashMap<String, String>>) getCommonScopeByDomain.invoke(null, parametersIntersectionByDomain, filtersByDomain);
+
+		// Only contains 'org.datadog.jmxfetch.test' domain
+		assertEquals(commonBeanScopeByDomain.size(), 1);
+		assertTrue(commonBeanScopeByDomain.containsKey("org.datadog.jmxfetch.test"));
+		LinkedHashMap<String, String> beanScope = commonBeanScopeByDomain.get("org.datadog.jmxfetch.test");
+
+		// Bean scope contains 'scope' parameter only
+		assertEquals(beanScope.size(), 1);
+		assertTrue(beanScope.containsKey("scope"));
+
+		// Common value is 'sameScope'
+		assertEquals(beanScope.get("scope"), "sameScope");
+
+	}
+
+	/**
+	 * Stringify a bean pattern to comply with the representation of a MBean
+	 * @throws SecurityException
+	 * @throws NoSuchMethodException
+	 * @throws InvocationTargetException
+	 * @throws IllegalArgumentException
+	 * @throws IllegalAccessException
+	 */
+	@Test
+	public void testBeanScopeToString() throws NoSuchMethodException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException{
+		// Private method reflection
+		Method beanScopeToString = Configuration.class.getDeclaredMethod("beanScopeToString", String.class, LinkedHashMap.class);
+		beanScopeToString.setAccessible(true);
+
+		// Mock parameters
+		LinkedHashMap<String, String> beanScope = new LinkedHashMap<String, String>();
+		beanScope.put("type", "someType");
+		beanScope.put("param", "someParam");
+
+		// No domain name, no parameters
+		assertEquals((String) beanScopeToString.invoke(null, null, new LinkedHashMap<String, String>()), "*:*");
+
+		// No domain but parameters
+		assertEquals((String) beanScopeToString.invoke(null, null, beanScope), "*:type=someType,param=someParam,*");
+
+		// Domain name with no parameters
+		assertEquals((String) beanScopeToString.invoke(null, "org.datadog.com", new LinkedHashMap<String, String>()), "org.datadog.com:*");
+
+		// Domain name with parameters
+		assertEquals((String) beanScopeToString.invoke(null, "org.datadog.com", beanScope), "org.datadog.com:type=someType,param=someParam,*");
+	}
+}

--- a/src/test/resources/jmx_bean_scope.yaml
+++ b/src/test/resources/jmx_bean_scope.yaml
@@ -1,0 +1,28 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        conf:
+            - include:
+               domain: org.datadog.jmxfetch.test
+               scope: sameScope
+               type: sameType
+               param: sameParam
+               additional: additionalParam
+            - include:
+               domain: org.datadog.jmxfetch.test
+               scope: sameScope
+               type: sameType
+               param: sameParam
+            - include:
+               domain: org.datadog.jmxfetch.test
+               scope: sameScope
+               type:
+                 - sameType
+                 - notTheSameType
+               param: sameParam
+            - include:
+               bean:
+                - org.datadog.jmxfetch.test:scope=sameScope,param=sameParam,type=sameType
+                - org.datadog.jmxfetch.test:scope=sameScope,param=notTheSameParam,type=sameType


### PR DESCRIPTION
JMXFetch is currently fetching all available beans regardless of the
user configuration. This might cause a high memory load when the
application is exposing a lot of metrics (thus OOM issues).

This change is the first step towards a bigger JMXFetch memory
consumption improvement: the idea is to find, among the user defined
beans, some common patterns to limit the scopes to query.

For instance,
```
- org.datadog.jmxfetch.test:scope=sameScope,param=sameParam,type=sameType
- org.datadog.jmxfetch.test:scope=sameScope,param=notTheSameParam,type=sameType
```
would induce a query on `org.datadog.jmxfetch.test:scope=sameScope,type=sameType,*`
instead of `*:*`.

At the moment, only one scope per domain name is computed: it's kind of
the greatest common divisor/pattern of the beans.

Ideally, this should be improved to recognize multiple scopes among the
same domain name.