### PR TITLE
Remove host name from service checks payloads

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -290,8 +290,7 @@ public class App {
     private void reportStatus(AppConfig appConfig, Reporter reporter, Instance instance,
                               int metricCount, String message, String status) {
         String checkName = instance.getCheckName();
-        reporter.sendServiceCheck(checkName, status, message, instance.getHostname(),
-                                  instance.getServiceCheckTags());
+        reporter.sendServiceCheck(checkName, status, message, instance.getServiceCheckTags());
 
         appConfig.getStatus().addInstanceStats(checkName, instance.getName(),
                                                metricCount, reporter.getServiceCheckCount(checkName),

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -298,15 +298,6 @@ public class Instance {
         return this.instanceName;
     }
 
-    public String getHostname(){
-        Object host = this.yaml.get("host");
-        if (host != null) {
-            return host.toString();
-        } else {
-            return null;
-        }
-    }
-
     LinkedHashMap<String, Object> getYaml() {
         return this.yaml;
     }

--- a/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
@@ -34,7 +34,7 @@ public class ConsoleReporter extends Reporter {
         return returnedMetrics;
     }
 
-    public void doSendServiceCheck(String checkName, String status, String message, String hostname, String[] tags) {
+    public void doSendServiceCheck(String checkName, String status, String message, String[] tags) {
         String tagString = "";
         if (tags != null && tags.length > 0) {
             tagString = "[" + Joiner.on(",").join(tags) + "]";
@@ -45,7 +45,6 @@ public class ConsoleReporter extends Reporter {
         sc.put("name", checkName);
         sc.put("status", status);
         sc.put("message", message);
-        sc.put("hostname", hostname);
         sc.put("tags", tags);
         serviceChecks.add(sc);
     }

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -109,11 +109,11 @@ public abstract class Reporter {
         }
     }
 
-    public void sendServiceCheck(String checkName, String status, String message, String hostname, String[] tags){
+    public void sendServiceCheck(String checkName, String status, String message, String[] tags){
         this.incrementServiceCheckCount(checkName);
         String dataName = Reporter.formatServiceCheckPrefix(checkName);
 
-        this.doSendServiceCheck(dataName, status, message, hostname, tags);
+        this.doSendServiceCheck(dataName, status, message, tags);
     }
 
     private void postProcessCassandra(HashMap<String, Object> metric) {
@@ -146,7 +146,7 @@ public abstract class Reporter {
 
     protected abstract void sendMetricPoint(String metricName, double value, String[] tags);
 
-    protected abstract void doSendServiceCheck(String checkName, String status, String message, String hostname, String[] tags);
+    protected abstract void doSendServiceCheck(String checkName, String status, String message, String[] tags);
 
     public abstract void displayMetricReached();
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -43,15 +43,14 @@ public class StatsdReporter extends Reporter {
         return 3;
     }
 
-    public void doSendServiceCheck(String checkName, String status, String message,
-                                 String hostname, String[] tags) {
+    public void doSendServiceCheck(String checkName, String status, String message, String[] tags) {
         if (System.currentTimeMillis() - this.initializationTime > 300 * 1000) {
             this.statsDClient.stop();
             init();
         }
 
         ServiceCheck sc = new ServiceCheck(String.format("%s.can_connect", checkName),
-            this.statusToInt(status), message, hostname, tags);
+            this.statusToInt(status), message, tags);
         statsDClient.serviceCheck(sc);
     }
 

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -481,9 +481,6 @@ public class TestApp {
 
     @Test
     public void testServiceCheckCounter() throws Exception {
-        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-        SimpleTestJavaApp testApp = new SimpleTestJavaApp();
-
         AppConfig appConfig = new AppConfig();
         App app = initApp("jmx.yaml", appConfig);
         Reporter repo = appConfig.getReporter();
@@ -494,7 +491,7 @@ public class TestApp {
         // Let's put a service check in the pipeline (we cannot call doIteration()
         // here unfortunately because it would call reportStatus which will flush
         // the count to the jmx_status.yaml file and reset the counter.
-        repo.sendServiceCheck("jmx", Status.STATUS_OK, "This is a test", "jmx_test_instance", null);
+        repo.sendServiceCheck("jmx", Status.STATUS_OK, "This is a test", null);
 
         // Let's check that the counter has been updated
         assertEquals(1, repo.getServiceCheckCount("jmx"));


### PR DESCRIPTION
The host name that is currently sent is the `host` defined in the yaml config for each instance, which is preventing the backend from correctly assigning host tags to the service checks.

This removes it completely ; the forwarder will take care of adding the correct hostname.

BC break: for users who have set up monitors on service checks filtered by `host`, the service check will disappear (because the value of the tag changes with this PR). Currently this value is `localhost` for most users and therefore quite useless, but it could still be used by a few orgs. We should probably reach out to all the orgs that use JMXFetch before we release this.