### PR TITLE
Replace host metadata in dogstasd payload with host tag

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -290,8 +290,7 @@ public class App {
     private void reportStatus(AppConfig appConfig, Reporter reporter, Instance instance,
                               int metricCount, String message, String status) {
         String checkName = instance.getCheckName();
-        reporter.sendServiceCheck(checkName, status, message, instance.getHostname(),
-                                  instance.getServiceCheckTags());
+        reporter.sendServiceCheck(checkName, status, message, instance.getServiceCheckTags());
 
         appConfig.getStatus().addInstanceStats(checkName, instance.getName(),
                                                metricCount, reporter.getServiceCheckCount(checkName),

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -290,21 +290,15 @@ public class Instance {
     public String[] getServiceCheckTags() {
 
         List<String> tags = new ArrayList<String>();
+        if (this.yaml.get("host") != null) {
+            tags.add("jmx_server:" + this.yaml.get("host"));
+        }
         tags.add("instance:" + this.instanceName);
         return tags.toArray(new String[tags.size()]);
     }
 
     public String getName() {
         return this.instanceName;
-    }
-
-    public String getHostname(){
-        Object host = this.yaml.get("host");
-        if (host != null) {
-            return host.toString();
-        } else {
-            return null;
-        }
     }
 
     LinkedHashMap<String, Object> getYaml() {

--- a/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
@@ -34,7 +34,7 @@ public class ConsoleReporter extends Reporter {
         return returnedMetrics;
     }
 
-    public void doSendServiceCheck(String checkName, String status, String message, String hostname, String[] tags) {
+    public void doSendServiceCheck(String checkName, String status, String message, String[] tags) {
         String tagString = "";
         if (tags != null && tags.length > 0) {
             tagString = "[" + Joiner.on(",").join(tags) + "]";
@@ -45,7 +45,6 @@ public class ConsoleReporter extends Reporter {
         sc.put("name", checkName);
         sc.put("status", status);
         sc.put("message", message);
-        sc.put("hostname", hostname);
         sc.put("tags", tags);
         serviceChecks.add(sc);
     }

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -109,11 +109,11 @@ public abstract class Reporter {
         }
     }
 
-    public void sendServiceCheck(String checkName, String status, String message, String hostname, String[] tags){
+    public void sendServiceCheck(String checkName, String status, String message, String[] tags){
         this.incrementServiceCheckCount(checkName);
         String dataName = Reporter.formatServiceCheckPrefix(checkName);
 
-        this.doSendServiceCheck(dataName, status, message, hostname, tags);
+        this.doSendServiceCheck(dataName, status, message, tags);
     }
 
     private void postProcessCassandra(HashMap<String, Object> metric) {
@@ -146,7 +146,7 @@ public abstract class Reporter {
 
     protected abstract void sendMetricPoint(String metricName, double value, String[] tags);
 
-    protected abstract void doSendServiceCheck(String checkName, String status, String message, String hostname, String[] tags);
+    protected abstract void doSendServiceCheck(String checkName, String status, String message, String[] tags);
 
     public abstract void displayMetricReached();
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -43,15 +43,14 @@ public class StatsdReporter extends Reporter {
         return 3;
     }
 
-    public void doSendServiceCheck(String checkName, String status, String message,
-                                 String hostname, String[] tags) {
+    public void doSendServiceCheck(String checkName, String status, String message, String[] tags) {
         if (System.currentTimeMillis() - this.initializationTime > 300 * 1000) {
             this.statsDClient.stop();
             init();
         }
 
         ServiceCheck sc = new ServiceCheck(String.format("%s.can_connect", checkName),
-            this.statusToInt(status), message, hostname, tags);
+            this.statusToInt(status), message, tags);
         statsDClient.serviceCheck(sc);
     }
 

--- a/src/test/java/org/datadog/jmxfetch/CommonTestSetup.java
+++ b/src/test/java/org/datadog/jmxfetch/CommonTestSetup.java
@@ -1,0 +1,25 @@
+package org.datadog.jmxfetch;
+
+import com.beust.jcommander.JCommander;
+import org.apache.log4j.Level;
+import org.datadog.jmxfetch.util.CustomLogger;
+
+public class CommonTestSetup {
+    public static void setupLogger() {
+        CustomLogger.setup(Level.toLevel("ALL"), "/tmp/jmxfetch_test.log");
+    }
+
+    public static App initApp(String yamlFileName, AppConfig appConfig){
+        // We do a first collection
+        // We initialize the main app that will collect these metrics using JMX
+        String confdDirectory = Thread.currentThread().getContextClassLoader().getResource(yamlFileName).getPath();
+        confdDirectory = new String(confdDirectory.substring(0, confdDirectory.length() - yamlFileName.length()));
+        String[] params = {"--reporter", "console", "-c", yamlFileName, "--conf_directory", confdDirectory, "collect"};
+        new JCommander(appConfig, params);
+
+        App app = new App(appConfig);
+        app.init(false);
+
+        return app;
+    }
+}

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -481,9 +481,6 @@ public class TestApp {
 
     @Test
     public void testServiceCheckCounter() throws Exception {
-        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
-        SimpleTestJavaApp testApp = new SimpleTestJavaApp();
-
         AppConfig appConfig = new AppConfig();
         App app = initApp("jmx.yaml", appConfig);
         Reporter repo = appConfig.getReporter();
@@ -494,7 +491,7 @@ public class TestApp {
         // Let's put a service check in the pipeline (we cannot call doIteration()
         // here unfortunately because it would call reportStatus which will flush
         // the count to the jmx_status.yaml file and reset the counter.
-        repo.sendServiceCheck("jmx", Status.STATUS_OK, "This is a test", "jmx_test_instance", null);
+        repo.sendServiceCheck("jmx", Status.STATUS_OK, "This is a test", null);
 
         // Let's check that the counter has been updated
         assertEquals(1, repo.getServiceCheckCount("jmx"));

--- a/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
+++ b/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
@@ -1,0 +1,202 @@
+package org.datadog.jmxfetch;
+
+import org.datadog.jmxfetch.reporter.ConsoleReporter;
+import org.datadog.jmxfetch.reporter.Reporter;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.LinkedList;
+
+import static org.junit.Assert.*;
+
+public class TestServiceChecks {
+
+    @BeforeClass
+    public static void init() {
+        CommonTestSetup.setupLogger();
+    }
+
+    @Test
+    public void testServiceCheckOK() throws Exception {
+        // We expose a few metrics through JMX
+        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        ObjectName objectName = new ObjectName("org.datadog.jmxfetch.test:type=ServiceCheckTest");
+        SimpleTestJavaApp testApp = new SimpleTestJavaApp();
+        mbs.registerMBean(testApp, objectName);
+
+        // We do a first collection
+        AppConfig appConfig = new AppConfig();
+        App app = CommonTestSetup.initApp("jmx.yaml", appConfig);
+
+        app.doIteration();
+        ConsoleReporter reporter = ((ConsoleReporter) appConfig.getReporter());
+        // Test that an OK service check status is sent
+        LinkedList<HashMap<String, Object>> serviceChecks = reporter.getServiceChecks();
+
+        assertEquals(1, serviceChecks.size());
+        HashMap<String, Object> sc = serviceChecks.getFirst();
+        assertNotNull(sc.get("name"));
+        assertNotNull(sc.get("status"));
+        assertNull(sc.get("message"));
+        assertNotNull(sc.get("tags"));
+
+        String scName = (String) (sc.get("name"));
+        String scStatus = (String) (sc.get("status"));
+        String[] scTags = (String[]) (sc.get("tags"));
+
+        assertEquals(Reporter.formatServiceCheckPrefix("jmx"), scName);
+        assertEquals(Status.STATUS_OK, scStatus);
+        assertEquals(scTags.length, 1);
+        assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
+        mbs.unregisterMBean(objectName);
+    }
+
+    @Test
+    public void testServiceCheckWarning() throws Exception {
+        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        ObjectName objectName = new ObjectName("org.datadog.jmxfetch.test:type=ServiceCheckTest");
+
+        //  Test application
+        SimpleTestJavaApp testApp = new SimpleTestJavaApp();
+        // Populate it with a lot of metrics (>350) !
+        testApp.populateHashMap(400);
+
+        // Exposing a few metrics through JMX
+        mbs.registerMBean(testApp, objectName);
+
+        AppConfig appConfig = new AppConfig();
+        App app = CommonTestSetup.initApp("too_many_metrics.yaml", appConfig);
+
+        // JMX configuration should return > 350 metrics
+        app.doIteration();
+        ConsoleReporter reporter = ((ConsoleReporter) appConfig.getReporter());
+
+        // Test that an WARNING service check status is sent
+        LinkedList<HashMap<String, Object>> serviceChecks = reporter.getServiceChecks();
+        LinkedList<HashMap<String, Object>> metrics = reporter.getMetrics();
+        assertTrue(metrics.size() >= 350 );
+
+        assertEquals(1, serviceChecks.size());
+        HashMap<String, Object> sc = serviceChecks.getFirst();
+        assertNotNull(sc.get("name"));
+        assertNotNull(sc.get("status"));
+
+        // Message should not be null anymore and reports a high number of metrics warning
+        assertNotNull(sc.get("message"));
+        assertNotNull(sc.get("tags"));
+
+        String scName = (String) (sc.get("name"));
+        String scStatus = (String) (sc.get("status"));
+        String[] scTags = (String[]) (sc.get("tags"));
+
+        assertEquals(Reporter.formatServiceCheckPrefix("too_many_metrics"), scName);
+        // We should have a warning status
+        assertEquals(Status.STATUS_WARNING, scStatus);
+        assertEquals(scTags.length, 1);
+        assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
+        mbs.unregisterMBean(objectName);
+    }
+
+    @Test
+    public void testServiceCheckCRITICAL() throws Exception {
+        // Test that a non-running service sends a critical service check
+        MBeanServer mbs = ManagementFactory.getPlatformMBeanServer();
+        ObjectName objectName = new ObjectName("org.datadog.jmxfetch.test_non_running:type=ServiceCheckTest2");
+        SimpleTestJavaApp testApp = new SimpleTestJavaApp();
+        mbs.registerMBean(testApp, objectName);
+
+        AppConfig appConfig = new AppConfig();
+
+        App app = CommonTestSetup.initApp("non_running_process.yaml", appConfig);
+        ConsoleReporter reporter = ((ConsoleReporter) appConfig.getReporter());
+
+        // Test that a CRITICAL service check status is sent on initialization
+        LinkedList<HashMap<String, Object>> serviceChecks = reporter.getServiceChecks();
+        assertEquals(1, serviceChecks.size());
+
+        HashMap<String, Object> sc = serviceChecks.getFirst();
+        assertNotNull(sc.get("name"));
+        assertNotNull(sc.get("status"));
+        assertNotNull(sc.get("message"));
+        assertNotNull(sc.get("tags"));
+
+        String scName = (String) (sc.get("name"));
+        String scStatus = (String) (sc.get("status"));
+        String scMessage = (String) (sc.get("message"));
+        String[] scTags = (String[]) (sc.get("tags"));
+
+        assertEquals(Reporter.formatServiceCheckPrefix("non_running_process"), scName);
+        assertEquals(Status.STATUS_ERROR, scStatus);
+        assertEquals("Cannot connect to instance process_regex: .*non_running_process_test.* Cannot find JVM matching regex: .*non_running_process_test.*", scMessage);
+        assertEquals(scTags.length, 1);
+        assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
+
+
+        // Test that a CRITICAL service check status is sent on iteration
+        app.doIteration();
+
+        serviceChecks = reporter.getServiceChecks();
+        assertEquals(1, serviceChecks.size());
+
+        sc = serviceChecks.getFirst();
+        assertNotNull(sc.get("name"));
+        assertNotNull(sc.get("status"));
+        assertNotNull(sc.get("message"));
+        assertNotNull(sc.get("tags"));
+
+        scName = (String) (sc.get("name"));
+        scStatus = (String) (sc.get("status"));
+        scMessage = (String) (sc.get("message"));
+        scTags = (String[]) (sc.get("tags"));
+
+        assertEquals(Reporter.formatServiceCheckPrefix("non_running_process"), scName);
+        assertEquals(Status.STATUS_ERROR, scStatus);
+        assertEquals("Cannot connect to instance process_regex: .*non_running_process_test.*. Is a JMX Server running at this address?", scMessage);
+        assertEquals(scTags.length, 1);
+        assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
+
+        mbs.unregisterMBean(objectName);
+    }
+
+    @Test
+    public void testServiceCheckCounter() throws Exception {
+        AppConfig appConfig = new AppConfig();
+        App app = CommonTestSetup.initApp("jmx.yaml", appConfig);
+        Reporter repo = appConfig.getReporter();
+
+        // Let's check that the counter is null
+        assertEquals(0, repo.getServiceCheckCount("jmx"));
+
+        // Let's put a service check in the pipeline (we cannot call doIteration()
+        // here unfortunately because it would call reportStatus which will flush
+        // the count to the jmx_status.yaml file and reset the counter.
+        repo.sendServiceCheck("jmx", Status.STATUS_OK, "This is a test", null);
+
+        // Let's check that the counter has been updated
+        assertEquals(1, repo.getServiceCheckCount("jmx"));
+
+        // Let's check that each service check counter is reset after each app
+        // app iteration
+        app.doIteration();
+        assertEquals(0, repo.getServiceCheckCount("jmx"));
+    }
+
+    @Test
+    public void testPrefixFormatter() throws Exception {
+        // Let's get a list of Strings to test (add real versionned check names
+        // here when you add  new versionned check)
+        String[][] data = {
+                {"activemq_58.foo.bar12", "activemq.foo.bar12"},
+                {"test_package-X86_64-VER1:0.weird.metric_name", "testpackage.weird.metric_name" }
+        };
+
+        // Let's test them all
+        for(int i=0; i<data.length; ++i)
+            assertEquals(data[i][1], Reporter.formatServiceCheckPrefix(data[i][0]));
+    }
+}


### PR DESCRIPTION
Supersedes https://github.com/DataDog/jmxfetch/pull/65.

The host name that's sent is the host that's defined in the yaml config for each instance, which is preventing the backend from correctly assigning host tags to the service checks.

We fix that by sending a `jmx_server` tag in the dogstatsd payload instead of a host_name metadata field. The agent's dogstatsd will then add the agent's hostname.

Also added an `is_jmx` tag to JMXFetch's service checks so that the backend can know which service checks come from JMXFetch.

cc @talwai @conorbranagan 