### PR TITLE
Log stack traces instead of only printing them

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -327,10 +327,9 @@ public class App {
                     instance = new Instance(configInstance, (LinkedHashMap<String, Object>) yamlConfig.getInitConfig(),
                             name, appConfig);
                 } catch (Exception e) {
-                    e.printStackTrace();
                     String warning = "Unable to create instance. Please check your yaml file";
                     appConfig.getStatus().addInitFailedCheck(name, warning, Status.STATUS_ERROR);
-                    LOGGER.error(warning);
+                    LOGGER.error(warning, e);
                     continue;
                 }
                 try {

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -280,8 +280,7 @@ public class Instance {
             }
         }
         catch (Exception e) {
-            e.printStackTrace();
-            LOGGER.error("Unable to compute a common bean scope, querying all beans as a fallback");
+            LOGGER.error("Unable to compute a common bean scope, querying all beans as a fallback", e);
             this.beans = connection.queryMBeans(null);
         }
         this.lastRefreshTime = System.currentTimeMillis();


### PR DESCRIPTION
Allows to have the stack traces in the logs on top of being output.