### PR TITLE
Ya memory improvement: `queryMBeans`→`queryNames`

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Connection.java
+++ b/src/main/java/org/datadog/jmxfetch/Connection.java
@@ -48,10 +48,10 @@ public class Connection {
         return mbs.getMBeanInfo(bean_name).getAttributes();
     }
 
-    public Set<ObjectInstance> queryMBeans(ObjectName name) throws IOException {
+    public Set<ObjectName> queryNames(ObjectName name) throws IOException {
         String scope = (name != null) ? name.toString() : "*:*";
-        LOGGER.debug("Querying beans on scope: " + scope);
-        return mbs.queryMBeans(name, null);
+        LOGGER.debug("Querying bean names on scope: " + scope);
+        return mbs.queryNames(name, null);
     }
 
     protected void createConnection() throws IOException {

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -16,7 +16,7 @@ import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanException;
-import javax.management.ObjectInstance;
+import javax.management.ObjectName;
 import javax.management.ReflectionException;
 
 import org.apache.log4j.Logger;
@@ -31,9 +31,9 @@ public abstract class JMXAttribute {
     private static final String DOT_UNDERSCORE = "_*\\._*";
     private MBeanAttributeInfo attribute;
     private Connection connection;
-    private ObjectInstance jmxInstance;
+    private ObjectName beanName;
     private String domain;
-    private String beanName;
+    private String beanStringName;
     private HashMap<String, String> beanParameters;
     private String attributeName;
     private LinkedHashMap<Object, Object> valueConversions;
@@ -41,19 +41,18 @@ public abstract class JMXAttribute {
     private Configuration matchingConf;
     private LinkedList<String> defaultTagsList;
 
-    JMXAttribute(MBeanAttributeInfo attribute, ObjectInstance jmxInstance, String instanceName,
+    JMXAttribute(MBeanAttributeInfo attribute, ObjectName beanName, String instanceName,
             Connection connection, HashMap<String, String> instanceTags) {
         this.attribute = attribute;
-        this.jmxInstance = jmxInstance;
+        this.beanName = beanName;
         this.matchingConf = null;
         this.connection = connection;
-
-        this.beanName = jmxInstance.getObjectName().toString();
         this.attributeName = attribute.getName();
+        this.beanStringName = beanName.toString();
 
         // A bean name is formatted like that: org.apache.cassandra.db:type=Caches,keyspace=system,cache=HintsColumnFamilyKeyCache
         // i.e. : domain:bean_parameter1,bean_parameter2
-        String[] splitBeanName = this.beanName.split(":");
+        String[] splitBeanName = beanStringName.split(":");
         String domain = splitBeanName[0];
         String beanParameters = splitBeanName[1];
         LinkedList<String> beanParametersList = getBeanParametersList(instanceName, domain, beanParameters, instanceTags);
@@ -120,7 +119,7 @@ public abstract class JMXAttribute {
 
     @Override
     public String toString() {
-        return "Bean name: " + beanName +
+        return "Bean name: " + beanStringName +
                 " - Attribute name: " + attributeName +
                 "  - Attribute type: " + attribute.getType();
     }
@@ -139,13 +138,13 @@ public abstract class JMXAttribute {
         try {
             return this.getMetrics().size();
         } catch (Exception e) {
-            LOGGER.warn("Unable to get metrics from " + beanName);
+            LOGGER.warn("Unable to get metrics from " + beanStringName);
             return 0;
         }
     }
 
     Object getJmxValue() throws AttributeNotFoundException, InstanceNotFoundException, MBeanException, ReflectionException, IOException {
-        return this.connection.getAttribute(this.jmxInstance.getObjectName(), this.attribute.getName());
+        return this.connection.getAttribute(this.beanName, this.attribute.getName());
     }
 
     boolean matchDomain(Configuration conf) {
@@ -214,7 +213,7 @@ public abstract class JMXAttribute {
         }
 
         for (Pattern beanRegex : beanRegexes) {
-            if(beanRegex.matcher(beanName).matches()) {
+            if(beanRegex.matcher(beanStringName).matches()) {
                 return true;
             }
         }
@@ -226,7 +225,7 @@ public abstract class JMXAttribute {
         boolean matchBeanAttr = true;
         Filter include = configuration.getInclude();
 
-        if (!include.isEmptyBeanName() && !include.getBeanNames().contains(beanName)) {
+        if (!include.isEmptyBeanName() && !include.getBeanNames().contains(beanStringName)) {
             return false;
         }
 
@@ -260,7 +259,7 @@ public abstract class JMXAttribute {
         Filter exclude = conf.getExclude();
         ArrayList<String> beanNames = exclude.getBeanNames();
 
-        if(beanNames.contains(beanName)){
+        if(beanNames.contains(beanStringName)){
             return true;
         }
 
@@ -348,8 +347,8 @@ public abstract class JMXAttribute {
         return tags;
     }
 
-    String getBeanName() {
-        return beanName;
+    String getBeanStringName() {
+        return beanStringName;
     }
 
     String getAttributeName() {

--- a/src/main/java/org/datadog/jmxfetch/JMXComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXComplexAttribute.java
@@ -12,7 +12,7 @@ import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanException;
-import javax.management.ObjectInstance;
+import javax.management.ObjectName;
 import javax.management.ReflectionException;
 import javax.management.openmbean.CompositeData;
 
@@ -21,9 +21,9 @@ public class JMXComplexAttribute extends JMXAttribute {
 
     private HashMap<String, HashMap<String, Object>> subAttributeList;
 
-    public JMXComplexAttribute(MBeanAttributeInfo attribute, ObjectInstance instance, String instanceName,
+    public JMXComplexAttribute(MBeanAttributeInfo attribute, ObjectName beanName, String instanceName,
                                Connection connection, HashMap<String, String> instanceTags) {
-        super(attribute, instance, instanceName, connection, instanceTags);
+        super(attribute, beanName, instanceName, connection, instanceTags);
         this.subAttributeList = new HashMap<String, HashMap<String, Object>>();
     }
 
@@ -118,9 +118,9 @@ public class JMXComplexAttribute extends JMXAttribute {
         if (include.getAttribute() instanceof LinkedHashMap<?, ?>) {
             return ((LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute())).get(subAttributeName).get("alias");
         } else if (conf.get("metric_prefix") != null) {
-            return conf.get("metric_prefix") + "." + getBeanName().split(":")[0] + "." + subAttributeName;
+            return conf.get("metric_prefix") + "." + getBeanStringName().split(":")[0] + "." + subAttributeName;
         }
-        return "jmx." + getBeanName().split(":")[0] + "." + subAttributeName;
+        return "jmx." + getBeanStringName().split(":")[0] + "." + subAttributeName;
     }
 
 

--- a/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
@@ -10,7 +10,7 @@ import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanException;
-import javax.management.ObjectInstance;
+import javax.management.ObjectName;
 import javax.management.ReflectionException;
 
 @SuppressWarnings("unchecked")
@@ -19,9 +19,9 @@ public class JMXSimpleAttribute extends JMXAttribute {
     private String alias;
     private String metricType;
 
-    public JMXSimpleAttribute(MBeanAttributeInfo attribute, ObjectInstance instance, String instanceName,
+    public JMXSimpleAttribute(MBeanAttributeInfo attribute, ObjectName beanName, String instanceName,
                               Connection connection, HashMap<String, String> instanceTags) {
-        super(attribute, instance, instanceName, connection, instanceTags);
+        super(attribute, beanName, instanceName, connection, instanceTags);
     }
 
     @Override
@@ -90,9 +90,9 @@ public class JMXSimpleAttribute extends JMXAttribute {
             LinkedHashMap<String, LinkedHashMap<String, String>> attribute = (LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute());
             alias = attribute.get(getAttribute().getName()).get("alias");
         } else if (conf.get("metric_prefix") != null) {
-            alias = conf.get("metric_prefix") + "." + getBeanName().split(":")[0] + "." + getAttributeName();
+            alias = conf.get("metric_prefix") + "." + getBeanStringName().split(":")[0] + "." + getAttributeName();
         } else {
-            alias = "jmx." + getBeanName().split(":")[0] + "." + getAttributeName();
+            alias = "jmx." + getBeanStringName().split(":")[0] + "." + getAttributeName();
         }
         alias = convertMetricName(alias);
         return alias;


### PR DESCRIPTION
JMXFetch was unnecessarily querying full bean objects: query bean names
instead (`queryMBeans`→`queryNames`).
As it queries one bean attributes at a time (`getAttributesForBean`),
extra memory is saved.