### PR TITLE
Yann/cassandra metric mapping update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ target/*
 .classpath
 .project
 /target
+.idea
+*.iml
 
 *.ucls
 

--- a/src/main/java/org/datadog/jmxfetch/Configuration.java
+++ b/src/main/java/org/datadog/jmxfetch/Configuration.java
@@ -88,8 +88,7 @@ public class Configuration {
                     String[] splitBeanName = beanName.split(":");
                     String domain = splitBeanName[0];
                     String rawBeanParameters = splitBeanName[1];
-                    LinkedList<String> beanParameters = new LinkedList<String>(Arrays.asList(new String(rawBeanParameters).replace("=", ":").split(",")));
-                    HashMap<String, String> beanParametersHash = JMXAttribute.getBeanParametersHash(beanParameters);
+                    HashMap<String, String> beanParametersHash = JMXAttribute.getBeanParametersHash(rawBeanParameters);
                     beanParametersHash.put("domain", domain);
                     filters.add(new Filter(beanParametersHash));
                 }

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -44,6 +44,7 @@ public class Instance {
     private boolean limitReached;
     private Connection connection;
     private AppConfig appConfig;
+    private Boolean cassandraAliasing;
 
 
     public Instance(Instance instance, AppConfig appConfig) {
@@ -93,6 +94,13 @@ public class Instance {
                 LOGGER.warn("Cannot determine a unique instance name. Please define a name in your instance configuration");
                 this.instanceName = this.checkName;
             }
+        }
+
+        // Alternative aliasing for CASSANDRA-4009 metrics
+        // More information: https://issues.apache.org/jira/browse/CASSANDRA-4009
+        this.cassandraAliasing = (Boolean) yaml.get("cassandra_aliasing");
+        if (this.cassandraAliasing == null){
+            this.cassandraAliasing = false;
         }
 
         // In case the configuration to match beans is not specified in the "instance" parameter but in the initConfig one
@@ -221,7 +229,7 @@ public class Instance {
                 String attributeType = attributeInfo.getType();
                 if (SIMPLE_TYPES.contains(attributeType)) {
                     LOGGER.debug("Attribute: " + beanName + " : " + attributeInfo + " has attributeInfo simple type");
-                    jmxAttribute = new JMXSimpleAttribute(attributeInfo, beanName, instanceName, connection, tags);
+                    jmxAttribute = new JMXSimpleAttribute(attributeInfo, beanName, instanceName, connection, tags, cassandraAliasing);
                 } else if (COMPOSED_TYPES.contains(attributeType)) {
                     LOGGER.debug("Attribute: " + beanName + " : " + attributeInfo + " has attributeInfo complex type");
                     jmxAttribute = new JMXComplexAttribute(attributeInfo, beanName, instanceName, connection, tags);

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -3,6 +3,7 @@ package org.datadog.jmxfetch;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
@@ -29,6 +30,7 @@ public abstract class JMXAttribute {
     private static final String ALL_CAP_PATTERN = "([a-z0-9])([A-Z])";
     private static final String METRIC_REPLACEMENT = "([^a-zA-Z0-9_.]+)|(^[^a-zA-Z]+)";
     private static final String DOT_UNDERSCORE = "_*\\._*";
+    protected static final String CASSANDRA_DOMAIN = "org.apache.cassandra.metrics";
     private MBeanAttributeInfo attribute;
     private Connection connection;
     private ObjectName beanName;
@@ -55,33 +57,41 @@ public abstract class JMXAttribute {
         String[] splitBeanName = beanStringName.split(":");
         String domain = splitBeanName[0];
         String beanParameters = splitBeanName[1];
-        LinkedList<String> beanParametersList = getBeanParametersList(instanceName, domain, beanParameters, instanceTags);
-        HashMap<String, String> beanParametersHash = getBeanParametersHash(beanParametersList);
+        HashMap<String, String> beanParametersHash = getBeanParametersHash(beanParameters);
+        LinkedList<String> beanParametersList = getBeanParametersList(instanceName, domain, beanParametersHash, instanceTags);
 
         this.domain = domain;
         this.beanParameters = beanParametersHash;
         this.defaultTagsList = renameConflictingParameters(beanParametersList);
     }
 
-    public static HashMap<String, String> getBeanParametersHash(LinkedList<String> beanParameters) {
-        HashMap<String, String> beanParams = new HashMap<String, String>();
+    public static HashMap<String, String> getBeanParametersHash(String beanParametersString) {
+        String[] beanParameters = beanParametersString.split(",");
+        HashMap<String, String> beanParamsMap = new HashMap<String, String>(beanParameters.length);
         for (String param : beanParameters) {
-            String[] paramSplit = param.split(":");
+            String[] paramSplit = param.split("=");
             if (paramSplit.length > 1) {
-                beanParams.put(new String(paramSplit[0]), new String(paramSplit[1]));
+                beanParamsMap.put(new String(paramSplit[0]), new String(paramSplit[1]));
             } else {
-                beanParams.put(new String(paramSplit[0]), "");
+                beanParamsMap.put(new String(paramSplit[0]), "");
             }
         }
 
-        return beanParams;
+        return beanParamsMap;
     }
 
-
-    private static LinkedList<String> getBeanParametersList(String instanceName, String domain, String beanParameters, HashMap<String, String> instanceTags) {
-        LinkedList<String> beanTags = new LinkedList<String>(Arrays.asList(new String(beanParameters).replace("=", ":").split(",")));
+    private static LinkedList<String> getBeanParametersList(String instanceName, String domain, Map<String, String> beanParameters, HashMap<String, String> instanceTags) {
+        LinkedList<String> beanTags = new LinkedList<String>();
         beanTags.add("instance:" + instanceName);
         beanTags.add("jmx_domain:" + domain);
+
+        if (domain.equals(CASSANDRA_DOMAIN)) {
+            beanTags.addAll(getCassandraBeanTags(beanParameters));
+        } else {
+            for (Map.Entry<String, String> param : beanParameters.entrySet()) {
+                beanTags.add(param.getKey() + ":" + param.getValue());
+            }
+        }
 
         if (instanceTags != null) {
             for (Map.Entry<String, String> tag : instanceTags.entrySet()) {
@@ -107,6 +117,22 @@ public abstract class JMXAttribute {
         }
 
         return defaultTagsList;
+    }
+
+    private static Collection<String> getCassandraBeanTags(Map<String, String> beanParameters) {
+        Collection<String> tags = new LinkedList<String>();
+        for (Map.Entry<String, String> param : beanParameters.entrySet()) {
+            if (param.getKey().equals("name")) {
+                //This is already in the alias
+                continue;
+            } else if (param.getKey().equals("scope")) {
+                String type = beanParameters.get("type");
+                tags.add(type + ":" + param.getValue());
+            } else {
+                tags.add(param.getKey() + ":" + param.getValue());
+            }
+        }
+        return tags;
     }
 
     static String convertMetricName(String metricName) {
@@ -343,5 +369,13 @@ public abstract class JMXAttribute {
 
     public static List<String> getExcludedBeanParams(){
         return EXCLUDED_BEAN_PARAMS;
+    }
+
+    protected String getDomain() {
+        return domain;
+    }
+
+    protected HashMap<String, String> getBeanParameters() {
+        return beanParameters;
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/JMXComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXComplexAttribute.java
@@ -118,9 +118,9 @@ public class JMXComplexAttribute extends JMXAttribute {
         if (include.getAttribute() instanceof LinkedHashMap<?, ?>) {
             return ((LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute())).get(subAttributeName).get("alias");
         } else if (conf.get("metric_prefix") != null) {
-            return conf.get("metric_prefix") + "." + getBeanStringName().split(":")[0] + "." + subAttributeName;
+            return conf.get("metric_prefix") + "." + getDomain() + "." + subAttributeName;
         }
-        return "jmx." + getBeanStringName().split(":")[0] + "." + subAttributeName;
+        return "jmx." + getDomain() + "." + subAttributeName;
     }
 
 

--- a/src/main/java/org/datadog/jmxfetch/JMXComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXComplexAttribute.java
@@ -23,7 +23,7 @@ public class JMXComplexAttribute extends JMXAttribute {
 
     public JMXComplexAttribute(MBeanAttributeInfo attribute, ObjectName beanName, String instanceName,
                                Connection connection, HashMap<String, String> instanceTags) {
-        super(attribute, beanName, instanceName, connection, instanceTags);
+        super(attribute, beanName, instanceName, connection, instanceTags, false);
         this.subAttributeList = new HashMap<String, HashMap<String, Object>>();
     }
 

--- a/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
@@ -21,8 +21,8 @@ public class JMXSimpleAttribute extends JMXAttribute {
     private String metricType;
 
     public JMXSimpleAttribute(MBeanAttributeInfo attribute, ObjectName beanName, String instanceName,
-                              Connection connection, HashMap<String, String> instanceTags) {
-        super(attribute, beanName, instanceName, connection, instanceTags);
+                              Connection connection, HashMap<String, String> instanceTags, Boolean cassandraAliasing) {
+        super(attribute, beanName, instanceName, connection, instanceTags, cassandraAliasing);
     }
 
     @Override
@@ -105,7 +105,7 @@ public class JMXSimpleAttribute extends JMXAttribute {
     }
 
     private String getCassandraAlias() {
-        if (getDomain().equals(CASSANDRA_DOMAIN)) {
+        if (renameCassandraMetrics()) {
             Map<String, String> beanParameters = getBeanParameters();
             String metricName = beanParameters.get("name");
             String attributeName = getAttributeName();

--- a/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.Map;
 
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
@@ -90,15 +91,31 @@ public class JMXSimpleAttribute extends JMXAttribute {
             LinkedHashMap<String, LinkedHashMap<String, String>> attribute = (LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute());
             alias = attribute.get(getAttribute().getName()).get("alias");
         } else if (conf.get("metric_prefix") != null) {
-            alias = conf.get("metric_prefix") + "." + getBeanStringName().split(":")[0] + "." + getAttributeName();
+            alias = conf.get("metric_prefix") + "." + getDomain() + "." + getAttributeName();
+        } else if (getDomain().startsWith("org.apache.cassandra")) {
+            alias = getCassandraAlias();
         }
 
         //If still null - generate generic alias,
         if (alias == null) {
-            alias = "jmx." + getBeanStringName().split(":")[0] + "." + getAttributeName();
+            alias = "jmx." + getDomain() + "." + getAttributeName();
         }
         alias = convertMetricName(alias);
         return alias;
+    }
+
+    private String getCassandraAlias() {
+        if (getDomain().equals(CASSANDRA_DOMAIN)) {
+            Map<String, String> beanParameters = getBeanParameters();
+            String metricName = beanParameters.get("name");
+            String attributeName = getAttributeName();
+            if (attributeName.equals("Value")) {
+                return "cassandra." + metricName;
+            }
+            return "cassandra." + metricName + "." + attributeName;
+        }
+        //Deprecated Cassandra metric.  Remove domain prefix.
+        return getDomain().replace("org.apache.", "") + "." + getAttributeName();
     }
 
     private String getMetricType() {

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -60,8 +60,6 @@ public abstract class Reporter {
             // We need to edit metrics for legacy reasons (rename metrics, etc)
             HashMap<String, Object> metric = new HashMap<String, Object>(m);
 
-            postProcess(metric);
-
             Double currentValue = (Double) metric.get("value");
             if (currentValue.isNaN() || currentValue.isInfinite()) {
                 continue;
@@ -102,22 +100,11 @@ public abstract class Reporter {
         ratesAggregator.put(instanceName, instanceRatesAggregator);
     }
 
-
-    void postProcess(HashMap<String, Object> metric) {
-        if (metric.get("check_name").equals("cassandra")) {
-            postProcessCassandra(metric);
-        }
-    }
-
     public void sendServiceCheck(String checkName, String status, String message, String[] tags){
         this.incrementServiceCheckCount(checkName);
         String dataName = Reporter.formatServiceCheckPrefix(checkName);
 
         this.doSendServiceCheck(dataName, status, message, tags);
-    }
-
-    private void postProcessCassandra(HashMap<String, Object> metric) {
-        metric.put("alias", ((String) metric.get("alias")).replace("jmx.org.apache.", ""));
     }
 
     public void incrementServiceCheckCount(String checkName){
@@ -129,7 +116,7 @@ public abstract class Reporter {
         Integer scCount = this.serviceCheckCount.get(checkName);
         return (scCount == null) ? 0 : scCount.intValue();
     }
-    
+
     public void resetServiceCheckCount(String checkName){
         this.serviceCheckCount.put(checkName, new Integer(0));
     }

--- a/src/test/java/org/datadog/jmxfetch/TestCommon.java
+++ b/src/test/java/org/datadog/jmxfetch/TestCommon.java
@@ -151,9 +151,9 @@ public class TestCommon {
 
             if (mName.equals(name)) {
 
-                if (lowerBound.equals(-1) && upperBound.equals(-1)){
+                if (!value.equals(-1)){
                     assertEquals((Double)value.doubleValue(), mValue);
-                }else{
+                } else if (!lowerBound.equals(-1) || !upperBound.equals(-1)){
                     assertTrue(mValue > (Double)lowerBound.doubleValue());
                     assertTrue(mValue < (Double)upperBound.doubleValue());
                 }
@@ -185,8 +185,12 @@ public class TestCommon {
         assertMetric(name, value, tags, new ArrayList<String>(), countTags);
     }
 
-    public void assertMetric(String name,Number lowerBound, Number upperBound, ArrayList<String> tags, int countTags){
+    public void assertMetric(String name, Number lowerBound, Number upperBound, ArrayList<String> tags, int countTags){
         assertMetric(name, lowerBound, upperBound, tags, new ArrayList<String>(), countTags);
+    }
+
+    public void assertMetric(String name, ArrayList<String> tags, int countTags){
+        assertMetric(name, -1, tags, new ArrayList<String>(), countTags);
     }
 
     /**

--- a/src/test/resources/jmx_cassandra.yaml
+++ b/src/test/resources/jmx_cassandra.yaml
@@ -1,0 +1,10 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        conf:
+            - include:
+               bean: org.apache.cassandra.metrics:keyspace=MyKeySpace,type=ColumnFamily,scope=MyColumnFamily,name=PendingTasks
+               attribute:
+                    - ShouldBe100

--- a/src/test/resources/jmx_cassandra.yaml
+++ b/src/test/resources/jmx_cassandra.yaml
@@ -2,9 +2,17 @@ init_config:
 
 instances:
     -   process_name_regex: .*surefire.*
-        name: jmx_test_instance
+        name: jmx_first_instance
+        cassandra_aliasing: true
         conf:
             - include:
                bean: org.apache.cassandra.metrics:keyspace=MyKeySpace,type=ColumnFamily,scope=MyColumnFamily,name=PendingTasks
                attribute:
                     - ShouldBe100
+    -   process_name_regex: .*surefire.*
+        name: jmx_second_instance
+        conf:
+            - include:
+               bean: org.apache.cassandra.metrics:keyspace=MyKeySpace,type=ColumnFamily,scope=MyColumnFamily,name=PendingTasks
+               attribute:
+                    - ShouldBe1000

--- a/src/test/resources/jmx_cassandra_deprecated.yaml
+++ b/src/test/resources/jmx_cassandra_deprecated.yaml
@@ -1,0 +1,10 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        conf:
+            - include:
+               bean: org.apache.cassandra.db:type=ColumnFamilies,keyspace=MyKeySpace,columnfamily=MyColumnFamily
+               attribute:
+                    - ShouldBe100


### PR DESCRIPTION
Rebase of https://github.com/DataDog/jmxfetch/pull/50

**Added changes**
Create a `cassandra_aliasing` flag to select the appropriate aliasing logic.
* `cassandra_aliasing` → compliant with CASSANDRA-4009
* default behavior