### PR TITLE
Support custom JMX urls

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/ConnectionManager.java
+++ b/src/main/java/org/datadog/jmxfetch/ConnectionManager.java
@@ -29,6 +29,8 @@ public class ConnectionManager {
     private static String generateKey(LinkedHashMap<String, Object> connectionParams) {
         if (connectionParams.get("process_name_regex") != null) {
             return (String) connectionParams.get("process_name_regex");
+        } else if (connectionParams.get("jmx_url") != null) {
+            return (String) connectionParams.get("jmx_url");
         }
         return connectionParams.get("host") + ":" + connectionParams.get("port") + ":" + connectionParams.get("user");
     }

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -85,10 +85,13 @@ public class Instance {
 
         // Generate an instance name that will be send as a tag with the metrics
         if (this.instanceName == null) {
-            if (this.yaml.get("process_name_regex") == null) {
+            if (this.yaml.get("process_name_regex") != null) {
+                this.instanceName = this.checkName + "-" + this.yaml.get("process_name_regex");
+            } else if (this.yaml.get("host") != null) {
                 this.instanceName = this.checkName + "-" + this.yaml.get("host") + "-" + this.yaml.get("port");
             } else {
-                this.instanceName = this.checkName + "-" + this.yaml.get("process_name_regex");
+                LOGGER.warn("Cannot determine a unique instance name. Please define a name in your instance configuration");
+                this.instanceName = this.checkName;
             }
         }
 
@@ -123,6 +126,8 @@ public class Instance {
     public String toString() {
         if (this.yaml.get("process_name_regex") != null) {
             return "process_regex: " + this.yaml.get("process_name_regex");
+        } else if (this.yaml.get("jmx_url") != null) {
+            return (String) this.yaml.get("jmx_url");
         } else {
             return this.yaml.get("host") + ":" + this.yaml.get("port");
         }

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -17,6 +17,7 @@ public class RemoteConnection extends Connection {
     private String user;
     private String password;
     private String path = "jmxrmi";
+    private String jmx_url;
     private static final String TRUST_STORE_PATH_KEY = "trust_store_path";
     private static final String TRUST_STORE_PASSWORD_KEY = "trust_store_password";
     private final static Logger LOGGER = Logger.getLogger(Connection.class.getName());
@@ -27,12 +28,13 @@ public class RemoteConnection extends Connection {
         port = (Integer) connectionParams.get("port");
         user = (String) connectionParams.get("user");
         password = (String) connectionParams.get("password");
+        jmx_url = (String) connectionParams.get("jmx_url");
         if (connectionParams.containsKey("path")){
             path = (String) connectionParams.get("path");
         }
         env = getEnv(connectionParams);
         address = getAddress(connectionParams);
-        
+
         String trustStorePath;
         String trustStorePassword;
         if (connectionParams.containsKey(TRUST_STORE_PATH_KEY)
@@ -42,7 +44,7 @@ public class RemoteConnection extends Connection {
             if (trustStorePath != null && trustStorePassword != null) {
                 System.setProperty("javax.net.ssl.trustStore", trustStorePath);
                 System.setProperty("javax.net.ssl.trustStorePassword", trustStorePassword);
-                
+
                 LOGGER.info("Setting trustStore path: " + trustStorePath + " and trustStorePassword");
             }
 
@@ -61,7 +63,10 @@ public class RemoteConnection extends Connection {
 
     private JMXServiceURL getAddress(
             LinkedHashMap<String, Object> connectionParams) throws MalformedURLException {
-        return new JMXServiceURL("service:jmx:rmi:///jndi/rmi://" + this.host + ":" + this.port +"/" + this.path); 
+        if (this.jmx_url != null) {
+            return new JMXServiceURL(this.jmx_url);
+        }
+        return new JMXServiceURL("service:jmx:rmi:///jndi/rmi://" + this.host + ":" + this.port +"/" + this.path);
     }
 
 


### PR DESCRIPTION
Allows using a non-custom URL for JMXFetch to connect to, on a per-instance basis.

See also https://github.com/DataDog/dd-agent/pull/1996, which allows adding custom JARs to JMXFetch's classpath.