### PR TITLE
Bean name matching logic: OR→AND

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -217,12 +217,10 @@ public abstract class JMXAttribute {
                 return true;
             }
         }
-
         return false;
     }
 
     private boolean matchBeanName(Configuration configuration) {
-        boolean matchBeanAttr = true;
         Filter include = configuration.getInclude();
 
         if (!include.isEmptyBeanName() && !include.getBeanNames().contains(beanStringName)) {
@@ -233,26 +231,14 @@ public abstract class JMXAttribute {
             if (EXCLUDED_BEAN_PARAMS.contains(bean_attr)) {
                 continue;
             }
-            matchBeanAttr = false;
-
-            if (beanParameters.get(bean_attr) == null) {
-                continue;
-            }
 
             ArrayList<String> beanValues = include.getParameterValues(bean_attr);
 
-
-            for (String beanVal : beanValues) {
-                if (!beanParameters.get(bean_attr).equals(beanVal)) {
-                    continue;
+            if (beanParameters.get(bean_attr) == null || !(beanValues.contains(beanParameters.get(bean_attr)))){
+                    return false;
                 }
-                return true;
-            }
-            // We havent' found a match among our attribute values list
-            return false;
         }
-        // Returns true if all bean_attr belong to EXCLUDED_BEAN_PARAMS otherwise false
-        return matchBeanAttr;
+        return true;
     }
 
     private boolean excludeMatchBeanName(Configuration conf) {

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -126,7 +126,7 @@ public class TestApp extends TestCommon {
     @Test
     public void testListParamsInclude() throws Exception {
         // We expose a few metrics through JMX
-        registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:type=RightType");
+        registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:foo=bar,type=RightType");
 
         // Initializing application
         initApplication("jmx_list_params_include.yaml");
@@ -276,7 +276,6 @@ public class TestApp extends TestCommon {
         assertMetric("test.boolean", 1.0, commonTags, 5);
         assertMetric("test.defaulted", 32.0, commonTags, 5);
         assertMetric("subattr.this.is.0", 0.0, commonTags, 5);
-        assertMetric("subattr.this.is.0", 0.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.atomic42", 42.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.atomic4242", 4242.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.object1337", 13.37, commonTags, 5);
@@ -299,7 +298,6 @@ public class TestApp extends TestCommon {
         assertMetric("test.converted", 5.0, commonTags, 5);
         assertMetric("test.boolean", 1.0, commonTags, 5);
         assertMetric("test.defaulted", 32.0, commonTags, 5);
-        assertMetric("subattr.this.is.0", 0.0, commonTags, 5);
         assertMetric("subattr.this.is.0", 0.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.atomic42", 42.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.atomic4242", 4242.0, commonTags, 5);
@@ -330,7 +328,6 @@ public class TestApp extends TestCommon {
         assertMetric("test.converted", 5.0, commonTags, 5);
         assertMetric("test.boolean", 1.0, commonTags, 5);
         assertMetric("test.defaulted", 32.0, commonTags, 5);
-        assertMetric("subattr.this.is.0", 0.0, commonTags, 5);
         assertMetric("subattr.this.is.0", 0.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.atomic42", 42.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.atomic4242", 4242.0, commonTags, 5);

--- a/src/test/resources/jmx_list_params_include.yaml
+++ b/src/test/resources/jmx_list_params_include.yaml
@@ -9,6 +9,10 @@ instances:
         conf:
             - include:
                domain: org.datadog.jmxfetch.test
+               foo: bar
+               type: WrongType
+            - include:
+               domain: org.datadog.jmxfetch.test
                type:
                     - WrongType
                     - RightType


### PR DESCRIPTION
`matchBeanName` was incorrectly reporting `true` as soon as one
bean parameter in a configuration was matching and regardless of the
others.
To sum up, fix bean parameters matching logic: `OR`→`AND`