### PR TITLE
[reporter][statsd] Allow configuration of statsd host

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
@@ -1,5 +1,8 @@
 package org.datadog.jmxfetch.reporter;
 
+import com.google.common.base.Joiner;
+import java.util.Arrays;
+
 public class ReporterFactory {
 
     public static Reporter getReporter(String type) {
@@ -9,7 +12,13 @@ public class ReporterFactory {
         if ("console".equals(type)) {
             return new ConsoleReporter();
         } else if (type.startsWith("statsd:")) {
-            return new StatsdReporter(Integer.valueOf(type.split(":")[1]));
+            String[] typeElements = type.split(":");
+            String host = "localhost";
+            Integer port = Integer.valueOf(typeElements[typeElements.length - 1]);
+            if (typeElements.length > 2) {
+                host = Joiner.on(":").join(Arrays.copyOfRange(typeElements, 1, typeElements.length - 1));
+            }
+            return new StatsdReporter(host, port);
         } else {
             throw new IllegalArgumentException("Invalid reporter type: " + type);
         }

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -10,17 +10,19 @@ import org.datadog.jmxfetch.Status;
 public class StatsdReporter extends Reporter {
 
     private StatsDClient statsDClient;
+    private String statsdHost;
     private int statsdPort;
     private long initializationTime;
 
-    public StatsdReporter(int statsdPort) {
+    public StatsdReporter(String statsdHost, int statsdPort) {
+        this.statsdHost = statsdHost;
         this.statsdPort = statsdPort;
         this.init();
     }
 
     private void init() {
         initializationTime = System.currentTimeMillis();
-        statsDClient = new NonBlockingStatsDClient(null, "localhost", this.statsdPort, new String[]{});
+        statsDClient = new NonBlockingStatsDClient(null, this.statsdHost, this.statsdPort, new String[]{});
     }
 
     protected void sendMetricPoint(String metricName, double value, String[] tags) {
@@ -69,6 +71,10 @@ public class StatsdReporter extends Reporter {
     @Override
     public void displayInstanceName(Instance instance) {
         throw new UnsupportedOperationException();
+    }
+
+    public String getStatsdHost() {
+        return statsdHost;
     }
 
     public int getStatsdPort() {

--- a/src/main/java/org/datadog/jmxfetch/validator/ReporterValidator.java
+++ b/src/main/java/org/datadog/jmxfetch/validator/ReporterValidator.java
@@ -10,7 +10,8 @@ public class ReporterValidator implements IParameterValidator {
 
     public void validate(String name, String value) throws ParameterException {
         if (value.startsWith(STATSD_PREFIX) && value.length() > STATSD_PREFIX.length()) {
-            String port = new String(value.split(":")[1]);
+            String[] splitValue = value.split(":");
+            String port = splitValue[splitValue.length - 1];
             try {
                 positiveIntegerValidator.validate(name, port);
             } catch (ParameterException pe) {
@@ -19,7 +20,7 @@ public class ReporterValidator implements IParameterValidator {
             return;
         }
         if (!value.equals("console")) {
-            throw new ParameterException("Parameter " + name + " should be either 'console' or 'statsd:[STATSD_PORT]'");
+            throw new ParameterException("Parameter " + name + " should be either 'console', 'statsd:[STATSD_PORT]' or 'statsd:[STATSD_HOST]:[STATSD_PORT]'");
         }
     }
 }

--- a/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
+++ b/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
@@ -122,6 +122,33 @@ public class TestParsingJCommander {
         appConfig = testCommand(params);
         assertNotNull(appConfig.getReporter());
         assertTrue(appConfig.getReporter() instanceof StatsdReporter);
+        assertEquals("localhost", ((StatsdReporter) appConfig.getReporter()).getStatsdHost());
+        assertEquals(10, ((StatsdReporter) appConfig.getReporter()).getStatsdPort());
+
+        // statsd reporter with custom ipv4 host
+        params = new String[]{
+                "--reporter", "statsd:127.0.0.1:10",
+                "--check", SINGLE_CHECK,
+                "--conf_directory", CONF_DIR,
+                AppConfig.ACTION_COLLECT
+        };
+        appConfig = testCommand(params);
+        assertNotNull(appConfig.getReporter());
+        assertTrue(appConfig.getReporter() instanceof StatsdReporter);
+        assertEquals("127.0.0.1", ((StatsdReporter) appConfig.getReporter()).getStatsdHost());
+        assertEquals(10, ((StatsdReporter) appConfig.getReporter()).getStatsdPort());
+
+        // statsd reporter with custom ipv6 host
+        params = new String[]{
+                "--reporter", "statsd:[::1]:10",
+                "--check", SINGLE_CHECK,
+                "--conf_directory", CONF_DIR,
+                AppConfig.ACTION_COLLECT
+        };
+        appConfig = testCommand(params);
+        assertNotNull(appConfig.getReporter());
+        assertTrue(appConfig.getReporter() instanceof StatsdReporter);
+        assertEquals("[::1]", ((StatsdReporter) appConfig.getReporter()).getStatsdHost());
         assertEquals(10, ((StatsdReporter) appConfig.getReporter()).getStatsdPort());
 
         // invalid reporter
@@ -135,7 +162,7 @@ public class TestParsingJCommander {
             testCommand(params);
             fail("Should have failed because reporter is invalid");
         } catch (ParameterException pe) {
-            assertEquals("Parameter --reporter should be either 'console' or 'statsd:[STATSD_PORT]'", pe.getMessage());
+            assertEquals("Parameter --reporter should be either 'console', 'statsd:[STATSD_PORT]' or 'statsd:[STATSD_HOST]:[STATSD_PORT]'", pe.getMessage());
         }
 
         // invalid port


### PR DESCRIPTION
An optional host can be specified when the `statsd` reporter is used. This allows the Agent to make JMXFetch send its dogstatsd payloads to the `bind_host` configured in `datadog.conf`