### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
@@ -23,4 +23,6 @@ public class ReporterFactory {
             throw new IllegalArgumentException("Invalid reporter type: " + type);
         }
     }
+
+    private ReporterFactory() {}
 }

--- a/src/main/java/org/datadog/jmxfetch/util/CustomLogger.java
+++ b/src/main/java/org/datadog/jmxfetch/util/CustomLogger.java
@@ -37,4 +37,5 @@ public class CustomLogger {
         }
     }
 
+    private CustomLogger() {}
 } 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava