### PR TITLE
squid:S1192 - String literals should not be duplicated

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -28,6 +28,7 @@ import com.beust.jcommander.ParameterException;
 @SuppressWarnings("unchecked")
 public class App {
     private final static Logger LOGGER = Logger.getLogger(App.class.getName());
+    public static final String CANNOT_CONNECT_TO_INSTANCE = "Cannot connect to instance ";
     private static int loopCounter;
     private HashMap<String, YamlParser> configs;
     private ArrayList<Instance> instances = new ArrayList<Instance>();
@@ -242,16 +243,16 @@ public class App {
                 String warning = null;
 
                 if(e instanceof IOException ) {
-                    warning = "Cannot connect to instance " + instance + ". Is a JMX Server running at this address?";
+                    warning = CANNOT_CONNECT_TO_INSTANCE + instance + ". Is a JMX Server running at this address?";
                     LOGGER.warn(warning);
                 } else if (e instanceof SecurityException) {
-                    warning = "Cannot connect to instance " + instance + " because of bad credentials. Please check your credentials";
+                    warning = CANNOT_CONNECT_TO_INSTANCE + instance + " because of bad credentials. Please check your credentials";
                     LOGGER.warn(warning);
                 } else if (e instanceof FailedLoginException) {
-                    warning = "Cannot connect to instance " + instance + " because of bad credentials. Please check your credentials";
+                    warning = CANNOT_CONNECT_TO_INSTANCE + instance + " because of bad credentials. Please check your credentials";
                     LOGGER.warn(warning);
                 } else {
-                    warning = "Cannot connect to instance " + instance + " for an unknown reason." + e.getMessage();
+                    warning = CANNOT_CONNECT_TO_INSTANCE + instance + " for an unknown reason." + e.getMessage();
                     LOGGER.fatal(warning, e);
                 }
 
@@ -355,7 +356,7 @@ public class App {
                 } catch (IOException e) {
                     instance.cleanUp();
                     brokenInstances.add(instance);
-                    String warning = "Cannot connect to instance " + instance + " " + e.getMessage();
+                    String warning = CANNOT_CONNECT_TO_INSTANCE + instance + " " + e.getMessage();
                     this.reportStatus(appConfig, reporter, instance, 0, warning, Status.STATUS_ERROR);
                     this.sendServiceCheck(reporter, instance, warning, Status.STATUS_ERROR);
                     LOGGER.error(warning);

--- a/src/main/java/org/datadog/jmxfetch/ConnectionManager.java
+++ b/src/main/java/org/datadog/jmxfetch/ConnectionManager.java
@@ -12,6 +12,7 @@ import org.apache.log4j.Logger;
  */
 public class ConnectionManager {
     private final static Logger LOGGER = Logger.getLogger(ConnectionManager.class.getName());
+    public static final String PROCESS_NAME_REGEX = "process_name_regex";
     private static ConnectionManager connectionManager = null;
     private HashMap<String, Connection> cache;
 
@@ -27,8 +28,8 @@ public class ConnectionManager {
     }
 
     private static String generateKey(LinkedHashMap<String, Object> connectionParams) {
-        if (connectionParams.get("process_name_regex") != null) {
-            return (String) connectionParams.get("process_name_regex");
+        if (connectionParams.get(PROCESS_NAME_REGEX) != null) {
+            return (String) connectionParams.get(PROCESS_NAME_REGEX);
         } else if (connectionParams.get("jmx_url") != null) {
             return (String) connectionParams.get("jmx_url");
         }
@@ -36,7 +37,7 @@ public class ConnectionManager {
     }
 
     private Connection createConnection(LinkedHashMap<String, Object> connectionParams) throws IOException {
-        if (connectionParams.get("process_name_regex") != null) {
+        if (connectionParams.get(PROCESS_NAME_REGEX) != null) {
             try {
                 Class.forName( "com.sun.tools.attach.AttachNotSupportedException" );
             } catch (ClassNotFoundException e) {

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -27,6 +27,8 @@ public class Instance {
     private final static List<String> COMPOSED_TYPES = Arrays.asList("javax.management.openmbean.CompositeData", "java.util.HashMap");
     private final static int MAX_RETURNED_METRICS = 350;
     private final static int DEFAULT_REFRESH_BEANS_PERIOD = 600;
+    public static final String PROCESS_NAME_REGEX = "process_name_regex";
+    public static final String ATTRIBUTE = "Attribute: ";
 
     private Set<ObjectName> beans;
     private LinkedList<String> beanScopes;
@@ -86,8 +88,8 @@ public class Instance {
 
         // Generate an instance name that will be send as a tag with the metrics
         if (this.instanceName == null) {
-            if (this.yaml.get("process_name_regex") != null) {
-                this.instanceName = this.checkName + "-" + this.yaml.get("process_name_regex");
+            if (this.yaml.get(PROCESS_NAME_REGEX) != null) {
+                this.instanceName = this.checkName + "-" + this.yaml.get(PROCESS_NAME_REGEX);
             } else if (this.yaml.get("host") != null) {
                 this.instanceName = this.checkName + "-" + this.yaml.get("host") + "-" + this.yaml.get("port");
             } else {
@@ -132,8 +134,8 @@ public class Instance {
 
     @Override
     public String toString() {
-        if (this.yaml.get("process_name_regex") != null) {
-            return "process_regex: " + this.yaml.get("process_name_regex");
+        if (this.yaml.get(PROCESS_NAME_REGEX) != null) {
+            return "process_regex: " + this.yaml.get(PROCESS_NAME_REGEX);
         } else if (this.yaml.get("jmx_url") != null) {
             return (String) this.yaml.get("jmx_url");
         } else {
@@ -230,14 +232,14 @@ public class Instance {
                 JMXAttribute jmxAttribute;
                 String attributeType = attributeInfo.getType();
                 if (SIMPLE_TYPES.contains(attributeType)) {
-                    LOGGER.debug("Attribute: " + beanName + " : " + attributeInfo + " has attributeInfo simple type");
+                    LOGGER.debug(ATTRIBUTE + beanName + " : " + attributeInfo + " has attributeInfo simple type");
                     jmxAttribute = new JMXSimpleAttribute(attributeInfo, beanName, instanceName, connection, tags, cassandraAliasing);
                 } else if (COMPOSED_TYPES.contains(attributeType)) {
-                    LOGGER.debug("Attribute: " + beanName + " : " + attributeInfo + " has attributeInfo complex type");
+                    LOGGER.debug(ATTRIBUTE + beanName + " : " + attributeInfo + " has attributeInfo complex type");
                     jmxAttribute = new JMXComplexAttribute(attributeInfo, beanName, instanceName, connection, tags);
                 } else {
                     try {
-                        LOGGER.debug("Attribute: " + beanName + " : " + attributeInfo + " has an unsupported type: " + attributeType);
+                        LOGGER.debug(ATTRIBUTE + beanName + " : " + attributeInfo + " has an unsupported type: " + attributeType);
                     } catch (NullPointerException e) {
                         LOGGER.warn("Caught unexpected NullPointerException");
                     }

--- a/src/main/java/org/datadog/jmxfetch/JMXComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXComplexAttribute.java
@@ -19,6 +19,8 @@ import javax.management.openmbean.CompositeData;
 @SuppressWarnings("unchecked")
 public class JMXComplexAttribute extends JMXAttribute {
 
+    public static final String ALIAS = "alias";
+    public static final String METRIC_TYPE = "metric_type";
     private HashMap<String, HashMap<String, Object>> subAttributeList;
 
     public JMXComplexAttribute(MBeanAttributeInfo attribute, ObjectName beanName, String instanceName,
@@ -53,12 +55,12 @@ public class JMXComplexAttribute extends JMXAttribute {
             String subAttribute = pair.getKey();
             HashMap<String, Object> metric = pair.getValue();
 
-            if (metric.get("alias") == null) {
-                metric.put("alias", convertMetricName(getAlias(subAttribute)));
+            if (metric.get(ALIAS) == null) {
+                metric.put(ALIAS, convertMetricName(getAlias(subAttribute)));
             }
 
-            if (metric.get("metric_type") == null) {
-                metric.put("metric_type", getMetricType(subAttribute));
+            if (metric.get(METRIC_TYPE) == null) {
+                metric.put(METRIC_TYPE, getMetricType(subAttribute));
             }
 
             if (metric.get("tags") == null) {
@@ -97,7 +99,7 @@ public class JMXComplexAttribute extends JMXAttribute {
         Filter include = getMatchingConf().getInclude();
         if (include.getAttribute() instanceof LinkedHashMap<?, ?>) {
             LinkedHashMap<String, LinkedHashMap<String, String>> attribute = (LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute());
-            metricType = attribute.get(subAttributeName).get("metric_type");
+            metricType = attribute.get(subAttributeName).get(METRIC_TYPE);
             if (metricType == null) {
                 metricType = attribute.get(subAttributeName).get("type");
             }
@@ -116,7 +118,7 @@ public class JMXComplexAttribute extends JMXAttribute {
         Filter include = getMatchingConf().getInclude();
         LinkedHashMap<String, Object> conf = getMatchingConf().getConf();
         if (include.getAttribute() instanceof LinkedHashMap<?, ?>) {
-            return ((LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute())).get(subAttributeName).get("alias");
+            return ((LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute())).get(subAttributeName).get(ALIAS);
         } else if (conf.get("metric_prefix") != null) {
             return conf.get("metric_prefix") + "." + getDomain() + "." + subAttributeName;
         }

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -15,6 +15,7 @@ import java.util.LinkedList;
 public abstract class Reporter {
 
     private final static Logger LOGGER = Logger.getLogger(App.class.getName());
+    public static final String VALUE = "value";
 
     private HashMap<String, Integer> serviceCheckCount;
     private HashMap<String, HashMap<String, HashMap<String, Object>>> ratesAggregator = new HashMap<String, HashMap<String, HashMap<String, Object>>>();
@@ -60,7 +61,7 @@ public abstract class Reporter {
             // We need to edit metrics for legacy reasons (rename metrics, etc)
             HashMap<String, Object> metric = new HashMap<String, Object>(m);
 
-            Double currentValue = (Double) metric.get("value");
+            Double currentValue = (Double) metric.get(VALUE);
             if (currentValue.isNaN() || currentValue.isInfinite()) {
                 continue;
             }
@@ -75,13 +76,13 @@ public abstract class Reporter {
                 if (!instanceRatesAggregator.containsKey(key)) {
                     HashMap<String, Object> rateInfo = new HashMap<String, Object>();
                     rateInfo.put("ts", System.currentTimeMillis());
-                    rateInfo.put("value", currentValue);
+                    rateInfo.put(VALUE, currentValue);
                     instanceRatesAggregator.put(key, rateInfo);
                     continue;
                 }
 
                 long oldTs = (Long) instanceRatesAggregator.get(key).get("ts");
-                double oldValue = (Double) instanceRatesAggregator.get(key).get("value");
+                double oldValue = (Double) instanceRatesAggregator.get(key).get(VALUE);
 
                 long now = System.currentTimeMillis();
                 double rate = 1000 * (currentValue - oldValue) / (now - oldTs);
@@ -91,7 +92,7 @@ public abstract class Reporter {
                 }
 
                 instanceRatesAggregator.get(key).put("ts", now);
-                instanceRatesAggregator.get(key).put("value", currentValue);
+                instanceRatesAggregator.get(key).put(VALUE, currentValue);
             } else { // The metric is a gauge
                 sendMetricPoint(metricName, currentValue, tags);
             }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1192 String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
George Kankava