### PR TITLE
Ensure correct handling of javax.management.Attribute

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Connection.java
+++ b/src/main/java/org/datadog/jmxfetch/Connection.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
+import javax.management.Attribute;
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
 import javax.management.IntrospectionException;
@@ -63,7 +64,11 @@ public class Connection {
     }
 
     public Object getAttribute(ObjectName objectName, String attributeName) throws AttributeNotFoundException, InstanceNotFoundException, MBeanException, ReflectionException, IOException {
-        return mbs.getAttribute(objectName, attributeName);
+        Object o = mbs.getAttribute(objectName, attributeName);
+        if (o instanceof javax.management.Attribute){
+            return ((Attribute)o).getValue();
+        }
+        return o;
     }
 
     /**

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -24,7 +24,7 @@ import org.apache.log4j.Logger;
 
 public abstract class JMXAttribute {
 
-    private final static Logger LOGGER = Logger.getLogger(Instance.class.getName());
+    private final static Logger LOGGER = Logger.getLogger(JMXAttribute.class.getName());
     private static final List<String> EXCLUDED_BEAN_PARAMS = Arrays.asList("domain", "domain_regex", "bean_name", "bean", "bean_regex", "attribute");
     private static final String FIRST_CAP_PATTERN = "(.)([A-Z][a-z]+)";
     private static final String ALL_CAP_PATTERN = "([a-z0-9])([A-Z])";
@@ -171,7 +171,7 @@ public abstract class JMXAttribute {
         try {
             return this.getMetrics().size();
         } catch (Exception e) {
-            LOGGER.warn("Unable to get metrics from " + beanStringName);
+            LOGGER.warn("Unable to get metrics from " + beanStringName + " - " + attributeName, e);
             return 0;
         }
     }


### PR DESCRIPTION
This is an issue when connecting to OpenDJ from forgerock.

Steps to reproduce:
* Start OpenDJ and enable JMX
* Configure as below
* List matched attributes and see it showing up
* Collect attributes and see that it is missing(When finally working I had to wait for a second round of collection) - observe "error" in log.

````
jmx_url: service:jmx:rmi:///jndi/rmi://localhost:1689/org.opends.server.protocols.jmx.client-unknown
user: cn=Directory Manager
password: INSERT YOUR PASSWORD
conf:
    - include:
        domain: org.opends.server
        bean: org.opends.server:Name=rootDSE,Rdn1=cn-monitor,Rdn2=cn-LDAPS_Connection_Handler_0000_port_1636
        attribute:
          ds-connectionhandler-num-connections:
            metric_type: counter
            alias: opendj.num_connections
```

When investigating I discovered the misconfigured logger in JMXAttribute, that why this is also included.