### PR TITLE
[instance] Simplify metric match counting

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -191,7 +191,7 @@ public class Instance {
 
         this.matchingAttributes.clear();
         this.failingAttributes.clear();
-        int metricsCount = 0;
+        int metricMatchCount = 0;
 
         if (!action.equals(AppConfig.ACTION_COLLECT)) {
             reporter.displayInstanceName(this);
@@ -217,7 +217,7 @@ public class Instance {
 
             for (MBeanAttributeInfo attributeInfo : attributeInfos) {
 
-                if (metricsCount >= maxReturnedMetrics) {
+                if (metricMatchCount >= maxReturnedMetrics) {
                     limitReached = true;
                     if (action.equals(AppConfig.ACTION_COLLECT)) {
                         LOGGER.warn("Maximum number of metrics reached.");
@@ -252,14 +252,14 @@ public class Instance {
                     try {
                         if (jmxAttribute.match(conf)) {
                             jmxAttribute.setMatchingConf(conf);
-                            metricsCount += jmxAttribute.getMetricsCount();
+                            metricMatchCount += 1;
                             this.matchingAttributes.add(jmxAttribute);
 
                             if (action.equals(AppConfig.ACTION_LIST_EVERYTHING) ||
                                     action.equals(AppConfig.ACTION_LIST_MATCHING) ||
                                     action.equals(AppConfig.ACTION_LIST_COLLECTED) && !limitReached ||
                                     action.equals(AppConfig.ACTION_LIST_LIMITED) && limitReached) {
-                                reporter.displayMatchingAttributeName(jmxAttribute, metricsCount, maxReturnedMetrics);
+                                reporter.displayMatchingAttributeName(jmxAttribute, metricMatchCount, maxReturnedMetrics);
                             }
                             break;
                         }

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -167,15 +167,6 @@ public abstract class JMXAttribute {
      */
     public abstract boolean match(Configuration conf);
 
-    public int getMetricsCount() {
-        try {
-            return this.getMetrics().size();
-        } catch (Exception e) {
-            LOGGER.warn("Unable to get metrics from " + beanStringName);
-            return 0;
-        }
-    }
-
     Object getJmxValue() throws AttributeNotFoundException, InstanceNotFoundException, MBeanException, ReflectionException, IOException {
         return this.connection.getAttribute(this.beanName, this.attribute.getName());
     }


### PR DESCRIPTION
We have some weird metric counting going on. My initial solution here is to literally just use a simple count. This works well for `list_everything`. Gonna check everything else to make sure we are g2g tho.
