### PR TITLE
Add option to generate alias from regexp match

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -342,6 +342,10 @@ public abstract class JMXAttribute {
         return attribute;
     }
 
+    public ObjectName getBeanName() {
+      return beanName;
+    }
+
     @SuppressWarnings("unchecked")
     protected String[] getTags() {
         if(tags != null) {

--- a/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
@@ -6,6 +6,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
@@ -89,7 +91,15 @@ public class JMXSimpleAttribute extends JMXAttribute {
             return alias;
         } else if (include.getAttribute() instanceof LinkedHashMap<?, ?>) {
             LinkedHashMap<String, LinkedHashMap<String, String>> attribute = (LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute());
-            alias = attribute.get(getAttribute().getName()).get("alias");
+            if (attribute.get(getAttribute().getName()).get("alias_match") != null) {
+              Pattern p = Pattern.compile(attribute.get(getAttribute().getName()).get("alias_match"));
+              Matcher m = p.matcher(getBeanName().getCanonicalName() + "." + getAttribute().getName());
+              if (m.find()) {
+                alias = m.replaceFirst(attribute.get(getAttribute().getName()).get("alias"));
+              }
+            } else {
+              alias = attribute.get(getAttribute().getName()).get("alias");
+            }
         } else if (conf.get("metric_prefix") != null) {
             alias = conf.get("metric_prefix") + "." + getDomain() + "." + getAttributeName();
         } else if (getDomain().startsWith("org.apache.cassandra")) {


### PR DESCRIPTION
This patch allows dynamic creation of metric aliases based on a regex match against <Bean>.<Attribute>. Example yaml with bean name "metrics:name=COUNTER1":

attribute:
            Count:
              metric_type: counter
              alias_match: metrics:name=(.*)
              alias: service.$1

Output alias becomes "services.counter1.count".

This greatly helps the creation of a generic config that splits hundreds (or thousands) of similarly named beans into different aliases, without the difficulty of grouping them under one alias and exceeding the maximum cardinality.