### PR TITLE
[service-checks] adds tags from configuration file to service checks

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -9,6 +9,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.management.MBeanAttributeInfo;
@@ -318,7 +319,9 @@ public class Instance {
             tags.add("jmx_server:" + this.yaml.get("host"));
         }
         if (this.tags != null) {
-            tags.addAll(this.tags.values());
+        	for (Entry<String, String> e : this.tags.entrySet()) {
+        		tags.add(e.getKey() + ":" + e.getValue());
+        	}
         }
         tags.add("instance:" + this.instanceName);
         return tags.toArray(new String[tags.size()]);

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -313,10 +313,12 @@ public class Instance {
     }
 
     public String[] getServiceCheckTags() {
-
         List<String> tags = new ArrayList<String>();
         if (this.yaml.get("host") != null) {
             tags.add("jmx_server:" + this.yaml.get("host"));
+        }
+        if (this.tags != null) {
+            tags.addAll(this.tags.values());
         }
         tags.add("instance:" + this.instanceName);
         return tags.toArray(new String[tags.size()]);

--- a/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
+++ b/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
@@ -43,7 +43,7 @@ public class TestServiceChecks extends TestCommon {
 
         assertEquals(Reporter.formatServiceCheckPrefix("jmx"), scName);
         assertEquals(Status.STATUS_OK, scStatus);
-        assertEquals(scTags.length, 1);
+        assertEquals(scTags.length, 3);
         assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
     }
 
@@ -83,7 +83,7 @@ public class TestServiceChecks extends TestCommon {
         assertEquals(Reporter.formatServiceCheckPrefix("too_many_metrics"), scName);
         // We should have an OK service check status when too many metrics are getting sent
         assertEquals(Status.STATUS_OK, scStatus);
-        assertEquals(scTags.length, 1);
+        assertEquals(scTags.length, 3);
         assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
     }
 
@@ -112,7 +112,7 @@ public class TestServiceChecks extends TestCommon {
         assertEquals(Reporter.formatServiceCheckPrefix("non_running_process"), scName);
         assertEquals(Status.STATUS_ERROR, scStatus);
         assertEquals("Cannot connect to instance process_regex: .*non_running_process_test.* Cannot find JVM matching regex: .*non_running_process_test.*", scMessage);
-        assertEquals(scTags.length, 1);
+        assertEquals(scTags.length, 3);
         assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
 
 
@@ -136,7 +136,7 @@ public class TestServiceChecks extends TestCommon {
         assertEquals(Reporter.formatServiceCheckPrefix("non_running_process"), scName);
         assertEquals(Status.STATUS_ERROR, scStatus);
         assertEquals("Cannot connect to instance process_regex: .*non_running_process_test.*. Is a JMX Server running at this address?", scMessage);
-        assertEquals(scTags.length, 1);
+        assertEquals(scTags.length, 3);
         assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
 
     }

--- a/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
+++ b/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
@@ -45,6 +45,8 @@ public class TestServiceChecks extends TestCommon {
         assertEquals(Status.STATUS_OK, scStatus);
         assertEquals(scTags.length, 3);
         assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
+        assertTrue(Arrays.asList(scTags).contains("env:stage"));
+        assertTrue(Arrays.asList(scTags).contains("newTag:test"));
     }
 
     @Test
@@ -85,6 +87,8 @@ public class TestServiceChecks extends TestCommon {
         assertEquals(Status.STATUS_OK, scStatus);
         assertEquals(scTags.length, 3);
         assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
+        assertTrue(Arrays.asList(scTags).contains("env:stage"));
+        assertTrue(Arrays.asList(scTags).contains("newTag:test"));
     }
 
     @Test
@@ -138,6 +142,8 @@ public class TestServiceChecks extends TestCommon {
         assertEquals("Cannot connect to instance process_regex: .*non_running_process_test.*. Is a JMX Server running at this address?", scMessage);
         assertEquals(scTags.length, 3);
         assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
+        assertTrue(Arrays.asList(scTags).contains("env:stage"));
+        assertTrue(Arrays.asList(scTags).contains("newTag:test"));
 
     }
 


### PR DESCRIPTION
Currently, only the scope and instance tags are available on service checks. 

This PR will make it so that, in addition to those tags, all the tags defined in the configuration file will be available to service checks, making it much easier to scope an integration monitor to a set of hosts.