### PR TITLE
[jmxattribute] generate alias from regexp match

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -351,6 +351,10 @@ public abstract class JMXAttribute {
         return attribute;
     }
 
+    public ObjectName getBeanName() {
+      return beanName;
+    }
+
     @SuppressWarnings("unchecked")
     protected String[] getTags() {
         if(tags != null) {

--- a/src/main/java/org/datadog/jmxfetch/JMXComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXComplexAttribute.java
@@ -19,8 +19,6 @@ import javax.management.openmbean.CompositeData;
 @SuppressWarnings("unchecked")
 public class JMXComplexAttribute extends JMXAttribute {
 
-    public static final String ALIAS = "alias";
-    public static final String METRIC_TYPE = "metric_type";
     private HashMap<String, HashMap<String, Object>> subAttributeList;
 
     public JMXComplexAttribute(MBeanAttributeInfo attribute, ObjectName beanName, String instanceName,
@@ -111,20 +109,6 @@ public class JMXComplexAttribute extends JMXAttribute {
 
         return metricType;
     }
-
-    private String getAlias(String subAttribute) {
-        String subAttributeName = getAttribute().getName() + "." + subAttribute;
-
-        Filter include = getMatchingConf().getInclude();
-        LinkedHashMap<String, Object> conf = getMatchingConf().getConf();
-        if (include.getAttribute() instanceof LinkedHashMap<?, ?>) {
-            return ((LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute())).get(subAttributeName).get(ALIAS);
-        } else if (conf.get("metric_prefix") != null) {
-            return conf.get("metric_prefix") + "." + getDomain() + "." + subAttributeName;
-        }
-        return "jmx." + getDomain() + "." + subAttributeName;
-    }
-
 
     @Override
     public boolean match(Configuration configuration) {

--- a/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
@@ -6,6 +6,8 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
@@ -89,7 +91,15 @@ public class JMXSimpleAttribute extends JMXAttribute {
             return alias;
         } else if (include.getAttribute() instanceof LinkedHashMap<?, ?>) {
             LinkedHashMap<String, LinkedHashMap<String, String>> attribute = (LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute());
-            alias = attribute.get(getAttribute().getName()).get("alias");
+            if (attribute.get(getAttribute().getName()).get("alias_match") != null) {
+              Pattern p = Pattern.compile(attribute.get(getAttribute().getName()).get("alias_match"));
+              Matcher m = p.matcher(getBeanName().getCanonicalName() + "." + getAttribute().getName());
+              if (m.find()) {
+                alias = m.replaceFirst(attribute.get(getAttribute().getName()).get("alias"));
+              }
+            } else {
+              alias = attribute.get(getAttribute().getName()).get("alias");
+            }
         } else if (conf.get("metric_prefix") != null) {
             alias = conf.get("metric_prefix") + "." + getDomain() + "." + getAttributeName();
         } else if (getDomain().startsWith("org.apache.cassandra")) {

--- a/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
@@ -6,8 +6,6 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
-import java.util.regex.Pattern;
-import java.util.regex.Matcher;
 
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
@@ -18,8 +16,6 @@ import javax.management.ReflectionException;
 
 @SuppressWarnings("unchecked")
 public class JMXSimpleAttribute extends JMXAttribute {
-
-    private String alias;
     private String metricType;
 
     public JMXSimpleAttribute(MBeanAttributeInfo attribute, ObjectName beanName, String instanceName,
@@ -40,7 +36,6 @@ public class JMXSimpleAttribute extends JMXAttribute {
         metrics.add(metric);
         return metrics;
     }
-
 
     public boolean match(Configuration configuration) {
         return matchDomain(configuration)
@@ -84,57 +79,13 @@ public class JMXSimpleAttribute extends JMXAttribute {
         return false;
     }
 
-    private String getAlias() {
-        Filter include = getMatchingConf().getInclude();
-        LinkedHashMap<String, Object> conf = getMatchingConf().getConf();
-        if (alias != null) {
-            return alias;
-        } else if (include.getAttribute() instanceof LinkedHashMap<?, ?>) {
-            LinkedHashMap<String, LinkedHashMap<String, String>> attribute = (LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute());
-            if (attribute.get(getAttribute().getName()).get("alias_match") != null) {
-              Pattern p = Pattern.compile(attribute.get(getAttribute().getName()).get("alias_match"));
-              Matcher m = p.matcher(getBeanName().getCanonicalName() + "." + getAttribute().getName());
-              if (m.find()) {
-                alias = m.replaceFirst(attribute.get(getAttribute().getName()).get("alias"));
-              }
-            } else {
-              alias = attribute.get(getAttribute().getName()).get("alias");
-            }
-        } else if (conf.get("metric_prefix") != null) {
-            alias = conf.get("metric_prefix") + "." + getDomain() + "." + getAttributeName();
-        } else if (getDomain().startsWith("org.apache.cassandra")) {
-            alias = getCassandraAlias();
-        }
-
-        //If still null - generate generic alias,
-        if (alias == null) {
-            alias = "jmx." + getDomain() + "." + getAttributeName();
-        }
-        alias = convertMetricName(alias);
-        return alias;
-    }
-
-    private String getCassandraAlias() {
-        if (renameCassandraMetrics()) {
-            Map<String, String> beanParameters = getBeanParameters();
-            String metricName = beanParameters.get("name");
-            String attributeName = getAttributeName();
-            if (attributeName.equals("Value")) {
-                return "cassandra." + metricName;
-            }
-            return "cassandra." + metricName + "." + attributeName;
-        }
-        //Deprecated Cassandra metric.  Remove domain prefix.
-        return getDomain().replace("org.apache.", "") + "." + getAttributeName();
-    }
-
     private String getMetricType() {
         Filter include = getMatchingConf().getInclude();
         if (metricType != null) {
             return metricType;
         } else if (include.getAttribute() instanceof LinkedHashMap<?, ?>) {
             LinkedHashMap<String, LinkedHashMap<String, String>> attribute = (LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute());
-            metricType = attribute.get(getAttributeName()).get("metric_type");
+            metricType = attribute.get(getAttributeName()).get(METRIC_TYPE);
             if (metricType == null) {
                 metricType = attribute.get(getAttributeName()).get("type");
             }

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -46,10 +46,39 @@ public class TestApp extends TestCommon {
 
         assertMetric("this.is.100", tags, 6);
     }
+    /**
+     * Generate metric aliases from a `alias_match` regular expression.
+     */
+    @Test
+    public void testRegexpAliasing() throws Exception {
+        // Expose MBeans
+        registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:foo=Bar,qux=Baz");
+        initApplication("jmx_alias_match.yaml");
+
+        // Collect metrics
+        run();
+        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+
+        // Assertions
+
+        // 15 metrics = 13 from `java.lang` + 2 from the user configuration file
+        assertEquals(15, metrics.size());
+
+        // Metric aliases are generated from `alias_match`
+        List<String> tags = Arrays.asList(
+            "jmx_domain:org.datadog.jmxfetch.test",
+            "instance:jmx_test_instance",
+            "foo:Bar",
+            "qux:Baz"
+        );
+
+        assertMetric("this.is.100.bar.baz", tags, 4);
+        assertMetric("org.datadog.jmxfetch.test.baz.hashmap.thisis0", tags, 4);
+    }
 
     /**
      * Check JMXFetch Cassandra metric aliasing logic, i.e. compliant with CASSANDRA-4009
-     * when `cassandra4009` flag is enabled, or default.
+     * when `cassandra_aliasing` flag is enabled, or default.
      *
      * More information: https://issues.apache.org/jira/browse/CASSANDRA-4009
      */

--- a/src/test/resources/jmx_alias_match.yaml
+++ b/src/test/resources/jmx_alias_match.yaml
@@ -1,0 +1,15 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        conf:
+            - include:
+               domain: org.datadog.jmxfetch.test
+               attribute:
+                    ShouldBe100:
+                        metric_type: gauge
+                        alias: this.is.100.$foo.$qux
+                    Hashmap.thisis0:
+                        metric_type: gauge
+                        alias: $domain.$qux.$attribute


### PR DESCRIPTION
Rebase of #94.

**Additional changes**

* Refactor `getAlias` logic from `JMXSimpleAttribute` &
  `JMXComplexAttribute` to `JMXAttribute`
* Allow group name substitutions in `attribute`/`alias` parameter.
  Available options are:
  * `$attribute` for the attribute name
  * `$<parameter>` for any of the bean parameters
* Test coverage

Example:
```
bean: org.datadog.jmxfetch.test:foo=Bar,qux=Baz
attribute:
  toto:
    alias: my.metric.$foo.$attribute
```
returns a metric name `my.metric.bar.toto`.

Thanks again @alz !