### PR TITLE
Added list_jvms option to list available JVMs (that this process can …

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -24,8 +24,7 @@ import org.datadog.jmxfetch.util.CustomLogger;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
-import com.sun.tools.attach.VirtualMachine;
-import com.sun.tools.attach.VirtualMachineDescriptor;
+
 
 @SuppressWarnings("unchecked")
 public class App {
@@ -84,9 +83,9 @@ public class App {
         }
 
         if( config.getAction().equals( AppConfig.ACTION_LIST_JVMS )) {
-            List<VirtualMachineDescriptor> descriptors = VirtualMachine.list();
+            List<com.sun.tools.attach.VirtualMachineDescriptor> descriptors = com.sun.tools.attach.VirtualMachine.list();
             System.out.println("List of JVMs for user " + System.getProperty("user.name") );
-            for( VirtualMachineDescriptor descriptor : descriptors ) {
+            for( com.sun.tools.attach.VirtualMachineDescriptor descriptor : descriptors ) {
                 System.out.println( "\tJVM id " + descriptor.id() + ": '" + descriptor.displayName() + "'" );
             }
             System.exit(0);

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -24,6 +24,7 @@ import org.datadog.jmxfetch.util.CustomLogger;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
+import com.sun.tools.attach.VirtualMachineDescriptor;
 
 @SuppressWarnings("unchecked")
 public class App {
@@ -320,7 +321,18 @@ public class App {
         clearInstances(instances);
         clearInstances(brokenInstances);
 
+
         Reporter reporter = appConfig.getReporter();
+
+        String action = appConfig.getAction();
+
+        if( action.equals( AppConfig.ACTION_LIST_JVMS )) {
+            List<VirtualMachineDescriptor> descriptors = com.sun.tools.attach.VirtualMachine.list();
+            for( VirtualMachineDescriptor descriptor : descriptors ) {
+                System.out.println( "\tJVM id " + descriptor.id() + ": '" + descriptor.displayName() + "'" );
+            }
+            return;
+        }
 
         Iterator<Entry<String, YamlParser>> it = configs.entrySet().iterator();
         while (it.hasNext()) {

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -24,6 +24,7 @@ import org.datadog.jmxfetch.util.CustomLogger;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
+import com.sun.tools.attach.VirtualMachine;
 import com.sun.tools.attach.VirtualMachineDescriptor;
 
 @SuppressWarnings("unchecked")
@@ -80,6 +81,15 @@ public class App {
         if (!config.getAction().equals(AppConfig.ACTION_COLLECT) && !config.isConsoleReporter()) {
             LOGGER.fatal(config.getAction() + " argument can only be used with the console reporter. Exiting.");
             System.exit(1);
+        }
+
+        if( config.getAction().equals( AppConfig.ACTION_LIST_JVMS )) {
+            List<VirtualMachineDescriptor> descriptors = VirtualMachine.list();
+            System.out.println("List of JVMs for user " + System.getProperty("user.name") );
+            for( VirtualMachineDescriptor descriptor : descriptors ) {
+                System.out.println( "\tJVM id " + descriptor.id() + ": '" + descriptor.displayName() + "'" );
+            }
+            System.exit(0);
         }
 
         // Set up the shutdown hook to properly close resources
@@ -324,15 +334,6 @@ public class App {
 
         Reporter reporter = appConfig.getReporter();
 
-        String action = appConfig.getAction();
-
-        if( action.equals( AppConfig.ACTION_LIST_JVMS )) {
-            List<VirtualMachineDescriptor> descriptors = com.sun.tools.attach.VirtualMachine.list();
-            for( VirtualMachineDescriptor descriptor : descriptors ) {
-                System.out.println( "\tJVM id " + descriptor.id() + ": '" + descriptor.displayName() + "'" );
-            }
-            return;
-        }
 
         Iterator<Entry<String, YamlParser>> it = configs.entrySet().iterator();
         while (it.hasNext()) {

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -18,6 +18,7 @@ import com.beust.jcommander.Parameters;
 @Parameters(separators = "=")
 class AppConfig {
     public static final String ACTION_COLLECT = "collect";
+    public static final String ACTION_LIST_JVMS = "list_jvms";
     public static final String ACTION_LIST_EVERYTHING = "list_everything";
     public static final String ACTION_LIST_COLLECTED = "list_collected_attributes";
     public static final String ACTION_LIST_MATCHING = "list_matching_attributes";
@@ -25,7 +26,7 @@ class AppConfig {
     public static final String ACTION_LIST_LIMITED = "list_limited_attributes";
     public static final String ACTION_HELP = "help";
     public static final HashSet<String> ACTIONS = new HashSet<String>(Arrays.asList(ACTION_COLLECT, ACTION_LIST_EVERYTHING,
-            ACTION_LIST_COLLECTED, ACTION_LIST_MATCHING, ACTION_LIST_NOT_MATCHING, ACTION_LIST_LIMITED, ACTION_HELP));
+            ACTION_LIST_COLLECTED, ACTION_LIST_MATCHING, ACTION_LIST_NOT_MATCHING, ACTION_LIST_LIMITED, ACTION_HELP, ACTION_LIST_JVMS));
 
     @Parameter(names = {"--help", "-h"},
             description = "Display this help page",
@@ -81,7 +82,7 @@ class AppConfig {
 
     @Parameter(description = "Action to take, should be in [help, collect, " +
             "list_everything, list_collected_attributes, list_matching_attributes, " +
-            "list_not_matching_attributes, list_limited_attributes]",
+            "list_not_matching_attributes, list_limited_attributes, list_jvms]",
             required = true)
     private List<String> action = null;
 

--- a/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
@@ -39,7 +39,7 @@ public class AttachApiConnection extends Connection {
         for (com.sun.tools.attach.VirtualMachineDescriptor vmd : com.sun.tools.attach.VirtualMachine.list()) {
             if (vmd.displayName().matches(processRegex)) {
                 com.sun.tools.attach.VirtualMachine vm = com.sun.tools.attach.VirtualMachine.attach(vmd);
-                LOGGER.info("Matched JVM '" + vmd.displayName() + "' against regex '" + processRegex + "'");
+//                LOGGER.info("Matched JVM '" + vmd.displayName() + "' against regex '" + processRegex + "'");
                 String connectorAddress = vm.getAgentProperties().getProperty(CONNECTOR_ADDRESS);
                 //If jmx agent is not running in VM, load it and return the connector url
                 if (connectorAddress == null) {
@@ -52,7 +52,7 @@ public class AttachApiConnection extends Connection {
 
                 return connectorAddress;
             }
-            jvms.add( vmd.displayName() );
+//            jvms.add( vmd.displayName() );
         }
 
         throw new IOException("Cannot find JVM matching regex: '" + processRegex + "'; available JVMs (for this user account): " + jvms );

--- a/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
@@ -31,10 +31,11 @@ public class AttachApiConnection extends Connection {
             throw new IOException("Unnable to attach to process regex:  "+ processRegex, e);
         }
         return address;
-        
+
     }
 
      private String getJMXUrlForProcessRegex(String processRegex) throws com.sun.tools.attach.AttachNotSupportedException, IOException {
+         List<String> jvms = new ArrayList<String>();
         for (com.sun.tools.attach.VirtualMachineDescriptor vmd : com.sun.tools.attach.VirtualMachine.list()) {
             if (vmd.displayName().matches(processRegex)) {
                 LOGGER.info("Matched JVM '" + vmd.displayName() + "' against regex '" + processRegex + "'");
@@ -51,12 +52,9 @@ public class AttachApiConnection extends Connection {
 
                 return connectorAddress;
             }
+            jvms.add( vmd.displayName() );
         }
 
-         List<String> jvms = new ArrayList<String>();
-         for (com.sun.tools.attach.VirtualMachineDescriptor vmd : com.sun.tools.attach.VirtualMachine.list()) {
-             jvms.add( vmd.displayName() );
-         }
         throw new IOException("Cannot find JVM matching regex: '" + processRegex + "'; available JVMs (for this user account): " + jvms );
     }
 

--- a/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
@@ -38,8 +38,8 @@ public class AttachApiConnection extends Connection {
          List<String> jvms = new ArrayList<String>();
         for (com.sun.tools.attach.VirtualMachineDescriptor vmd : com.sun.tools.attach.VirtualMachine.list()) {
             if (vmd.displayName().matches(processRegex)) {
-                LOGGER.info("Matched JVM '" + vmd.displayName() + "' against regex '" + processRegex + "'");
                 com.sun.tools.attach.VirtualMachine vm = com.sun.tools.attach.VirtualMachine.attach(vmd);
+                LOGGER.info("Matched JVM '" + vmd.displayName() + "' against regex '" + processRegex + "'");
                 String connectorAddress = vm.getAgentProperties().getProperty(CONNECTOR_ADDRESS);
                 //If jmx agent is not running in VM, load it and return the connector url
                 if (connectorAddress == null) {

--- a/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
@@ -39,7 +39,7 @@ public class AttachApiConnection extends Connection {
         for (com.sun.tools.attach.VirtualMachineDescriptor vmd : com.sun.tools.attach.VirtualMachine.list()) {
             if (vmd.displayName().matches(processRegex)) {
                 com.sun.tools.attach.VirtualMachine vm = com.sun.tools.attach.VirtualMachine.attach(vmd);
-//                LOGGER.info("Matched JVM '" + vmd.displayName() + "' against regex '" + processRegex + "'");
+                LOGGER.info("Matched JVM '" + vmd.displayName() + "' against regex '" + processRegex + "'");
                 String connectorAddress = vm.getAgentProperties().getProperty(CONNECTOR_ADDRESS);
                 //If jmx agent is not running in VM, load it and return the connector url
                 if (connectorAddress == null) {
@@ -52,7 +52,7 @@ public class AttachApiConnection extends Connection {
 
                 return connectorAddress;
             }
-//            jvms.add( vmd.displayName() );
+            jvms.add( vmd.displayName() );
         }
 
         throw new IOException("Cannot find JVM matching regex: '" + processRegex + "'; available JVMs (for this user account): " + jvms );

--- a/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
@@ -2,8 +2,10 @@ package org.datadog.jmxfetch;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
+import java.util.List;
 
 import javax.management.remote.JMXServiceURL;
 
@@ -35,6 +37,7 @@ public class AttachApiConnection extends Connection {
      private String getJMXUrlForProcessRegex(String processRegex) throws com.sun.tools.attach.AttachNotSupportedException, IOException {
         for (com.sun.tools.attach.VirtualMachineDescriptor vmd : com.sun.tools.attach.VirtualMachine.list()) {
             if (vmd.displayName().matches(processRegex)) {
+                LOGGER.info("Matched JVM '" + vmd.displayName() + "' against regex '" + processRegex + "'");
                 com.sun.tools.attach.VirtualMachine vm = com.sun.tools.attach.VirtualMachine.attach(vmd);
                 String connectorAddress = vm.getAgentProperties().getProperty(CONNECTOR_ADDRESS);
                 //If jmx agent is not running in VM, load it and return the connector url
@@ -49,7 +52,12 @@ public class AttachApiConnection extends Connection {
                 return connectorAddress;
             }
         }
-        throw new IOException("Cannot find JVM matching regex: " + processRegex);
+
+         List<String> jvms = new ArrayList<String>();
+         for (com.sun.tools.attach.VirtualMachineDescriptor vmd : com.sun.tools.attach.VirtualMachine.list()) {
+             jvms.add( vmd.displayName() );
+         }
+        throw new IOException("Cannot find JVM matching regex: '" + processRegex + "'; available JVMs (for this user account): " + jvms );
     }
 
     private void loadJMXAgent(com.sun.tools.attach.VirtualMachine vm) throws IOException {

--- a/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
+++ b/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
@@ -312,7 +312,7 @@ public class TestParsingJCommander {
         } catch (ParameterException pe) {
             String expectedMessage = "Main parameters are required (\"Action to take, should be in [help, collect, " +
                     "list_everything, list_collected_attributes, list_matching_attributes, " +
-                    "list_not_matching_attributes, list_limited_attributes]\")";
+                    "list_not_matching_attributes, list_limited_attributes, list_jvms]\")";
             assertEquals(expectedMessage, pe.getMessage());
         }
 
@@ -329,7 +329,7 @@ public class TestParsingJCommander {
         } catch (ParameterException pe) {
             String expectedMessage = "Main parameters are required (\"Action to take, should be in [help, collect, " +
                     "list_everything, list_collected_attributes, list_matching_attributes, " +
-                    "list_not_matching_attributes, list_limited_attributes]\")";
+                    "list_not_matching_attributes, list_limited_attributes, list_jvms]\")";
             assertEquals(expectedMessage, pe.getMessage());
         }
     }

--- a/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
+++ b/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
@@ -113,7 +113,7 @@ public class TestServiceChecks extends TestCommon {
 
         assertEquals(Reporter.formatServiceCheckPrefix("non_running_process"), scName);
         assertEquals(Status.STATUS_ERROR, scStatus);
-        assertEquals("Cannot connect to instance process_regex: .*non_running_process_test.* Cannot find JVM matching regex: .*non_running_process_test.*", scMessage);
+        assertTrue( scMessage, scMessage.startsWith("Cannot connect to instance process_regex: .*non_running_process_test.* Cannot find JVM matching regex: '.*non_running_process_test.*'; available JVMs (for this user account): "));
         assertEquals(scTags.length, 3);
         assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
 


### PR DESCRIPTION
Add list_jvms to show JVMs available for use by process_name_regex.  Improve diagnostic message when no matching JVM found.

Also requires change to jmxfetch.py script to allow this option.