### PR TITLE
Do not scope MBeans queries on `list_not_matching_attributes` action

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -294,7 +294,7 @@ public class Instance {
     private void refreshBeansList() throws IOException {
         this.beans = new HashSet<ObjectName>();
         String action = appConfig.getAction();
-        Boolean limitQueryScopes = !action.equals(AppConfig.ACTION_LIST_EVERYTHING) && !action.equals(AppConfig.ACTION_LIST_EVERYTHING);
+        Boolean limitQueryScopes = !action.equals(AppConfig.ACTION_LIST_EVERYTHING) && !action.equals(AppConfig.ACTION_LIST_NOT_MATCHING);
 
         if (limitQueryScopes) {
             try {


### PR DESCRIPTION
Kudos to @nwillems for finding this bug! (https://github.com/DataDog/jmxfetch/commit/4d9b0fab97432c454ec4d9bc354d3dd056ef012f#commitcomment-17642270)

cc @yannmh 