### PR TITLE
Added JMX TabularData support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changes
 =======
+# 0.12.0 / Unreleased
+
+#### Changes
+* [BUGFIX] Fix `list_not_matching_attributes` action to return all "not matching" attributes. See [#102][] (Thanks [@nwillems][])
 
 # 0.11.0 / 05-23-2016
 
@@ -115,6 +119,7 @@ Changes
 [#95]: https://github.com/DataDog/jmxfetch/issues/95
 [#96]: https://github.com/DataDog/jmxfetch/issues/96
 [#97]: https://github.com/DataDog/jmxfetch/issues/97
+[#102]: https://github.com/DataDog/jmxfetch/issues/102
 [@alz]: https://github.com/alz
 [@bluestix]: https://github.com/bluestix
 [@coupacooke]: https://github.com/coupacooke

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Changes
 =======
-# 0.12.0 / Unreleased
+# 0.12.0 / 09-27-2016
 
 #### Changes
 * [BUGFIX] Fix `list_not_matching_attributes` action to return all "not matching" attributes. See [#102][] (Thanks [@nwillems][])

--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ mvn test
 # To run:
 ```
 Get help on usage:
-java -jar jmxfetch-0.11.0-jar-with-dependencies.jar --help
+java -jar jmxfetch-0.12.0-jar-with-dependencies.jar --help
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>datadog</groupId>
 	<artifactId>jmxfetch</artifactId>
-	<version>0.11.0</version>
+	<version>0.12.0</version>
 	<packaging>jar</packaging>
 
 	<name>jmxfetch</name>

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -26,6 +26,7 @@ public class Instance {
             "java.util.concurrent.atomic.AtomicInteger", "java.util.concurrent.atomic.AtomicLong",
             "java.lang.Object", "java.lang.Boolean", "boolean", "java.lang.Number");
     private final static List<String> COMPOSED_TYPES = Arrays.asList("javax.management.openmbean.CompositeData", "java.util.HashMap");
+    private final static List<String> MULTI_TYPES = Arrays.asList("javax.management.openmbean.TabularData");
     private final static int MAX_RETURNED_METRICS = 350;
     private final static int DEFAULT_REFRESH_BEANS_PERIOD = 600;
     public static final String PROCESS_NAME_REGEX = "process_name_regex";
@@ -238,6 +239,9 @@ public class Instance {
                 } else if (COMPOSED_TYPES.contains(attributeType)) {
                     LOGGER.debug(ATTRIBUTE + beanName + " : " + attributeInfo + " has attributeInfo complex type");
                     jmxAttribute = new JMXComplexAttribute(attributeInfo, beanName, instanceName, connection, tags);
+                } else if (MULTI_TYPES.contains(attributeType)) {
+                    LOGGER.debug(ATTRIBUTE + beanName + " : " + attributeInfo + " has attributeInfo dynamic type");
+                    jmxAttribute = new JMXMultiAttribute(attributeInfo, beanName, instanceName, connection, tags);
                 } else {
                     try {
                         LOGGER.debug(ATTRIBUTE + beanName + " : " + attributeInfo + " has an unsupported type: " + attributeType);

--- a/src/main/java/org/datadog/jmxfetch/JMXMultiAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXMultiAttribute.java
@@ -1,0 +1,290 @@
+package org.datadog.jmxfetch;
+
+import javax.management.AttributeNotFoundException;
+import javax.management.InstanceNotFoundException;
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanException;
+import javax.management.ObjectName;
+import javax.management.ReflectionException;
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.TabularData;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class JMXMultiAttribute extends JMXAttribute {
+    private String instanceName;
+    private HashMap<String, HashMap<String, HashMap<String, Object>>> subAttributeList;
+
+    public JMXMultiAttribute(MBeanAttributeInfo attribute, ObjectName beanName, String instanceName,
+                             Connection connection, HashMap<String, String> instanceTags) {
+        super(attribute, beanName, instanceName, connection, instanceTags, false);
+        subAttributeList = new HashMap<String, HashMap<String, HashMap<String, Object>>>();
+    }
+
+    private String getMultiKey(Collection keys) {
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for (Object key : keys) {
+            if (!first) { sb.append(","); }
+            // I hope these have sane toString() methods
+            sb.append(key.toString());
+            first = false;
+        }
+        return sb.toString();
+    }
+
+    private void populateSubAttributeList(Object value) {
+        String attributeType = getAttribute().getType();
+        if ("javax.management.openmbean.TabularData".equals(attributeType)) {
+            TabularData data = (TabularData) value;
+            for (Object rowKey : data.keySet()) {
+                Collection keys = (Collection) rowKey;
+                CompositeData compositeData = data.get(keys.toArray());
+                String pathKey = getMultiKey(keys);
+                HashMap<String, HashMap<String, Object>> subAttributes = new HashMap<String, HashMap<String, Object>>();
+                for (String key : compositeData.getCompositeType().keySet()) {
+                    if (compositeData.get(key) instanceof CompositeData) {
+                        for (String subKey : ((CompositeData) compositeData.get(key)).getCompositeType().keySet()) {
+                            subAttributes.put(key + "." + subKey, new HashMap<String, Object>());
+                        }
+                    } else {
+                        subAttributes.put(key, new HashMap<String, Object>());
+                    }
+                }
+                subAttributeList.put(pathKey, subAttributes);
+            }
+        }
+    }
+
+    protected String convertMetricName(String key, String metricName) {
+        // replace known keys
+        metricName = metricName.replace("$key", key);
+        return convertMetricName(metricName);
+    }
+
+    protected String[] getTags(String key, String keyValue) {
+        List<String> tagsList = new ArrayList<String>();
+        Map<String, ?> attributeParams = getAttributesFor(key);
+        if (attributeParams != null) {
+            Map<String, String> yamlTags = (Map) attributeParams.get("tags");
+            if (yamlTags != null) {
+                for (String tagName : yamlTags.keySet()) {
+                    String tag = tagName;
+                    String value = yamlTags.get(tagName);
+                    if (value.equals("$key")) {
+                        value = keyValue;
+                    }
+                    tagsList.add(tag + ":" + value);
+                }
+            }
+        }
+        String[] defaultTags = super.getTags();
+        tagsList.addAll(Arrays.asList(defaultTags));
+
+        String[] tags = new String[tagsList.size()];
+        tags = tagsList.toArray(tags);
+        return tags;
+    }
+
+    private Map<String, ?> getAttributesFor(String key) {
+        Filter include = getMatchingConf().getInclude();
+        if (include != null) {
+            Object includeAttribute = include.getAttribute();
+            if (includeAttribute instanceof LinkedHashMap<?, ?>) {
+                return (Map<String, ?>) ((Map)includeAttribute).get(key);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public LinkedList<HashMap<String, Object>> getMetrics() throws AttributeNotFoundException,
+            InstanceNotFoundException, MBeanException, ReflectionException, IOException {
+        LinkedList<HashMap<String, Object>> metrics = new LinkedList<HashMap<String, Object>>();
+        HashMap<String, LinkedList<HashMap<String, Object>>> subMetrics = new HashMap<String,
+                LinkedList<HashMap<String, Object>>>();
+
+        for (String dataKey : subAttributeList.keySet()) {
+            HashMap<String, HashMap<String, Object>> subSub = subAttributeList.get(dataKey);
+            for (String metricKey : subSub.keySet()) {
+                String fullMetricKey = getAttributeName() + "." + metricKey;
+
+                HashMap<String, Object> metric = subSub.get(metricKey);
+
+                if (metric.get(ALIAS) == null) {
+                    metric.put(ALIAS, convertMetricName(dataKey, getAlias(metricKey)));
+                }
+
+                if (metric.get(METRIC_TYPE) == null) {
+                    metric.put(METRIC_TYPE, getMetricType(metricKey));
+                }
+
+                if (metric.get("tags") == null) {
+                    metric.put("tags", getTags(fullMetricKey, dataKey));
+                }
+
+                metric.put("value", getValue(dataKey, metricKey));
+
+                if(!subMetrics.containsKey(fullMetricKey)) {
+                    subMetrics.put(fullMetricKey, new LinkedList<HashMap<String, Object>>());
+                }
+                subMetrics.get(fullMetricKey).add(metric);
+            }
+        }
+
+        for (String key : subMetrics.keySet()) {
+            metrics.addAll(sortAndFilter(key, subMetrics.get(key)));
+        }
+
+        return metrics;
+    }
+
+    private List<HashMap<String, Object>> sortAndFilter(String metricKey, LinkedList<HashMap<String, Object>>
+            metrics) {
+        Map<String, ?> attributes = getAttributesFor(metricKey);
+        if (!attributes.containsKey("limit")) {
+            return metrics;
+        }
+        Integer limit = (Integer) attributes.get("limit");
+        if (metrics.size() <= limit) {
+            return metrics;
+        }
+        MetricComparator comp = new MetricComparator();
+        Collections.sort(metrics, comp);
+        String sort = (String) attributes.get("limit_sort");
+        if (sort == null || sort.equals("desc")) {
+            metrics.subList(0, limit).clear();
+        } else {
+            metrics.subList(metrics.size() - limit, metrics.size()).clear();
+        }
+        return metrics;
+    }
+
+    private class MetricComparator implements Comparator<HashMap<String, Object>> {
+        public int compare(HashMap<String, Object> o1, HashMap<String, Object> o2) {
+            Double v1 = (Double) o1.get("value");
+            Double v2 = (Double) o2.get("value");
+            return v1.compareTo(v2);
+        }
+    }
+
+    private double getValue(String key, String subAttribute) throws AttributeNotFoundException,
+            InstanceNotFoundException,
+            MBeanException, ReflectionException, IOException {
+
+        Object value = this.getJmxValue();
+        String attributeType = getAttribute().getType();
+
+        if ("javax.management.openmbean.TabularData".equals(attributeType)) {
+            TabularData data = (TabularData) value;
+            for (Object rowKey : data.keySet()) {
+                Collection keys = (Collection) rowKey;
+                String pathKey = getMultiKey(keys);
+                if (key.equals(pathKey)) {
+                    CompositeData compositeData = data.get(keys.toArray());
+                    if (subAttribute.contains(".")) {
+                        // walk down the path
+                        Object o;
+                        for (String subPathKey : subAttribute.split("\\.")) {
+                            o = compositeData.get(subPathKey);
+                            if (o instanceof CompositeData) {
+                                compositeData = (CompositeData) o;
+                            } else {
+                                return getValueAsDouble(compositeData.get(subPathKey));
+                            }
+                        }
+                    } else {
+                        return getValueAsDouble(compositeData.get(subAttribute));
+                    }
+                }
+            }
+        }
+        throw new NumberFormatException();
+    }
+
+    private Object getMetricType(String subAttribute) {
+        String subAttributeName = getAttribute().getName() + "." + subAttribute;
+        String metricType = null;
+
+        Filter include = getMatchingConf().getInclude();
+        if (include.getAttribute() instanceof LinkedHashMap<?, ?>) {
+            LinkedHashMap<String, LinkedHashMap<String, String>> attribute = (LinkedHashMap<String,
+                    LinkedHashMap<String, String>>) (include.getAttribute());
+            metricType = attribute.get(subAttributeName).get(METRIC_TYPE);
+            if (metricType == null) {
+                metricType = attribute.get(subAttributeName).get("type");
+            }
+        }
+
+        if (metricType == null) {
+            metricType = "gauge";
+        }
+
+        return metricType;
+    }
+
+    @Override
+    public boolean match(Configuration configuration) {
+        if (!matchDomain(configuration)
+                || !matchBean(configuration)
+                || excludeMatchDomain(configuration)
+                || excludeMatchBean(configuration)) {
+            return false;
+        }
+
+        try {
+            populateSubAttributeList(getJmxValue());
+        } catch (Exception e) {
+            return false;
+        }
+
+        return matchAttribute(configuration);//TODO && !excludeMatchAttribute(configuration);
+    }
+
+    private boolean matchSubAttribute(Filter params, String subAttributeName, boolean matchOnEmpty) {
+        if ((params.getAttribute() instanceof LinkedHashMap<?, ?>)
+                && ((LinkedHashMap<String, Object>) (params.getAttribute())).containsKey(subAttributeName)) {
+            return true;
+        } else if ((params.getAttribute() instanceof ArrayList<?>
+                && ((ArrayList<String>) (params.getAttribute())).contains(subAttributeName))) {
+            return true;
+        } else if (params.getAttribute() == null) {
+            return matchOnEmpty;
+        }
+        return false;
+    }
+
+    private boolean matchAttribute(Configuration configuration) {
+        if (matchSubAttribute(configuration.getInclude(), getAttributeName(), true)) {
+            return true;
+        }
+
+        Iterator<String> it1 = subAttributeList.keySet().iterator();
+        while (it1.hasNext()) {
+            String key = it1.next();
+            HashMap<String, HashMap<String, Object>> subSub = subAttributeList.get(key);
+            Iterator<String> it2 = subSub.keySet().iterator();
+            while (it2.hasNext()) {
+                String subKey = it2.next();
+                if (!matchSubAttribute(configuration.getInclude(), getAttributeName() + "." + subKey, true)) {
+                    it2.remove();
+                }
+            }
+            if (subSub.size() <= 0) {
+                it1.remove();
+            }
+        }
+
+        return subAttributeList.size() > 0;
+    }
+}

--- a/src/test/java/org/datadog/jmxfetch/SimpleTestJavaApp.java
+++ b/src/test/java/org/datadog/jmxfetch/SimpleTestJavaApp.java
@@ -1,5 +1,14 @@
 package org.datadog.jmxfetch;
 
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeDataSupport;
+import javax.management.openmbean.CompositeType;
+import javax.management.openmbean.OpenDataException;
+import javax.management.openmbean.OpenType;
+import javax.management.openmbean.SimpleType;
+import javax.management.openmbean.TabularData;
+import javax.management.openmbean.TabularDataSupport;
+import javax.management.openmbean.TabularType;
 import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -30,12 +39,18 @@ public class SimpleTestJavaApp implements SimpleTestJavaAppMBean {
     private final HashMap<String, Integer> hashmap = new HashMap<String, Integer>();
     private final Object object1337 = new Double(13.37);
     private final BigDecimal numberBig = new BigDecimal(123456788901234567890.0);
-
+    private final TabularData tabulardata;
+    private final CompositeType compositetype;
 
     SimpleTestJavaApp() {
         hashmap.put("thisis0", 0);
         hashmap.put("thisis10", 10);
         hashmap.put("thisiscounter", 0);
+        compositetype = buildCompositeType();
+        tabulardata = buildTabularType();
+        if (tabulardata != null) {
+            tabulardata.put(buildCompositeData(1));
+        }
     }
 
     public int getShouldBe100() {
@@ -111,4 +126,45 @@ public class SimpleTestJavaApp implements SimpleTestJavaAppMBean {
     public Float getInstanceFloat(){
         return instanceFloat;
     }
+
+    private TabularData buildTabularType() {
+        try {
+            CompositeType rowType = buildCompositeType();
+            TabularType tabularType = new TabularType("myTabularType", "My tabular type", rowType,
+                    new String[]{"thisiskey"});
+            return new TabularDataSupport(tabularType);
+        } catch (OpenDataException e) {
+            return null;
+        }
+    }
+
+    private CompositeType buildCompositeType() {
+        try {
+            return new CompositeType("myCompositeType", "My composite type",
+                    new String[]{"thisiskey", "thisisx"},
+                    new String[]{"This is key", "This is x"},
+                    new OpenType[]{SimpleType.STRING, SimpleType.INTEGER});
+        } catch (OpenDataException e) {
+            return null;
+        }
+    }
+
+    private CompositeData buildCompositeData(Integer i) {
+        try {
+            return new CompositeDataSupport(compositetype,
+                    new String[]{"thisiskey", "thisisx"},
+                    new Object[]{i.toString(), i});
+        } catch (OpenDataException e) {
+            return null;
+        }
+    }
+
+    public void populateTabularData(int count) {
+        tabulardata.clear();
+        for (Integer i = 1; i <= count; i++) {
+            tabulardata.put(buildCompositeData(i));
+        }
+    }
+
+    public TabularData getTabulardata() { return tabulardata; }
 }

--- a/src/test/java/org/datadog/jmxfetch/SimpleTestJavaAppMBean.java
+++ b/src/test/java/org/datadog/jmxfetch/SimpleTestJavaAppMBean.java
@@ -1,5 +1,6 @@
 package org.datadog.jmxfetch;
 
+import javax.management.openmbean.TabularData;
 import java.util.HashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
@@ -36,4 +37,5 @@ public interface SimpleTestJavaAppMBean {
 
     Float getInstanceFloat();
 
+    TabularData getTabulardata();
 }

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -344,7 +345,10 @@ public class TestApp extends TestCommon {
         run();
         LinkedList<HashMap<String, Object>> metrics = getMetrics();
 
-        assertEquals(27, metrics.size()); // 27 = 13 metrics from java.lang + the 5 gauges we are explicitly collecting + the 9 gauges that is implicitly collected, see jmx.yaml in the test/resources folder
+        // 28 = 13 metrics from java.lang + the 5 gauges we are explicitly collecting + 9 gauges implicitly collected
+        // + 1 multi-value, see jmx.yaml in the test/resources folder
+        assertEquals(28, metrics.size());
+
 
         // We test for the presence and the value of the metrics we want to collect
         List<String> commonTags = Arrays.asList(
@@ -366,12 +370,17 @@ public class TestApp extends TestCommon {
         assertMetric("jmx.org.datadog.jmxfetch.test.object1337", 13.37, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.primitive_float", 123.4f, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.instance_float", 567.8f, commonTags, 5);
+        assertMetric("multiattr.this.is.x", 1.0, commonTags, Arrays.asList("KeyName:1"), 6);
+
         assertCoverage();
 
         // We run a second collection. The counter should now be present
         run();
         metrics = getMetrics();
-        assertEquals(29, metrics.size()); // 29 = 13 metrics from java.lang + the 5 gauges we are explicitly collecting + 9 gauges implicitly collected + 2 counter, see jmx.yaml in the test/resources folder
+        // 30 = 13 metrics from java.lang + the 5 gauges we are explicitly collecting + 9 gauges implicitly collected
+        // + 1 multi-value + 2 counter, see jmx.yaml in the test/resources folder
+        assertEquals(30, metrics.size());
+
 
         // We test for the same metrics but this time, the counter should be here
         // Previous metrics
@@ -389,6 +398,7 @@ public class TestApp extends TestCommon {
         assertMetric("jmx.org.datadog.jmxfetch.test.object1337", 13.37, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.primitive_float", 123.4f, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.instance_float", 567.8f, commonTags, 5);
+        assertMetric("multiattr.this.is.x", 1.0, commonTags, Arrays.asList("KeyName:1"), 6);
 
         // Counters
         assertMetric("subattr.counter", 0.0, commonTags, 5);
@@ -399,10 +409,14 @@ public class TestApp extends TestCommon {
         Thread.sleep(5000);
         testApp.incrementCounter(5);
         testApp.incrementHashMapCounter(5);
+        testApp.populateTabularData(2);
 
         run();
         metrics = getMetrics();
-        assertEquals(metrics.size(), 29); // 28 = 13 metrics from java.lang + the 5 gauges we are explicitly collecting + 9 gauges implicitly collected + 2 counter, see jmx.yaml in the test/resources folder
+        // 31 = 13 metrics from java.lang + the 5 gauges we are explicitly collecting + 9 gauges implicitly collected
+        // + 2 multi-value + 2 counter, see jmx.yaml in the test/resources folder
+        assertEquals(31, metrics.size());
+
 
         // Previous metrics
         assertMetric("this.is.100", 100.0, commonTags, 8);
@@ -419,6 +433,8 @@ public class TestApp extends TestCommon {
         assertMetric("jmx.org.datadog.jmxfetch.test.object1337", 13.37, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.primitive_float", 123.4f, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.instance_float", 567.8f, commonTags, 5);
+        assertMetric("multiattr.this.is.x", 1.0, commonTags, Arrays.asList("KeyName:1"), 6, "KeyName:1");
+        assertMetric("multiattr.this.is.x", 2.0, commonTags, Arrays.asList("KeyName:2"), 6, "KeyName:2");
 
         // Counter
         assertMetric("subattr.counter", 0.98, 1, commonTags, 5);

--- a/src/test/java/org/datadog/jmxfetch/TestCommon.java
+++ b/src/test/java/org/datadog/jmxfetch/TestCommon.java
@@ -142,7 +142,7 @@ public class TestCommon {
      *
      * @return                  fail if the metric was not found
      */
-    public void assertMetric(String name, Number value, Number lowerBound, Number upperBound, List<String> commonTags, List<String> additionalTags, int countTags){
+    public void assertMetric(String name, Number value, Number lowerBound, Number upperBound, List<String> commonTags, List<String> additionalTags, int countTags, String keyTag){
         List<String> tags = new ArrayList<String>(commonTags);
         tags.addAll(additionalTags);
 
@@ -150,8 +150,9 @@ public class TestCommon {
             String mName = (String) (m.get("name"));
             Double mValue = (Double) (m.get("value"));
             Set<String> mTags = new HashSet<String>(Arrays.asList((String[]) (m.get("tags"))));
+            boolean keyMatch = keyTag == null || mTags.contains(keyTag);
 
-            if (mName.equals(name)) {
+            if (mName.equals(name) && keyMatch) {
 
                 if (!value.equals(-1)){
                     assertEquals((Double)value.doubleValue(), mValue);
@@ -176,11 +177,15 @@ public class TestCommon {
     }
 
     public void assertMetric(String name, Number value, List<String> commonTags, List<String> additionalTags, int countTags){
-        assertMetric(name, value, -1, -1, commonTags, additionalTags, countTags);
+        assertMetric(name, value, -1, -1, commonTags, additionalTags, countTags, null);
+    }
+
+    public void assertMetric(String name, Number value, List<String> commonTags, List<String> additionalTags, int countTags, String keyTag){
+        assertMetric(name, value, -1, -1, commonTags, additionalTags, countTags, keyTag);
     }
 
     public void assertMetric(String name, Number lowerBound, Number upperBound, List<String> commonTags, List<String> additionalTags, int countTags){
-        assertMetric(name, -1, lowerBound, upperBound, commonTags, additionalTags, countTags);
+        assertMetric(name, -1, lowerBound, upperBound, commonTags, additionalTags, countTags, null);
     }
 
     public void assertMetric(String name, Number value, List<String> tags, int countTags){

--- a/src/test/resources/jmx.yaml
+++ b/src/test/resources/jmx.yaml
@@ -2,6 +2,7 @@ init_config:
 
 instances:
     -   process_name_regex: .*surefire.*
+        refresh_beans: 4
         name: jmx_test_instance
         tags:
             env: stage
@@ -40,5 +41,10 @@ instances:
                         alias: test.defaulted
                         values:
                           default: 32
+                    Tabulardata.thisisx:
+                        metric_type: gauge
+                        alias: multiattr.this.is.x
+                        tags:
+                          KeyName: $key
             - include:
                domain: org.datadog.jmxfetch.test


### PR DESCRIPTION
Hi, this is a bit sloppy and there are no tests, but I wanted to get some feedback. Is this of any value to anyone else? 

* Added JMX `TabularData` support
* When a TabularData type is encountered, multiple metrics are generated with the same alias, but a unique tag per entry
* The tag is generated by concatenating each of the (possibly multiple) key values for each CompositeData entry in the TabularData JMX value
* Also included `limit` and `sort` capability to allow sorting and limiting the number of metrics returned for a single configuration entry (since a `TabularData` value could have many records).
* YAML config format:
```
      - include:
          domain: <domain>
          bean:
            - <bean name>
          attribute:
            <TabularData attribute name>:
              metric_type: <type>
              alias: <alias>
              tags:
                <tag name>: $key
              limit: 20
              sort: desc
```