### PR TITLE
[service_discovery][rpc] implementing an RPC server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 		<maven-surefire-plugin.version>2.9</maven-surefire-plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<snakeyaml.version>1.13</snakeyaml.version>
+        <grpc.version>1.0.1</grpc.version><!-- CURRENT_GRPC_VERSION -->
 	</properties>
 
 	<repositories>
@@ -32,9 +33,24 @@
 		</repository>
 	</repositories>
 
-	<dependencies>
-		<dependency>
-			<groupId>com.beust</groupId>
+    <dependencies>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-netty</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-protobuf</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-stub</artifactId>
+            <version>1.0.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.beust</groupId>
 			<artifactId>jcommander</artifactId>
 			<version>${jcommander.version}</version>
 		</dependency>
@@ -102,21 +118,51 @@
 		</developerConnection>
 		<url>git@github.com:Datadog/jmxfetch.git</url>
 	</scm>
-	<build>
-		<plugins>
-			<plugin>
-				<artifactId>maven-assembly-plugin</artifactId>
-				<configuration>
-					<archive>
-						<manifest>
-							<mainClass>org.datadog.jmxfetch.App</mainClass>
-						</manifest>
-					</archive>
-					<descriptorRefs>
-						<descriptorRef>jar-with-dependencies</descriptorRef>
-					</descriptorRefs>
-				</configuration>
-			</plugin>
-		</plugins>
-	</build>
+    <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.4.1.Final</version>
+            </extension>
+        </extensions>
+        <plugins>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <archive>
+                        <manifest>
+                            <mainClass>org.datadog.jmxfetch.App</mainClass>
+                        </manifest>
+                    </archive>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.5.0</version>
+                <configuration>
+                    <!--
+                      The version of protoc must match protobuf-java. If you don't depend on
+                      protobuf-java directly, you will be transitively depending on the
+                      protobuf-java version that grpc depends on.
+                    -->
+                    <protocArtifact>com.google.protobuf:protoc:3.1.0:exe:${os.detected.classifier}</protocArtifact>
+                    <pluginId>grpc-java</pluginId>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>compile-custom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 	<properties>
 		<commons-io.version>2.4</commons-io.version>
 		<commons-lang.version>2.6</commons-lang.version>
-		<guava.version>17.0</guava.version>
+		<guava.version>19.0</guava.version>
 		<java-dogstatsd-client.version>2.1.0</java-dogstatsd-client.version>
 		<jcommander.version>1.35</jcommander.version>
 		<junit.version>4.11</junit.version>

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -52,7 +52,6 @@ public class App {
     public App(AppConfig appConfig) {
         this.appConfig = appConfig;
         this.configs = getConfigs(appConfig);
-        //this.rpcserver = new ServiceDiscoveryServer(8980, this);
     }
 
     /**
@@ -102,6 +101,16 @@ public class App {
 
         App app = new App(config);
 
+        ServiceDiscoveryServer rpcserver;
+        try {
+            rpcserver = new ServiceDiscoveryServer(config.getRpcPort(), app);
+            rpcserver.start();
+            LOGGER.info("RPC server started. Yay!");
+        }catch(IOException e) {
+            LOGGER.info("Failed to start the RPC server... moving on.");
+            rpcserver = null;
+        }
+
         // Initiate JMX Connections, get attributes that match the yaml configuration
         app.init(false);
 
@@ -109,6 +118,10 @@ public class App {
         if (config.getAction().equals(AppConfig.ACTION_COLLECT)) {
             // Start the main loop
             app.start();
+        }
+
+        if (rpcserver != null) {
+            rpcserver.stop(); //Add to shutdown hook.
         }
     }
 

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -106,7 +106,7 @@ public class App {
 
         ServiceDiscoveryServer rpcserver;
         try {
-            rpcserver = new ServiceDiscoveryServer(config.getRpcPort(), app, LOGGER);
+            rpcserver = new ServiceDiscoveryServer(config.getRpcPort(), app);
             rpcserver.start();
             LOGGER.info("RPC server started. Yay!");
         }catch(IOException e) {
@@ -338,7 +338,13 @@ public class App {
     private ConcurrentHashMap<String, YamlParser> getConfigs(AppConfig config) {
         ConcurrentHashMap<String, YamlParser> configs = new ConcurrentHashMap<String, YamlParser>();
         YamlParser fileConfig;
-        for (String fileName : config.getYamlFileList()) {
+
+        List<String> fileList = config.getYamlFileList();
+        if (fileList == null) {
+            return configs;
+        }
+
+        for (String fileName : fileList) {
             File f = new File(config.getConfdDirectory(), fileName);
             String name = f.getName().replace(".yaml", "");
             FileInputStream yamlInputStream = null;
@@ -362,45 +368,6 @@ public class App {
                 }
             }
         }
-        /*
-        File dir = new File(config.getTmpDirectory());
-        FileFilter fileFilter = new WildcardFileFilter(".yml.*.yaml");
-        File[] files = dir.listFiles(fileFilter);
-
-        Pattern pattern = Pattern.compile("\.jmx\.(?<check>.+)\.yaml");
-        for (int i = 0; i < files.length; i++) {
-            Matcher matcher = pattern.matcher(files[i].getName());
-            matcher.find(); //should always match
-            try {
-                check = matcher.group("check");
-                if (configs.containsKey(check)) {
-                    continue;
-                }
-
-                String yamlPath = files[i].getAbsolutePath();
-                try {
-                    LOGGER.info("Reading SD config from: " + yamlPath);
-                    yamlInputStream = new FileInputStream(yamlPath);
-                    fileConfig = new YamlParser(yamlInputStream);
-                    configs.put(check, fileConfig);
-                } catch (FileNotFoundException e) {
-                    LOGGER.warn("Cannot find " + yamlPath);
-                } catch (Exception e) {
-                    LOGGER.warn("Cannot parse yaml file " + yamlPath, e);
-                } finally {
-                    if (yamlInputStream != null) {
-                        try {
-                            yamlInputStream.close();
-                        } catch (IOException e) {
-                            // ignore
-                        }
-                    }
-                }
-            } catch (IllegalStateException | IndexOutOfBoundsException e) {
-                LOGGER.warn("Cannot load valid SD configuration for check: " + e);
-            }
-        }
-        */
 
         LOGGER.info("Found " + configs.size() + " config files");
         return configs;

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -167,9 +167,16 @@ public class App {
 
     void start() {
         // Main Loop that will periodically collect metrics from the JMX Server
+        long start_ms = System.currentTimeMillis();
+        boolean rpc_wait = true;
+        long delta_s = 0;
         while (true) {
-            // Exit on exit file trigger
-            if (appConfig.getExitWatcher().shouldExit()){
+            if (rpc_wait){
+                rpc_wait = ((System.currentTimeMillis() -  start_ms) / 1000) > appConfig.getRpcWait();
+            }
+
+            // Exit on exit file trigger if RPC wait period is over.
+            if (!rpc_wait && appConfig.getExitWatcher().shouldExit()){
                 LOGGER.info("Exit file detected: stopping JMXFetch.");
                 System.exit(0);
             }

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -174,7 +174,7 @@ public class App {
         long start_ms = System.currentTimeMillis();
         boolean rpc_wait = true;
         long delta_s = 0;
-        while (true) {
+        while (true) { // we currently wait forever if any value for RPC wait is set. Should we?
             if (rpc_wait){
                 rpc_wait = ((System.currentTimeMillis() -  start_ms) / 1000) < appConfig.getRpcWait();
             }

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -62,7 +62,7 @@ class AppConfig {
 
     @Parameter(names = {"--check", "-c"},
             description = "Yaml file name to read (must be in the confd directory)",
-            required = true,
+            required = false,
             variableArity = true)
     private List<String> yamlFileList;
 

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -72,6 +72,12 @@ class AppConfig {
             required = false)
     private int checkPeriod = 15000;
 
+    @Parameter(names = {"--rpc-port", "-x"},
+            description = "Port where the RPC server should be listening.",
+            validateWith = PositiveIntegerValidator.class,
+            required = false)
+    private int rpcPort = 50051;
+
     @Parameter(names = {"--status_location", "-s"},
             description = "Absolute path of the status file. (default to null = no status file written)",
             converter = StatusConverter.class,
@@ -112,6 +118,10 @@ class AppConfig {
 
     public int getCheckPeriod() {
         return checkPeriod;
+    }
+
+    public int getRpcPort() {
+        return rpcPort;
     }
 
     public Reporter getReporter() {

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -48,6 +48,11 @@ class AppConfig {
             required = true)
     private String confdDirectory;
 
+    @Parameter(names = {"--tmp_directory", "-T"},
+            description = "Absolute path to a temporary directory",
+            required = false)
+    private String tmpDirectory = "/tmp";
+
     @Parameter(names = {"--reporter", "-r"},
             description = "Reporter to use: should be either \"statsd:[STATSD_PORT]\" or \"console\"",
             validateWith = ReporterValidator.class,
@@ -119,6 +124,10 @@ class AppConfig {
 
     public String getConfdDirectory() {
         return confdDirectory;
+    }
+
+    public String getTmpDirectory() {
+        return tmpDirectory;
     }
 
     public String getLogLevel() {

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -72,13 +72,13 @@ class AppConfig {
             required = false)
     private int checkPeriod = 15000;
 
-    @Parameter(names = {"--rpc-port", "-x"},
+    @Parameter(names = {"--rpc_port", "-x"},
             description = "Port where the RPC server should be listening.",
             validateWith = PositiveIntegerValidator.class,
             required = false)
     private int rpcPort = 50051;
 
-    @Parameter(names = {"--rpc-wait", "-w"},
+    @Parameter(names = {"--rpc_wait", "-w"},
             description = "RPC config wait period in seconds.",
             validateWith = PositiveIntegerValidator.class,
             required = false)

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -78,6 +78,12 @@ class AppConfig {
             required = false)
     private int rpcPort = 50051;
 
+    @Parameter(names = {"--rpc-wait", "-w"},
+            description = "RPC config wait period in seconds.",
+            validateWith = PositiveIntegerValidator.class,
+            required = false)
+    private int rpcWait = 0;
+
     @Parameter(names = {"--status_location", "-s"},
             description = "Absolute path of the status file. (default to null = no status file written)",
             converter = StatusConverter.class,
@@ -122,6 +128,10 @@ class AppConfig {
 
     public int getRpcPort() {
         return rpcPort;
+    }
+
+    public int getRpcWait() {
+        return rpcWait;
     }
 
     public Reporter getReporter() {

--- a/src/main/java/org/datadog/jmxfetch/ServiceDiscoveryServer.java
+++ b/src/main/java/org/datadog/jmxfetch/ServiceDiscoveryServer.java
@@ -46,26 +46,32 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
 
 /**
  * A sample gRPC server that serve the ServiceDiscovery (see route_guide.proto) service.
  */
 public class ServiceDiscoveryServer {
-    private static final Logger logger = Logger.getLogger(ServiceDiscoveryServer.class.getName());
+    //private static final Logger logger = Logger.getLogger(ServiceDiscoveryServer.class.getName());
+    private final Logger logger;
 
     private final int port;
     private final Server server;
 
     public ServiceDiscoveryServer(int port, App app) throws IOException {
-        this(ServerBuilder.forPort(port), port, app);
+        this(ServerBuilder.forPort(port), port, app, Logger.getLogger(ServiceDiscoveryServer.class.getName()));
+    }
+
+    public ServiceDiscoveryServer(int port, App app, Logger logger) throws IOException {
+        this(ServerBuilder.forPort(port), port, app, logger);
     }
 
     /** Create a ServiceDiscovery server using serverBuilder as a base and features as data. */
-    public ServiceDiscoveryServer(ServerBuilder<?> serverBuilder, int port, App app) {
+    public ServiceDiscoveryServer(ServerBuilder<?> serverBuilder, int port, App app, Logger logger) {
         this.port = port;
-        server = serverBuilder.addService(new ServiceDiscoveryService(app))
+        this.logger = logger;
+        server = serverBuilder.addService(new ServiceDiscoveryService(app, logger))
             .build();
     }
 
@@ -108,9 +114,11 @@ public class ServiceDiscoveryServer {
      */
     private static class ServiceDiscoveryService extends ServiceDiscoveryGrpc.ServiceDiscoveryImplBase {
         private final App app;
+        private final Logger logger;
 
-        ServiceDiscoveryService(App app) {
+        ServiceDiscoveryService(App app, Logger logger) {
             this.app = app;
+            this.logger = logger;
         }
 
         @Override
@@ -124,6 +132,11 @@ public class ServiceDiscoveryServer {
             YamlParser yaml = new YamlParser(stream);
 
             boolean applied = app.addConfig(config.getName(), yaml);
+            if (applied) {
+                logger.info("Configuration was successfully applied for " + config.getName());
+            } else {
+                logger.info("Configuration failed for " + config.getName());
+            }
             return SDConfigApplied.newBuilder().setApplied(applied).build();
         }
     }

--- a/src/main/java/org/datadog/jmxfetch/ServiceDiscoveryServer.java
+++ b/src/main/java/org/datadog/jmxfetch/ServiceDiscoveryServer.java
@@ -53,25 +53,19 @@ import org.apache.log4j.Logger;
  * A sample gRPC server that serve the ServiceDiscovery (see route_guide.proto) service.
  */
 public class ServiceDiscoveryServer {
-    //private static final Logger logger = Logger.getLogger(ServiceDiscoveryServer.class.getName());
-    private final Logger logger;
+    private static final Logger logger = Logger.getLogger(ServiceDiscoveryServer.class.getName());
 
     private final int port;
     private final Server server;
 
     public ServiceDiscoveryServer(int port, App app) throws IOException {
-        this(ServerBuilder.forPort(port), port, app, Logger.getLogger(ServiceDiscoveryServer.class.getName()));
-    }
-
-    public ServiceDiscoveryServer(int port, App app, Logger logger) throws IOException {
-        this(ServerBuilder.forPort(port), port, app, logger);
+        this(ServerBuilder.forPort(port), port, app);
     }
 
     /** Create a ServiceDiscovery server using serverBuilder as a base and features as data. */
-    public ServiceDiscoveryServer(ServerBuilder<?> serverBuilder, int port, App app, Logger logger) {
+    public ServiceDiscoveryServer(ServerBuilder<?> serverBuilder, int port, App app) {
         this.port = port;
-        this.logger = logger;
-        server = serverBuilder.addService(new ServiceDiscoveryService(app, logger))
+        server = serverBuilder.addService(new ServiceDiscoveryService(app))
             .build();
     }
 
@@ -114,11 +108,9 @@ public class ServiceDiscoveryServer {
      */
     private static class ServiceDiscoveryService extends ServiceDiscoveryGrpc.ServiceDiscoveryImplBase {
         private final App app;
-        private final Logger logger;
 
-        ServiceDiscoveryService(App app, Logger logger) {
+        ServiceDiscoveryService(App app) {
             this.app = app;
-            this.logger = logger;
         }
 
         @Override

--- a/src/main/java/org/datadog/jmxfetch/ServiceDiscoveryServer.java
+++ b/src/main/java/org/datadog/jmxfetch/ServiceDiscoveryServer.java
@@ -73,16 +73,6 @@ public class ServiceDiscoveryServer {
     public void start() throws IOException {
         server.start();
         logger.info("Server started, listening on " + port);
-        // Should control shutdown in the main shutdown hook.
-        // Runtime.getRuntime().addShutdownHook(new Thread() {
-        //     @Override
-        //     public void run() {
-        //         // Use stderr here since the logger may has been reset by its JVM shutdown hook.
-        //         System.err.println("*** shutting down gRPC server since JVM is shutting down");
-        //         ServiceDiscoveryServer.this.stop();
-        //         System.err.println("*** server shut down");
-        //     }
-        // });
     }
 
     /** Stop serving requests and shutdown resources. */
@@ -114,12 +104,12 @@ public class ServiceDiscoveryServer {
         }
 
         @Override
-        public void setConfig(SDConfig request, StreamObserver<SDConfigApplied> responseObserver) {
+        public void setConfig(SDConfig request, StreamObserver<Confirmation> responseObserver) {
             responseObserver.onNext(setSDConfig(request));
             responseObserver.onCompleted();
         }
 
-        private SDConfigApplied setSDConfig(SDConfig config) {
+        private Confirmation setSDConfig(SDConfig config) {
             InputStream stream = new ByteArrayInputStream(config.getConfig().getBytes(StandardCharsets.UTF_8));
             YamlParser yaml = new YamlParser(stream);
 
@@ -129,7 +119,7 @@ public class ServiceDiscoveryServer {
             } else {
                 logger.info("Configuration failed for " + config.getName());
             }
-            return SDConfigApplied.newBuilder().setApplied(applied).build();
+            return Confirmation.newBuilder().setSuccess(applied).build();
         }
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/ServiceDiscoveryServer.java
+++ b/src/main/java/org/datadog/jmxfetch/ServiceDiscoveryServer.java
@@ -73,15 +73,16 @@ public class ServiceDiscoveryServer {
     public void start() throws IOException {
         server.start();
         logger.info("Server started, listening on " + port);
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            @Override
-            public void run() {
-                // Use stderr here since the logger may has been reset by its JVM shutdown hook.
-                System.err.println("*** shutting down gRPC server since JVM is shutting down");
-                ServiceDiscoveryServer.this.stop();
-                System.err.println("*** server shut down");
-            }
-        });
+        // Should control shutdown in the main shutdown hook.
+        // Runtime.getRuntime().addShutdownHook(new Thread() {
+        //     @Override
+        //     public void run() {
+        //         // Use stderr here since the logger may has been reset by its JVM shutdown hook.
+        //         System.err.println("*** shutting down gRPC server since JVM is shutting down");
+        //         ServiceDiscoveryServer.this.stop();
+        //         System.err.println("*** server shut down");
+        //     }
+        // });
     }
 
     /** Stop serving requests and shutdown resources. */
@@ -99,14 +100,6 @@ public class ServiceDiscoveryServer {
             server.awaitTermination();
         }
     }
-
-    /*
-    public static void main(String[] args) throws Exception {
-        ServiceDiscoveryServer server = new ServiceDiscoveryServer(8980);
-        server.start();
-        server.blockUntilShutdown();
-    }
-    */
 
     /**
      * Our implementation of ServiceDiscovery service.
@@ -131,7 +124,6 @@ public class ServiceDiscoveryServer {
             YamlParser yaml = new YamlParser(stream);
 
             boolean applied = app.addConfig(config.getName(), yaml);
-            // No feature was found, return an unnamed feature.
             return SDConfigApplied.newBuilder().setApplied(applied).build();
         }
     }

--- a/src/main/java/org/datadog/jmxfetch/ServiceDiscoveryServer.java
+++ b/src/main/java/org/datadog/jmxfetch/ServiceDiscoveryServer.java
@@ -105,11 +105,11 @@ public class ServiceDiscoveryServer {
 
         @Override
         public void setConfig(SDConfig request, StreamObserver<Confirmation> responseObserver) {
-            responseObserver.onNext(setSDConfig(request));
+            responseObserver.onNext(setConfigHandler(request));
             responseObserver.onCompleted();
         }
 
-        private Confirmation setSDConfig(SDConfig config) {
+        private Confirmation setConfigHandler(SDConfig config) {
             InputStream stream = new ByteArrayInputStream(config.getConfig().getBytes(StandardCharsets.UTF_8));
             YamlParser yaml = new YamlParser(stream);
 

--- a/src/main/java/org/datadog/jmxfetch/ServiceDiscoveryServer.java
+++ b/src/main/java/org/datadog/jmxfetch/ServiceDiscoveryServer.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2015, Google Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *    * Redistributions of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *    * Redistributions in binary form must reproduce the above
+ * copyright notice, this list of conditions and the following disclaimer
+ * in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ *    * Neither the name of Google Inc. nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.datadog.jmxfetch;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.stub.StreamObserver;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * A sample gRPC server that serve the ServiceDiscovery (see route_guide.proto) service.
+ */
+public class ServiceDiscoveryServer {
+    private static final Logger logger = Logger.getLogger(ServiceDiscoveryServer.class.getName());
+
+    private final int port;
+    private final Server server;
+
+    public ServiceDiscoveryServer(int port, App app) throws IOException {
+        this(ServerBuilder.forPort(port), port, app);
+    }
+
+    /** Create a ServiceDiscovery server using serverBuilder as a base and features as data. */
+    public ServiceDiscoveryServer(ServerBuilder<?> serverBuilder, int port, App app) {
+        this.port = port;
+        server = serverBuilder.addService(new ServiceDiscoveryService(app))
+            .build();
+    }
+
+    /** Start serving requests. */
+    public void start() throws IOException {
+        server.start();
+        logger.info("Server started, listening on " + port);
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                // Use stderr here since the logger may has been reset by its JVM shutdown hook.
+                System.err.println("*** shutting down gRPC server since JVM is shutting down");
+                ServiceDiscoveryServer.this.stop();
+                System.err.println("*** server shut down");
+            }
+        });
+    }
+
+    /** Stop serving requests and shutdown resources. */
+    public void stop() {
+        if (server != null) {
+            server.shutdown();
+        }
+    }
+
+    /**
+     * Await termination on the main thread since the grpc library uses daemon threads.
+     */
+    private void blockUntilShutdown() throws InterruptedException {
+        if (server != null) {
+            server.awaitTermination();
+        }
+    }
+
+    /*
+    public static void main(String[] args) throws Exception {
+        ServiceDiscoveryServer server = new ServiceDiscoveryServer(8980);
+        server.start();
+        server.blockUntilShutdown();
+    }
+    */
+
+    /**
+     * Our implementation of ServiceDiscovery service.
+     *
+     * <p>See route_guide.proto for details of the methods.
+     */
+    private static class ServiceDiscoveryService extends ServiceDiscoveryGrpc.ServiceDiscoveryImplBase {
+        private final App app;
+
+        ServiceDiscoveryService(App app) {
+            this.app = app;
+        }
+
+        @Override
+        public void setConfig(SDConfig request, StreamObserver<SDConfigApplied> responseObserver) {
+            responseObserver.onNext(setSDConfig(request));
+            responseObserver.onCompleted();
+        }
+
+        private SDConfigApplied setSDConfig(SDConfig config) {
+            InputStream stream = new ByteArrayInputStream(config.getConfig().getBytes(StandardCharsets.UTF_8));
+            YamlParser yaml = new YamlParser(stream);
+
+            boolean applied = app.addConfig(config.getName(), yaml);
+            // No feature was found, return an unnamed feature.
+            return SDConfigApplied.newBuilder().setApplied(applied).build();
+        }
+    }
+}

--- a/src/main/proto/service_discovery.proto
+++ b/src/main/proto/service_discovery.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+option java_multiple_files = true;
+option java_package = "org.datadog.jmxfetch";
+option java_outer_classname = "ServiceDiscoveryProto";
+
+package servicediscovery;
+
+// Interface exported by the server.
+service ServiceDiscovery {
+  // A simple RPC.
+  //
+  // Obtains the feature at a given position.
+  //
+  // A feature with an empty name is returned if there's no feature at the given
+  // position.
+  rpc SetConfig(SDConfig) returns (SDConfigApplied) {}
+
+}
+
+message SDConfigApplied {
+  bool applied = 1;
+}
+
+message SDConfig {
+  string name = 1;
+  string config = 2;
+}

--- a/src/main/proto/service_discovery.proto
+++ b/src/main/proto/service_discovery.proto
@@ -8,18 +8,19 @@ package servicediscovery;
 
 // Interface exported by the server.
 service ServiceDiscovery {
+
   // A simple RPC.
   //
-  // Obtains the feature at a given position.
+  // Attempts to set a YAML service discovery configuration.
   //
-  // A feature with an empty name is returned if there's no feature at the given
-  // position.
-  rpc SetConfig(SDConfig) returns (SDConfigApplied) {}
+  // A confirmation message is returned with the status of the
+  // operation.
+  rpc SetConfig(SDConfig) returns (Confirmation) {}
 
 }
 
-message SDConfigApplied {
-  bool applied = 1;
+message Confirmation {
+  bool success = 1;
 }
 
 message SDConfig {


### PR DESCRIPTION
This PR introduces an RPC server into jmx so that we may submit YAML configs via RPC calls and thus enable service_discovery for JMX.

This is still a work in progress, but is functional at this stage. The code relies on [GRPC.io](http://www.grpc.io/) - server is on the java side, client side is in python in the dd-agent (responsible for the actual configuration management and service discovery.
