### PR TITLE
[service_discovery] enabling service discovery via named pipe.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: java
 jdk:
+- oraclejdk8
 - oraclejdk7
 - openjdk7
 - openjdk6

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 		<jcommander.version>1.35</jcommander.version>
 		<junit.version>4.11</junit.version>
 		<log4j.version>1.2.17</log4j.version>
+        <mockito.version>2.2.27</mockito.version>
 		<maven-surefire-plugin.version>2.9</maven-surefire-plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<snakeyaml.version>1.13</snakeyaml.version>
@@ -102,6 +103,11 @@
 			<artifactId>snakeyaml</artifactId>
 			<version>${snakeyaml.version}</version>
 		</dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito.version}</version>
+        </dependency>
 	</dependencies>
 	<scm>
 		<connection>scm:git:git@github.com:Datadog/jmxfetch.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 	<properties>
 		<commons-io.version>2.4</commons-io.version>
 		<commons-lang.version>2.6</commons-lang.version>
+		<apache-commons-lang3.version>3.5</apache-commons-lang3.version>
 		<guava.version>17.0</guava.version>
 		<java-dogstatsd-client.version>2.1.0</java-dogstatsd-client.version>
 		<jcommander.version>1.35</jcommander.version>
@@ -59,7 +60,13 @@
 			<groupId>commons-lang</groupId>
 			<artifactId>commons-lang</artifactId>
 			<version>${commons-lang.version}</version>
-		</dependency>
+        </dependency>
+        <dependency>
+            <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+			<version>${apache-commons-lang3.version}</version>
+        </dependency>
 		<dependency>
 			<groupId>com.datadoghq</groupId>
 			<artifactId>java-dogstatsd-client</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
+			<scope>test</scope>
         </dependency>
 	</dependencies>
 	<scm>

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -355,7 +355,8 @@ public class App {
     }
 
     public boolean addConfig(String name, YamlParser config) {
-        Pattern pattern = Pattern.compile(SERVICE_DISCOVERY_PREFIX+"(?<check>.*)(?<version>_\\d*)");
+        // named groups not supported with Java6: "(?<check>.{1,30})_(?<version>\\d{0,30})"
+        Pattern pattern = Pattern.compile(SERVICE_DISCOVERY_PREFIX+"(.{1,30})_(\\d{0,30})");
 
         Matcher matcher = pattern.matcher(name);
         if (!matcher.find()) {

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -30,8 +30,6 @@ import org.apache.log4j.Appender;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.commons.lang3.CharEncoding;
-import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.datadog.jmxfetch.reporter.Reporter;
 import org.datadog.jmxfetch.util.CustomLogger;
 
@@ -138,8 +136,8 @@ public class App {
         new ShutdownHook().attachShutDownHook();
     }
 
-    public void setReinit() {
-        this.reinit.set(true);
+    public void setReinit(boolean reinit) {
+        this.reinit.set(reinit);
     }
 
     public static int getLoopCounter() {
@@ -222,7 +220,7 @@ public class App {
                 int len = sd_pipe.available();
                 byte[] buffer = new byte[len];
                 sd_pipe.read(buffer);
-                reinit.set(process_service_discovery(buffer));
+                setReinit(process_service_discovery(buffer));
               }
             } catch(IOException e) {
               LOGGER.warn("Unable to read from pipe - Service Discovery configuration may have been skipped.");
@@ -374,7 +372,7 @@ public class App {
         }
 
         this.sd_configs.put(name, config);
-        this.setReinit();
+        this.setReinit(true);
 
         return true;
     }

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -5,7 +5,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileFilter;
 import java.io.FileNotFoundException;
-import java.io.FileInputStream;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -159,7 +158,7 @@ public class App {
       return SERVICE_DISCOVERY_PREFIX + splitted[0].substring(2, splitted[0].length());
     }
 
-    private boolean processServiceDiscovery(byte[] buffer) {
+    public boolean processServiceDiscovery(byte[] buffer) {
       boolean reinit = false;
       String[] discovered;
 

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -156,13 +156,13 @@ class AppConfig {
     }
 
     public String getServiceDiscoveryPipe() {
-        String pipe_path;
+        String pipePath;
 
         if (System.getProperty("os.name").startsWith("Windows")) {
-            pipe_path = SD_WIN_PIPE_PATH + "/" + sdPipe;
+            pipePath = SD_WIN_PIPE_PATH + "/" + sdPipe;
         } else {
-            pipe_path = getTmpDirectory() + "/" + sdPipe;
+            pipePath = getTmpDirectory() + "/" + sdPipe;
         }
-        return pipe_path;
+        return pipePath;
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -27,6 +27,9 @@ class AppConfig {
     public static final HashSet<String> ACTIONS = new HashSet<String>(Arrays.asList(ACTION_COLLECT, ACTION_LIST_EVERYTHING,
             ACTION_LIST_COLLECTED, ACTION_LIST_MATCHING, ACTION_LIST_NOT_MATCHING, ACTION_LIST_LIMITED, ACTION_HELP));
 
+    private static final String SD_WIN_PIPE_PATH = "\\\\.\\pipe\\";
+    private static final String SD_PIPE_NAME = "dd-service_discovery";
+
     @Parameter(names = {"--help", "-h"},
             description = "Display this help page",
             help = true)
@@ -48,6 +51,11 @@ class AppConfig {
             required = true)
     private String confdDirectory;
 
+    @Parameter(names = {"--tmp_directory", "-T"},
+            description = "Absolute path to a temporary directory",
+            required = false)
+    private String tmpDirectory = "/tmp";
+
     @Parameter(names = {"--reporter", "-r"},
             description = "Reporter to use: should be either \"statsd:[STATSD_PORT]\" or \"console\"",
             validateWith = ReporterValidator.class,
@@ -57,7 +65,7 @@ class AppConfig {
 
     @Parameter(names = {"--check", "-c"},
             description = "Yaml file name to read (must be in the confd directory)",
-            required = true,
+            required = false,
             variableArity = true)
     private List<String> yamlFileList;
 
@@ -66,6 +74,16 @@ class AppConfig {
             validateWith = PositiveIntegerValidator.class,
             required = false)
     private int checkPeriod = 15000;
+
+    @Parameter(names = {"--sd_standby", "-w"},
+            description = "Service Discovery standby.",
+            required = false)
+    private boolean sdStandby = false;
+
+    @Parameter(names = {"--sd_pipe", "-S"},
+            description = "Service Discovery pipe name.",
+            required = false)
+    private String sdPipe = SD_PIPE_NAME;
 
     @Parameter(names = {"--status_location", "-s"},
             description = "Absolute path of the status file. (default to null = no status file written)",
@@ -109,6 +127,10 @@ class AppConfig {
         return checkPeriod;
     }
 
+    public boolean getSDStandby() {
+        return sdStandby;
+    }
+
     public Reporter getReporter() {
         return reporter;
     }
@@ -121,11 +143,26 @@ class AppConfig {
         return confdDirectory;
     }
 
+    public String getTmpDirectory() {
+        return tmpDirectory;
+    }
+
     public String getLogLevel() {
         return logLevel;
     }
 
     public String getLogLocation() {
         return logLocation;
+    }
+
+    public String getServiceDiscoveryPipe() {
+        String pipe_path;
+
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            pipe_path = SD_WIN_PIPE_PATH + "/" + sdPipe;
+        } else {
+            pipe_path = getTmpDirectory() + "/" + sdPipe;
+        }
+        return pipe_path;
     }
 }

--- a/src/test/resources/jmx_sd_pipe.txt
+++ b/src/test/resources/jmx_sd_pipe.txt
@@ -1,0 +1,41 @@
+#### SERVICE-DISCOVERY ####
+# cassandra_0
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_first_instance
+        cassandra_aliasing: true
+        conf:
+            - include:
+               bean: org.apache.cassandra.metrics:keyspace=MyKeySpace,type=ColumnFamily,scope=MyColumnFamily,name=PendingTasks
+               attribute:
+                    - ShouldBe100
+    -   process_name_regex: .*surefire.*
+        name: jmx_second_instance
+        conf:
+            - include:
+               bean: org.apache.cassandra.metrics:keyspace=MyKeySpace,type=ColumnFamily,scope=MyColumnFamily,name=PendingTasks
+               attribute:
+                    - ShouldBe1000
+
+#### SERVICE-DISCOVERY ####
+# jmx_0
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        conf:
+            - include:
+               bean: org.datadog.jmxfetch.test:type=SimpleTestJavaApp,scope=Co|olScope,host=localhost,component=
+               attribute:
+                    ShouldBe100:
+                        metric_type: gauge
+                        alias: this.is.100
+            - include:
+               bean: org.datadog.jmxfetch.test:type=WrongType,scope=WrongScope,host=localhost,component=
+               attribute:
+                    Hashmap.thisis0:
+                        metric_type: gauge
+                        alias: bean.parameters.should.not.match


### PR DESCRIPTION
### What does this PR do?

Enables service discovery for JMXfetch.

Once a service discovery config is detected by the agent it will be pushed as YAML via a named pipe: `dd-service_discovery` that lives in /tmp by default.

If multiple changes are detected, these will be submitted to JMXfetch in a single write operation to avoid race conditions. The pipe should take care of locking from the reading and writing ends, so we can guarantee all configs will be read on the JMXfetch in a single iteration and thus help avoid having multiple versions of the same config in the pipe at any given time. We will then do the chopping up of the various configurations read with a simple String.split(SD_CONFIGURATION_SEPARATOR) operaion.

### Motivation

Enabling Service Discovery for JMXfetch integrations.

### Testing Guidelines

An overview on testing
is available in our contribution guidelines.

### Additional Notes

Related PR: https://github.com/DataDog/dd-agent/pull/3010