### PR TITLE
Adding 'histogram' metric type to JMXFetch.

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
@@ -14,7 +14,7 @@ public class ConsoleReporter extends Reporter {
     private LinkedList<HashMap<String, Object>> serviceChecks = new LinkedList<HashMap<String, Object>>();
 
     @Override
-    protected void sendMetricPoint(String metricName, double value, String[] tags) {
+    protected void sendMetricPoint(String metricType, String metricName, double value, String[] tags) {
         String tagString = "[" + Joiner.on(",").join(tags) + "]";
         System.out.println(metricName + tagString + " - " + System.currentTimeMillis() / 1000 + " = " + value);
 
@@ -22,6 +22,7 @@ public class ConsoleReporter extends Reporter {
         m.put("name", metricName);
         m.put("value", value);
         m.put("tags", tags);
+        m.put("type", metricType);
         metrics.add(m);
     }
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -70,7 +70,9 @@ public abstract class Reporter {
             String[] tags = Arrays.asList((String[]) metric.get("tags")).toArray(new String[0]);
 
             // StatsD doesn't support rate metrics so we need to have our own aggregator to compute rates
-            if (!"gauge".equals(metricType)) {
+            if ("gauge".equals(metricType) || "histogram".equals(metricType)) {
+                sendMetricPoint(metricType, metricName, currentValue, tags);
+            } else { // The metric should be 'counter'
                 String key = generateId(metric);
                 if (!instanceRatesAggregator.containsKey(key)) {
                     HashMap<String, Object> rateInfo = new HashMap<String, Object>();
@@ -87,13 +89,11 @@ public abstract class Reporter {
                 double rate = 1000 * (currentValue - oldValue) / (now - oldTs);
 
                 if (!Double.isNaN(rate) && !Double.isInfinite(rate)) {
-                    sendMetricPoint(metricName, rate, tags);
+                    sendMetricPoint(metricType, metricName, rate, tags);
                 }
 
                 instanceRatesAggregator.get(key).put("ts", now);
                 instanceRatesAggregator.get(key).put(VALUE, currentValue);
-            } else { // The metric is a gauge
-                sendMetricPoint(metricName, currentValue, tags);
             }
         }
 
@@ -131,7 +131,7 @@ public abstract class Reporter {
         return StringUtils.join(chunks, ".");
     }
 
-    protected abstract void sendMetricPoint(String metricName, double value, String[] tags);
+    protected abstract void sendMetricPoint(String metricType, String metricName, double value, String[] tags);
 
     protected abstract void doSendServiceCheck(String checkName, String status, String message, String[] tags);
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -26,12 +26,16 @@ public class StatsdReporter extends Reporter {
         statsDClient = new NonBlockingStatsDClient(null, this.statsdHost, this.statsdPort, new String[]{});
     }
 
-    protected void sendMetricPoint(String metricName, double value, String[] tags) {
+    protected void sendMetricPoint(String metricType, String metricName, double value, String[] tags) {
         if (System.currentTimeMillis() - this.initializationTime > 300 * 1000) {
             this.statsDClient.stop();
             init();
         }
-        statsDClient.gauge(metricName, value, tags);
+        if (metricType.equals("histogram")) {
+            statsDClient.histogram(metricName, value, tags);
+        } else {
+            statsDClient.gauge(metricName, value, tags);
+        }
     }
 
     private int statusToInt(String status) {

--- a/src/test/java/org/datadog/jmxfetch/TestCommon.java
+++ b/src/test/java/org/datadog/jmxfetch/TestCommon.java
@@ -177,9 +177,11 @@ public class TestCommon {
      *
      * @param countTags         number of metric tags
      *
+     * @param metricType        type of the metric (gauge, histogram, ...)
+     *
      * @return                  fail if the metric was not found
      */
-    public void assertMetric(String name, Number value, Number lowerBound, Number upperBound, List<String> commonTags, List<String> additionalTags, int countTags){
+    public void assertMetric(String name, Number value, Number lowerBound, Number upperBound, List<String> commonTags, List<String> additionalTags, int countTags, String metricType){
         List<String> tags = new ArrayList<String>(commonTags);
         tags.addAll(additionalTags);
 
@@ -203,6 +205,10 @@ public class TestCommon {
                 for (String t: tags) {
                     assertTrue(mTags.contains(t));
                 }
+
+                if (metricType != null) {
+                    assertEquals(metricType, m.get("type"));
+                }
                 // Brand the metric
                 m.put("tested", true);
 
@@ -212,24 +218,47 @@ public class TestCommon {
         fail("Metric assertion failed (name: "+name+", value: "+value+", tags: "+tags+", #tags: "+countTags+").");
     }
 
+    public void assertMetric(String name, Number value, Number lowerBound, Number upperBound, List<String> commonTags, List<String> additionalTags, int countTags) {
+        assertMetric(name, value, lowerBound, upperBound, commonTags, additionalTags, countTags, null);
+    }
+
     public void assertMetric(String name, Number value, List<String> commonTags, List<String> additionalTags, int countTags){
         assertMetric(name, value, -1, -1, commonTags, additionalTags, countTags);
     }
 
+    public void assertMetric(String name, Number value, List<String> commonTags, List<String> additionalTags, int countTags, String metricType){
+        assertMetric(name, value, -1, -1, commonTags, additionalTags, countTags, metricType);
+    }
+
     public void assertMetric(String name, Number lowerBound, Number upperBound, List<String> commonTags, List<String> additionalTags, int countTags){
         assertMetric(name, -1, lowerBound, upperBound, commonTags, additionalTags, countTags);
+    }
+    public void assertMetric(String name, Number lowerBound, Number upperBound, List<String> commonTags, List<String> additionalTags, int countTags, String metricType){
+        assertMetric(name, -1, lowerBound, upperBound, commonTags, additionalTags, countTags, metricType);
     }
 
     public void assertMetric(String name, Number value, List<String> tags, int countTags){
         assertMetric(name, value, tags, new ArrayList<String>(), countTags);
     }
 
+    public void assertMetric(String name, Number value, List<String> tags, int countTags, String metricType){
+        assertMetric(name, value, tags, new ArrayList<String>(), countTags, metricType);
+    }
+
     public void assertMetric(String name, Number lowerBound, Number upperBound, List<String> tags, int countTags){
         assertMetric(name, lowerBound, upperBound, tags, new ArrayList<String>(), countTags);
     }
 
+    public void assertMetric(String name, Number lowerBound, Number upperBound, List<String> tags, int countTags, String metricType){
+        assertMetric(name, lowerBound, upperBound, tags, new ArrayList<String>(), countTags, metricType);
+    }
+
     public void assertMetric(String name, List<String> tags, int countTags){
         assertMetric(name, -1, tags, new ArrayList<String>(), countTags);
+    }
+
+    public void assertMetric(String name, List<String> tags, int countTags, String metricType){
+        assertMetric(name, -1, tags, new ArrayList<String>(), countTags, metricType);
     }
 
     /**

--- a/src/test/resources/jmx_histogram.yaml
+++ b/src/test/resources/jmx_histogram.yaml
@@ -1,0 +1,23 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        tags:
+            env: stage
+            newTag: test
+        conf:
+            - include:
+               domain: org.datadog.jmxfetch.test
+               attribute:
+                    Atomic42:
+                        alias: test.gauge_by_default
+                    ShouldBe100:
+                        metric_type: counter
+                        alias: test.counter
+                    ShouldBe1000:
+                        metric_type: gauge
+                        alias: test.gauge
+                    Int424242:
+                        metric_type: histogram
+                        alias: test.histogram


### PR DESCRIPTION
We now support 'histogram' type for metric (in addition of 'gauge' and 'counter').

This is a first step toward blacklisting tags (as different points may have the same tags set).