### PR TITLE
Maxime/jmxfetch exclude tags

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Filter.java
+++ b/src/main/java/org/datadog/jmxfetch/Filter.java
@@ -10,6 +10,7 @@ class Filter {
     HashMap<String, Object> filter;
     Pattern domainRegex;
     ArrayList<Pattern> beanRegexes = null;
+    ArrayList<String> excludeTags = null;
 
     /**
      * A simple class to manipulate include/exclude filter elements more easily
@@ -103,6 +104,21 @@ class Filter {
         }
 
         return this.beanRegexes;
+    }
+
+    public ArrayList<String> getExcludeTags() {
+        // Return excluded tags  as an ArrayList whether it's defined as a list or not
+
+        if (this.excludeTags == null) {
+            if (filter.get("exclude_tags") == null){
+                this.excludeTags = new ArrayList<String>();
+            } else {
+                final Object exclude_tags = filter.get("exclude_tags");
+                this.excludeTags = toStringArrayList(exclude_tags);
+            }
+        }
+
+        return this.excludeTags;
     }
 
     public String getDomain() {

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -28,7 +28,7 @@ public abstract class JMXAttribute {
     protected static final String ALIAS = "alias";
     protected static final String METRIC_TYPE = "metric_type";
     private final static Logger LOGGER = Logger.getLogger(JMXAttribute.class.getName());
-    private static final List<String> EXCLUDED_BEAN_PARAMS = Arrays.asList("domain", "domain_regex", "bean_name", "bean", "bean_regex", "attribute");
+    private static final List<String> EXCLUDED_BEAN_PARAMS = Arrays.asList("domain", "domain_regex", "bean_name", "bean", "bean_regex", "attribute", "exclude_tags");
     private static final String FIRST_CAP_PATTERN = "(.)([A-Z][a-z]+)";
     private static final String ALL_CAP_PATTERN = "([a-z0-9])([A-Z])";
     private static final String METRIC_REPLACEMENT = "([^a-zA-Z0-9_.]+)|(^[^a-zA-Z]+)";
@@ -71,6 +71,23 @@ public abstract class JMXAttribute {
 
         this.beanParameters = beanParametersHash;
         this.defaultTagsList = sanitizeParameters(beanParametersList);
+    }
+
+    /**
+     * Remove tags listed in the 'exclude_tags' list from configuration.
+     */
+    private void applyTagsBlackList() {
+        Filter include = this.matchingConf.getInclude();
+        if (include != null) {
+
+            for (String excludedTagName : include.getExcludeTags()) {
+                for (String tag: this.defaultTagsList) {
+                    if (tag.startsWith(excludedTagName + ":")) {
+                        this.defaultTagsList.remove(tag);
+                    }
+                }
+            }
+        }
     }
 
     public static HashMap<String, String> getBeanParametersHash(String beanParametersString) {
@@ -349,6 +366,9 @@ public abstract class JMXAttribute {
 
     public void setMatchingConf(Configuration matchingConf) {
         this.matchingConf = matchingConf;
+
+        // Now that we have the matchingConf, we can filter out excluded tags
+        applyTagsBlackList();
     }
 
     MBeanAttributeInfo getAttribute() {

--- a/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
@@ -14,7 +14,7 @@ public class ConsoleReporter extends Reporter {
     private LinkedList<HashMap<String, Object>> serviceChecks = new LinkedList<HashMap<String, Object>>();
 
     @Override
-    protected void sendMetricPoint(String metricName, double value, String[] tags) {
+    protected void sendMetricPoint(String metricType, String metricName, double value, String[] tags) {
         String tagString = "[" + Joiner.on(",").join(tags) + "]";
         System.out.println(metricName + tagString + " - " + System.currentTimeMillis() / 1000 + " = " + value);
 
@@ -22,6 +22,7 @@ public class ConsoleReporter extends Reporter {
         m.put("name", metricName);
         m.put("value", value);
         m.put("tags", tags);
+        m.put("type", metricType);
         metrics.add(m);
     }
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -70,7 +70,7 @@ public abstract class Reporter {
             String[] tags = Arrays.asList((String[]) metric.get("tags")).toArray(new String[0]);
 
             // StatsD doesn't support rate metrics so we need to have our own aggregator to compute rates
-            if (!"gauge".equals(metricType)) {
+            if ("counter".equals(metricType)) {
                 String key = generateId(metric);
                 if (!instanceRatesAggregator.containsKey(key)) {
                     HashMap<String, Object> rateInfo = new HashMap<String, Object>();
@@ -87,13 +87,13 @@ public abstract class Reporter {
                 double rate = 1000 * (currentValue - oldValue) / (now - oldTs);
 
                 if (!Double.isNaN(rate) && !Double.isInfinite(rate)) {
-                    sendMetricPoint(metricName, rate, tags);
+                    sendMetricPoint(metricType, metricName, rate, tags);
                 }
 
                 instanceRatesAggregator.get(key).put("ts", now);
                 instanceRatesAggregator.get(key).put(VALUE, currentValue);
-            } else { // The metric is a gauge
-                sendMetricPoint(metricName, currentValue, tags);
+            } else { // The metric is a gauge or histogram
+                sendMetricPoint(metricType, metricName, currentValue, tags);
             }
         }
 
@@ -131,7 +131,7 @@ public abstract class Reporter {
         return StringUtils.join(chunks, ".");
     }
 
-    protected abstract void sendMetricPoint(String metricName, double value, String[] tags);
+    protected abstract void sendMetricPoint(String metricType, String metricName, double value, String[] tags);
 
     protected abstract void doSendServiceCheck(String checkName, String status, String message, String[] tags);
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -26,12 +26,16 @@ public class StatsdReporter extends Reporter {
         statsDClient = new NonBlockingStatsDClient(null, this.statsdHost, this.statsdPort, new String[]{});
     }
 
-    protected void sendMetricPoint(String metricName, double value, String[] tags) {
+    protected void sendMetricPoint(String metricType, String metricName, double value, String[] tags) {
         if (System.currentTimeMillis() - this.initializationTime > 300 * 1000) {
             this.statsDClient.stop();
             init();
         }
-        statsDClient.gauge(metricName, value, tags);
+        if (metricType.equals("histogram")) {
+            statsDClient.histogram(metricName, value, tags);
+        } else {
+            statsDClient.gauge(metricName, value, tags);
+        }
     }
 
     private int statusToInt(String status) {

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -366,6 +366,31 @@ public class TestApp extends TestCommon {
         assertMetric("test.counter", 0.0, commonTags, 5, "counter");
     }
 
+    @Test
+    public void testExcludeTags() throws Exception {
+        // We expose a few metrics through JMX
+        SimpleTestJavaApp testApp = new SimpleTestJavaApp();
+        registerMBean(testApp, "org.datadog.jmxfetch.test:type=SimpleTestJavaApp");
+
+        // We do a first collection
+        initApplication("jmx_exclude_tags.yml");
+        run();
+        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+
+        // We test for the presence and the value of the metrics we want to collect.
+        // Tags "type", "newTag" and "env" should be excluded
+        List<String> commonTags = Arrays.asList(
+            "instance:jmx_test_instance",
+            "jmx_domain:org.datadog.jmxfetch.test");
+
+        // 15 = 13 metrics from java.lang + the 2 collected (gauge and histogram)
+        assertEquals(15, metrics.size());
+
+        // There should only left 2 tags per metric
+        assertMetric("test1.gauge", 1000.0, commonTags, 2, "gauge");
+        assertMetric("test1.histogram", 424242, commonTags, 2, "histogram");
+    }
+
     /**
      * FIXME: Split this test in multiple sub-tests.
      */

--- a/src/test/java/org/datadog/jmxfetch/TestCommon.java
+++ b/src/test/java/org/datadog/jmxfetch/TestCommon.java
@@ -177,9 +177,11 @@ public class TestCommon {
      *
      * @param countTags         number of metric tags
      *
+     * @param metricType        type of the metric (gauge, histogram, ...)
+     *
      * @return                  fail if the metric was not found
      */
-    public void assertMetric(String name, Number value, Number lowerBound, Number upperBound, List<String> commonTags, List<String> additionalTags, int countTags){
+    public void assertMetric(String name, Number value, Number lowerBound, Number upperBound, List<String> commonTags, List<String> additionalTags, int countTags, String metricType){
         List<String> tags = new ArrayList<String>(commonTags);
         tags.addAll(additionalTags);
 
@@ -203,6 +205,10 @@ public class TestCommon {
                 for (String t: tags) {
                     assertTrue(mTags.contains(t));
                 }
+
+                if (metricType != null) {
+                    assertEquals(metricType, m.get("type"));
+                }
                 // Brand the metric
                 m.put("tested", true);
 
@@ -212,24 +218,47 @@ public class TestCommon {
         fail("Metric assertion failed (name: "+name+", value: "+value+", tags: "+tags+", #tags: "+countTags+").");
     }
 
+    public void assertMetric(String name, Number value, Number lowerBound, Number upperBound, List<String> commonTags, List<String> additionalTags, int countTags) {
+        assertMetric(name, value, lowerBound, upperBound, commonTags, additionalTags, countTags, null);
+    }
+
     public void assertMetric(String name, Number value, List<String> commonTags, List<String> additionalTags, int countTags){
         assertMetric(name, value, -1, -1, commonTags, additionalTags, countTags);
     }
 
+    public void assertMetric(String name, Number value, List<String> commonTags, List<String> additionalTags, int countTags, String metricType){
+        assertMetric(name, value, -1, -1, commonTags, additionalTags, countTags, metricType);
+    }
+
     public void assertMetric(String name, Number lowerBound, Number upperBound, List<String> commonTags, List<String> additionalTags, int countTags){
         assertMetric(name, -1, lowerBound, upperBound, commonTags, additionalTags, countTags);
+    }
+    public void assertMetric(String name, Number lowerBound, Number upperBound, List<String> commonTags, List<String> additionalTags, int countTags, String metricType){
+        assertMetric(name, -1, lowerBound, upperBound, commonTags, additionalTags, countTags, metricType);
     }
 
     public void assertMetric(String name, Number value, List<String> tags, int countTags){
         assertMetric(name, value, tags, new ArrayList<String>(), countTags);
     }
 
+    public void assertMetric(String name, Number value, List<String> tags, int countTags, String metricType){
+        assertMetric(name, value, tags, new ArrayList<String>(), countTags, metricType);
+    }
+
     public void assertMetric(String name, Number lowerBound, Number upperBound, List<String> tags, int countTags){
         assertMetric(name, lowerBound, upperBound, tags, new ArrayList<String>(), countTags);
     }
 
+    public void assertMetric(String name, Number lowerBound, Number upperBound, List<String> tags, int countTags, String metricType){
+        assertMetric(name, lowerBound, upperBound, tags, new ArrayList<String>(), countTags, metricType);
+    }
+
     public void assertMetric(String name, List<String> tags, int countTags){
         assertMetric(name, -1, tags, new ArrayList<String>(), countTags);
+    }
+
+    public void assertMetric(String name, List<String> tags, int countTags, String metricType){
+        assertMetric(name, -1, tags, new ArrayList<String>(), countTags, metricType);
     }
 
     /**

--- a/src/test/resources/jmx_exclude_tags.yml
+++ b/src/test/resources/jmx_exclude_tags.yml
@@ -1,0 +1,22 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        tags:
+            env: stage
+            newTag: test
+        conf:
+            - include:
+               domain: org.datadog.jmxfetch.test
+               exclude_tags:
+                    - env
+                    - type
+                    - newTag
+               attribute:
+                    ShouldBe1000:
+                        metric_type: gauge
+                        alias: test1.gauge
+                    Int424242:
+                        metric_type: histogram
+                        alias: test1.histogram

--- a/src/test/resources/jmx_histogram.yaml
+++ b/src/test/resources/jmx_histogram.yaml
@@ -1,0 +1,23 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        tags:
+            env: stage
+            newTag: test
+        conf:
+            - include:
+               domain: org.datadog.jmxfetch.test
+               attribute:
+                    Atomic42:
+                        alias: test.gauge_by_default
+                    ShouldBe100:
+                        metric_type: counter
+                        alias: test.counter
+                    ShouldBe1000:
+                        metric_type: gauge
+                        alias: test.gauge
+                    Int424242:
+                        metric_type: histogram
+                        alias: test.histogram


### PR DESCRIPTION
This is usefull to filter out unique tags like host/client id, ...
This may/should be use in combination with the 'histogram' metric_type to avoid loosing metric points.