### PR TITLE
Maxime/add additional tags option

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Filter.java
+++ b/src/main/java/org/datadog/jmxfetch/Filter.java
@@ -11,6 +11,7 @@ class Filter {
     Pattern domainRegex;
     ArrayList<Pattern> beanRegexes = null;
     ArrayList<String> excludeTags = null;
+    HashMap<String, String> additionalTags = null;
 
     /**
      * A simple class to manipulate include/exclude filter elements more easily
@@ -119,6 +120,20 @@ class Filter {
         }
 
         return this.excludeTags;
+    }
+
+    public HashMap<String, String> getAdditionalTags() {
+        // Return additional tags
+
+        if (this.additionalTags == null) {
+            if (filter.get("tags") == null){
+                this.additionalTags = new HashMap<String, String>();
+            } else {
+                this.additionalTags = (HashMap<String, String>)filter.get("tags");
+            }
+        }
+
+        return this.additionalTags;
     }
 
     public String getDomain() {

--- a/src/test/resources/jmx_additional_tags.yml
+++ b/src/test/resources/jmx_additional_tags.yml
@@ -1,0 +1,20 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        conf:
+            - include:
+               domain: org.datadog.jmxfetch.test
+               tags:
+                    simple: $type
+                    raw_value: value
+                    unknown_tag: $does-not-exist
+                    multiple: $type-$name
+               attribute:
+                    ShouldBe1000:
+                        metric_type: gauge
+                        alias: test1.gauge
+                    Int424242:
+                        metric_type: histogram
+                        alias: test1.histogram


### PR DESCRIPTION
Add 'additional_tags' list to the configuration: ref #108

This allows a user to define additional tag at the 'include' level (with alias using the '$tag_name' notation).