### PR TITLE
Use https://oss.sonatype.org/content/groups/public/ instead of http:/…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,14 +26,6 @@
 		<snakeyaml.version>1.13</snakeyaml.version>
 	</properties>
 
-	<repositories>
-		<repository>
-			<id>Sonatype-public</id>
-			<name>SnakeYAML repository</name>
-			<url>https://oss.sonatype.org/content/groups/public/</url>
-		</repository>
-	</repositories>
-
 	<dependencies>
 		<dependency>
 			<groupId>com.beust</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
 		<repository>
 			<id>Sonatype-public</id>
 			<name>SnakeYAML repository</name>
-			<url>http://oss.sonatype.org/content/groups/public/</url>
+			<url>https://oss.sonatype.org/content/groups/public/</url>
 		</repository>
 	</repositories>
 


### PR DESCRIPTION
…/oss.sonatype.org/content/groups/public/ .

Signed-off-by: David Black <dblack@atlassian.com>