### PR TITLE
[remoteconnection] if the port is a string, cast w/ parseInt().

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -25,7 +25,11 @@ public class RemoteConnection extends Connection {
     public RemoteConnection(LinkedHashMap<String, Object> connectionParams)
             throws IOException {
         host = (String) connectionParams.get("host");
-        port = (Integer) connectionParams.get("port");
+        try{
+            port = (Integer) connectionParams.get("port");
+        } catch(ClassCastException e) {
+            port = Integer.parseInt((String) connectionParams.get("port"));
+        }
         user = (String) connectionParams.get("user");
         password = (String) connectionParams.get("password");
         jmx_url = (String) connectionParams.get("jmx_url");


### PR DESCRIPTION
This is an issue now giving the way service discovery on the `dd-agent` side populates the templates. Besides, customers can always make the mistake of putting quotes around a port number. This should be able to address that.