### PR TITLE
[instance] support instance tags in list format

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -134,7 +134,12 @@ public abstract class JMXAttribute {
 
         if (instanceTags != null) {
             for (Map.Entry<String, String> tag : instanceTags.entrySet()) {
-                beanTags.add(tag.getKey() + ":" + tag.getValue());
+                if (tag.getValue() != null) {
+                    beanTags.add(tag.getKey() + ":" + tag.getValue());
+                }
+                else {
+                    beanTags.add(tag.getKey());
+                }
             }
         }
 

--- a/src/test/resources/jmx.yaml
+++ b/src/test/resources/jmx.yaml
@@ -5,8 +5,8 @@ instances:
         refresh_beans: 4
         name: jmx_test_instance
         tags:
-            env: stage
-            newTag: test
+            - "env:stage"
+            - "newTag:test"
         conf:
             - include:
                domain: org.datadog.jmxfetch.test


### PR DESCRIPTION
Support instance tags defined in an array/list format.

Fix https://github.com/DataDog/jmxfetch/issues/131