### PR TITLE
[service_discovery] Fix race condition preventing SD initialization

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -237,8 +237,8 @@ public class App {
                 sdPipe = newSdPipe();
             }
             try {
-                if(sdPipe != null && sdPipe.available() > 0) {
-                    int len = sdPipe.available();
+                int len;
+                if(sdPipe != null && (len = sdPipe.available()) > 0) {
                     byte[] buffer = new byte[len];
                     sdPipe.read(buffer);
                     setReinit(processServiceDiscovery(buffer));

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -3,12 +3,10 @@ package org.datadog.jmxfetch;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileFilter;
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -169,6 +167,17 @@ public class App {
       return SERVICE_DISCOVERY_PREFIX + splitted[0].substring(2, splitted[0].length());
     }
 
+    private FileInputStream newSdPipe() {
+        FileInputStream sdPipe = null;
+        try {
+            sdPipe = new FileInputStream(appConfig.getServiceDiscoveryPipe()); //Should we use RandomAccessFile?
+            LOGGER.info("Named pipe for Service Discovery opened");
+        } catch (FileNotFoundException e) {
+            LOGGER.info("Unable to open named pipe for Service Discovery.");
+        }
+        return sdPipe;
+    }
+
     public boolean processServiceDiscovery(byte[] buffer) {
       boolean reinit = false;
       String[] discovered;
@@ -210,11 +219,9 @@ public class App {
         long delta_s = 0;
         FileInputStream sdPipe = null;
 
-        try {
-          sdPipe = new FileInputStream(appConfig.getServiceDiscoveryPipe()); //Should we use RandomAccessFile?
-        } catch (FileNotFoundException e) {
-          LOGGER.warn("Unable to open named pipe - Service Discovery disabled.");
-          sdPipe = null;
+        if(appConfig.getSDEnabled()) {
+            LOGGER.info("Service Discovery enabled");
+            sdPipe = newSdPipe();
         }
 
         while (true) {
@@ -225,13 +232,17 @@ public class App {
             }
 
             // any SD configs waiting in pipe?
+            if(sdPipe == null && appConfig.getSDEnabled()) {
+                // If SD is enabled and the pipe is not open, retry opening pipe
+                sdPipe = newSdPipe();
+            }
             try {
-              if(sdPipe != null && sdPipe.available() > 0) {
-                int len = sdPipe.available();
-                byte[] buffer = new byte[len];
-                sdPipe.read(buffer);
-                setReinit(processServiceDiscovery(buffer));
-              }
+                if(sdPipe != null && sdPipe.available() > 0) {
+                    int len = sdPipe.available();
+                    byte[] buffer = new byte[len];
+                    sdPipe.read(buffer);
+                    setReinit(processServiceDiscovery(buffer));
+                }
             } catch(IOException e) {
               LOGGER.warn("Unable to read from pipe - Service Discovery configuration may have been skipped.");
             }

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -76,10 +76,10 @@ class AppConfig {
             required = false)
     private int checkPeriod = 15000;
 
-    @Parameter(names = {"--sd_standby", "-w"},
-            description = "Service Discovery standby.",
+    @Parameter(names = {"--sd_enabled", "-w"},
+            description = "Enable Service Discovery.",
             required = false)
-    private boolean sdStandby = false;
+    private boolean sdEnabled = false;
 
     @Parameter(names = {"--sd_pipe", "-S"},
             description = "Service Discovery pipe name.",
@@ -128,8 +128,8 @@ class AppConfig {
         return checkPeriod;
     }
 
-    public boolean getSDStandby() {
-        return sdStandby;
+    public boolean getSDEnabled() {
+        return sdEnabled;
     }
 
     public Reporter getReporter() {

--- a/src/test/java/org/datadog/jmxfetch/TestCommon.java
+++ b/src/test/java/org/datadog/jmxfetch/TestCommon.java
@@ -103,6 +103,7 @@ public class TestCommon {
         if (sdEnabled) {
             params.add(4, "--tmp_directory");
             params.add(5, "/foo"); //could be anything we're stubbing it out
+            params.add(6, "--sd_enabled");
         }
         new JCommander(appConfig, params.toArray(new String[params.size()]));
 


### PR DESCRIPTION
If JMXFetch starts before the collector process creates the SD pipe,
JMXFetch doesn't find the SD pipe and never re-tries opening it (until
it's fully restarted).

To solve this, retry opening the SD pipe at every run iteration when
SD is enabled. Also, add an `--sd-enabled` option to know whether
JMXFetch should enable SD (i.e. whether it should expect the SD pipe
to exist or not).

The `--sd-standby` option is not used and has therefore been removed.

This change requires a change to `dd-agent` to make `jmxfetch.py` pass
the `--sd-enabled` option when SD-JMXFetch is enabled. See https://github.com/DataDog/dd-agent/pull/3306