### PR TITLE
adds min collection interval

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -287,6 +287,11 @@ public class App {
             int numberOfMetrics = 0;
 
             try {
+            	if (!instance.timeToCollect()) {
+            		LOGGER.debug("it is not time to collect, skipping run for " + instance.getName());
+            		continue;
+            	}
+            	
                 metrics = instance.getMetrics();
                 numberOfMetrics = metrics.size();
 

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -82,7 +82,10 @@ public class Instance {
             // Useful because sometimes if the application restarts, jmxfetch might read
             // a jmxtree that is not completely initialized and would be missing some attributes
         }
-        this.minCollectionPeriod = (Integer) yaml.get("min_collection_period");
+        this.minCollectionPeriod = (Integer) initConfig.get("min_collection_period");
+        if (this.minCollectionPeriod == null) {
+        	this.minCollectionPeriod = (Integer) yaml.get("min_collection_period");
+        }
         this.lastCollectionTime = 0;
         this.lastRefreshTime = 0;
         this.limitReached = false;

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -197,13 +197,8 @@ public class Instance {
         Iterator<JMXAttribute> it = matchingAttributes.iterator();
         
         
-        // If we collected already, don't collect again
-        if (!this.timeToCollect()) {
-        	LOGGER.debug("it is not time to collect, skipping run for " + this.instanceName);
-        	return metrics;
-        } else {
-        	this.lastCollectionTime = System.currentTimeMillis();
-        }
+        // increment the lastCollectionTime
+        this.lastCollectionTime = System.currentTimeMillis();
 
         while (it.hasNext()) {
             JMXAttribute jmxAttr = it.next();

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -82,9 +82,10 @@ public class Instance {
             // Useful because sometimes if the application restarts, jmxfetch might read
             // a jmxtree that is not completely initialized and would be missing some attributes
         }
-        this.minCollectionPeriod = (Integer) initConfig.get("min_collection_period");
+        
+        this.minCollectionPeriod = (Integer) yaml.get("min_collection_period");
         if (this.minCollectionPeriod == null) {
-        	this.minCollectionPeriod = (Integer) yaml.get("min_collection_period");
+        	this.minCollectionPeriod = (Integer) initConfig.get("min_collection_period");
         }
         this.lastCollectionTime = 0;
         this.lastRefreshTime = 0;

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -18,13 +18,16 @@ public class TestInstance extends TestCommon {
 		
 		LinkedList<HashMap<String, Object>> metrics = getMetrics();
 		assertEquals(15, metrics.size());
+		metrics = new LinkedList<HashMap<String, Object>>();
+		
 		run();
 		metrics = getMetrics();
 		assertEquals(0, metrics.size());
+		metrics = new LinkedList<HashMap<String, Object>>();
+		
 		Thread.sleep(300000);
 		
 		run();
-		
 		metrics = getMetrics();
 		assertEquals(15, metrics.size());
 		

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -17,24 +17,18 @@ public class TestInstance extends TestCommon {
 		initApplication("jmx_min_collection_period.yml");
 		
 		run();
-		
 		LinkedList<HashMap<String, Object>> metrics = getMetrics();
 		assertEquals(15, metrics.size());
-		metrics = new LinkedList<HashMap<String, Object>>();
 		
 		run();
 		metrics = getMetrics();
 		assertEquals(0, metrics.size());
-		metrics = new LinkedList<HashMap<String, Object>>();
 		
 		LOGGER.info("sleeping before the next collection");
-		
 		Thread.sleep(5000);
-		
 		run();
 		metrics = getMetrics();
 		assertEquals(15, metrics.size());
-		
 	}
 
 }

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -1,0 +1,33 @@
+package org.datadog.jmxfetch;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+
+import org.junit.Test;
+
+public class TestInstance extends TestCommon {
+	
+	@Test
+	public void testMinCollectionInterval() throws Exception {
+		registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:foo=Bar,qux=Baz");
+		initApplication("jmx_min_collection_period.yml");
+		
+		run();
+		
+		LinkedList<HashMap<String, Object>> metrics = getMetrics();
+		assertEquals(15, metrics.size());
+		run();
+		metrics = getMetrics();
+		assertEquals(0, metrics.size());
+		Thread.sleep(300000);
+		
+		run();
+		
+		metrics = getMetrics();
+		assertEquals(15, metrics.size());
+		
+	}
+
+}

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -5,9 +5,11 @@ import static org.junit.Assert.assertEquals;
 import java.util.HashMap;
 import java.util.LinkedList;
 
+import org.apache.log4j.Logger;
 import org.junit.Test;
 
 public class TestInstance extends TestCommon {
+	private final static Logger LOGGER = Logger.getLogger("Test Instance");
 	
 	@Test
 	public void testMinCollectionInterval() throws Exception {
@@ -25,7 +27,9 @@ public class TestInstance extends TestCommon {
 		assertEquals(0, metrics.size());
 		metrics = new LinkedList<HashMap<String, Object>>();
 		
-		Thread.sleep(300000);
+		LOGGER.info("sleeping before the next collection");
+		
+		Thread.sleep(5000);
 		
 		run();
 		metrics = getMetrics();

--- a/src/test/resources/jmx_min_collection_period.yml
+++ b/src/test/resources/jmx_min_collection_period.yml
@@ -1,0 +1,16 @@
+init_config:
+
+instances:
+  -   process_name_regex: .*surefire.*
+      min_collection_period: 300
+      name: jmx_test_instance
+      conf:
+          - include:
+             domain: org.datadog.jmxfetch.test
+             attribute:
+                  ShouldBe100:
+                      metric_type: gauge
+                      alias: this.is.100.$foo.$qux
+                  Hashmap.thisis0:
+                      metric_type: gauge
+                      alias: $domain.$qux.$attribute

--- a/src/test/resources/jmx_min_collection_period.yml
+++ b/src/test/resources/jmx_min_collection_period.yml
@@ -2,7 +2,7 @@ init_config:
 
 instances:
   -   process_name_regex: .*surefire.*
-      min_collection_period: 300
+      min_collection_period: 5
       name: jmx_test_instance
       conf:
           - include:


### PR DESCRIPTION
We had a request for this change: someone wanted to be able to configure the collection period for each jmx check. This will allow you to do that.

Right now the only thing you can do is to configure the loop for all checks, this allows you to configure the loop for each check, or even for each instance of each check.