### PR TITLE
[auto-discovery] set jmx launch file on boot-up.

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -30,6 +30,8 @@ import org.apache.log4j.Logger;
 import org.apache.commons.lang3.CharEncoding;
 import org.datadog.jmxfetch.reporter.Reporter;
 import org.datadog.jmxfetch.util.CustomLogger;
+import org.datadog.jmxfetch.util.FileHelper;
+
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
@@ -234,6 +236,12 @@ public class App {
         if(appConfig.getAutoDiscoveryEnabled()) {
             LOGGER.info("Auto Discovery enabled");
             adPipe = newAutoDiscoveryPipe();
+            try {
+                FileHelper.touch(new File(appConfig.getJMXLaunchFile()));
+            } catch (IOException e) {
+                  LOGGER.warn("Unable to create launch file"
+                          + " - Auto-Discovery configs will not be automatically resubmitted.");
+            }
         }
 
         while (true) {

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -31,6 +31,7 @@ class AppConfig {
     private static final String AD_WIN_PIPE_PATH = "\\\\.\\pipe\\";
     private static final String AD_LEGACY_PIPE_NAME = "dd-service_discovery";
     private static final String AD_PIPE_NAME = "dd-auto_discovery";
+    private static final String AD_LAUNCH_FILE = "jmx.launch";
 
     @Parameter(names = {"--help", "-h"},
             description = "Display this help page",
@@ -166,5 +167,9 @@ class AppConfig {
             pipePath = getTmpDirectory() + "/" + adPipe;
         }
         return pipePath;
+    }
+
+    public String getJMXLaunchFile() {
+        return getTmpDirectory() + "/" + AD_LAUNCH_FILE;
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/util/FileHelper.java
+++ b/src/main/java/org/datadog/jmxfetch/util/FileHelper.java
@@ -1,0 +1,21 @@
+package org.datadog.jmxfetch.util;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+
+public class FileHelper {
+    public static void touch(File file) throws IOException{
+        long timestamp = System.currentTimeMillis();
+        touch(file, timestamp);
+    }
+
+    public static void touch(File file, long timestamp) throws IOException{
+        if (!file.exists()) {
+            new FileOutputStream(file).close();
+        }
+
+        file.setLastModified(timestamp);
+    }
+}


### PR DESCRIPTION
We need to touch a jmx helper launch file - empty. We can then use the last access time to the file to prompt reloading the checks and resubmission of the configurations over the pipe.