### PR TITLE
[auto_discovery] process templates larger than the page buffer size

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -249,7 +249,7 @@ public class App {
                 adPipe = newAutoDiscoveryPipe();
             }
             try {
-                if(adPipe != null) {
+                if(adPipe != null && adPipe.available() > 0) {
                     byte[] buffer = new byte[0];
                     boolean terminated = false;
                     while (!terminated) {
@@ -261,7 +261,7 @@ public class App {
                             // The separator always comes in its own atomic write() from the agent side -
                             // so it will never be chopped.
                             if (Bytes.indexOf(minibuff, App.AD_LEGACY_CONFIG_TERM.getBytes()) > -1 ||
-                                Bytes.indexOf(minibuff, App.AD_CONFIG_TERM.getBytes()) > -1 ) {
+                                    Bytes.indexOf(minibuff, App.AD_CONFIG_TERM.getBytes()) > -1 ) {
                                 terminated = true;
                             }
 

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -171,12 +171,12 @@ public class App {
 
     private FileInputStream newAutoDiscoveryPipe() {
         FileInputStream adPipe = null;
+        String pipeName = appConfig.getAutoDiscoveryPipe();
         try {
-            String pipeName = appConfig.getAutoDiscoveryPipe();
             adPipe = new FileInputStream(pipeName);
             LOGGER.info("Named pipe for Auto-Discovery opened: " + pipeName);
         } catch (FileNotFoundException e) {
-            LOGGER.info("Unable to open named pipe for Auto-Discovery.");
+            LOGGER.info("Unable to open named pipe for Auto-Discovery: " + pipeName);
         }
 
         return adPipe;
@@ -247,7 +247,6 @@ public class App {
             }
             try {
                 if(adPipe != null) {
-                    int offset = 0;
                     byte[] buffer = new byte[0];
                     while (adPipe.available() > 0) {
                         int len = adPipe.available();

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -172,8 +172,9 @@ public class App {
     private FileInputStream newAutoDiscoveryPipe() {
         FileInputStream adPipe = null;
         try {
-            adPipe = new FileInputStream(appConfig.getAutoDiscoveryPipe()); //Should we use RandomAccessFile?
-            LOGGER.info("Named pipe for Auto-Discovery opened");
+            String pipeName = appConfig.getAutoDiscoveryPipe();
+            adPipe = new FileInputStream(pipeName);
+            LOGGER.info("Named pipe for Auto-Discovery opened: " + pipeName);
         } catch (FileNotFoundException e) {
             LOGGER.info("Unable to open named pipe for Auto-Discovery.");
         }


### PR DESCRIPTION
We must be able to process templates as large as necessary - customer encountered we were just processing 64K configurations at most when reading from the pipe - consistent with the default page buffer on linux. Let's read the entire buffer... Also, this is necessary to avoid blocking the writing side indefinitely.