### PR TITLE
Support value conversion for complex types

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/JMXComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXComplexAttribute.java
@@ -65,7 +65,7 @@ public class JMXComplexAttribute extends JMXAttribute {
                 metric.put("tags", getTags());
             }
 
-            metric.put("value", castToDouble(getValue(subAttribute)));
+            metric.put("value", castToDouble(getValue(subAttribute), subAttribute));
             metrics.add(metric);
 
         }

--- a/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXSimpleAttribute.java
@@ -29,7 +29,7 @@ public class JMXSimpleAttribute extends JMXAttribute {
         HashMap<String, Object> metric = new HashMap<String, Object>();
 
         metric.put("alias", getAlias());
-        metric.put("value", castToDouble(getValue()));
+        metric.put("value", castToDouble(getValue(), null));
         metric.put("tags", getTags());
         metric.put("metric_type", getMetricType());
         LinkedList<HashMap<String, Object>> metrics = new LinkedList<HashMap<String, Object>>();

--- a/src/main/java/org/datadog/jmxfetch/JMXTabularAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXTabularAttribute.java
@@ -131,7 +131,7 @@ public class JMXTabularAttribute extends JMXAttribute {
                     metric.put("tags", getTags(dataKey, metricKey));
                 }
 
-                metric.put("value", castToDouble(getValue(dataKey, metricKey)));
+                metric.put("value", castToDouble(getValue(dataKey, metricKey), null));
 
                 if(!subMetrics.containsKey(fullMetricKey)) {
                     subMetrics.put(fullMetricKey, new LinkedList<HashMap<String, Object>>());

--- a/src/test/java/org/datadog/jmxfetch/SimpleTestJavaApp.java
+++ b/src/test/java/org/datadog/jmxfetch/SimpleTestJavaApp.java
@@ -46,6 +46,7 @@ public class SimpleTestJavaApp implements SimpleTestJavaAppMBean {
         hashmap.put("thisis0", 0);
         hashmap.put("thisis10", 10);
         hashmap.put("thisiscounter", 0);
+        hashmap.put("shouldBeDefaulted", 0);
         compositetype = buildCompositeType();
         tabulardata = buildTabularType();
         if (tabulardata != null) {

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -182,8 +182,8 @@ public class TestApp extends TestCommon {
         run();
         LinkedList<HashMap<String, Object>> metrics = getMetrics();
 
-        // First filter 28 = 13 metrics from java.lang + 15 metrics implicitly defined
-        assertEquals(28, metrics.size());
+        // First filter 29 = 13 metrics from java.lang + 16 metrics implicitly defined
+        assertEquals(29, metrics.size());
     }
 
     @Test
@@ -467,9 +467,9 @@ public class TestApp extends TestCommon {
         run();
         LinkedList<HashMap<String, Object>> metrics = getMetrics();
 
-        // 28 = 13 metrics from java.lang + the 5 gauges we are explicitly collecting + 9 gauges implicitly collected
+        // 29 = 13 metrics from java.lang + the 6 gauges we are explicitly collecting + 9 gauges implicitly collected
         // + 1 multi-value, see jmx.yaml in the test/resources folder
-        assertEquals(28, metrics.size());
+        assertEquals(29, metrics.size());
 
 
         // We test for the presence and the value of the metrics we want to collect
@@ -487,6 +487,7 @@ public class TestApp extends TestCommon {
         assertMetric("test.boolean", 1.0, commonTags, 5);
         assertMetric("test.defaulted", 32.0, commonTags, 5);
         assertMetric("subattr.this.is.0", 0.0, commonTags, 5);
+        assertMetric("subattr.defaulted", 42.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.atomic42", 42.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.atomic4242", 4242.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.object1337", 13.37, commonTags, 5);
@@ -499,9 +500,9 @@ public class TestApp extends TestCommon {
         // We run a second collection. The counter should now be present
         run();
         metrics = getMetrics();
-        // 30 = 13 metrics from java.lang + the 5 gauges we are explicitly collecting + 9 gauges implicitly collected
+        // 31 = 13 metrics from java.lang + the 6 gauges we are explicitly collecting + 9 gauges implicitly collected
         // + 1 multi-value + 2 counter, see jmx.yaml in the test/resources folder
-        assertEquals(30, metrics.size());
+        assertEquals(31, metrics.size());
 
 
         // We test for the same metrics but this time, the counter should be here
@@ -515,6 +516,7 @@ public class TestApp extends TestCommon {
         assertMetric("test.boolean", 1.0, commonTags, 5);
         assertMetric("test.defaulted", 32.0, commonTags, 5);
         assertMetric("subattr.this.is.0", 0.0, commonTags, 5);
+        assertMetric("subattr.defaulted", 42.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.atomic42", 42.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.atomic4242", 4242.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.object1337", 13.37, commonTags, 5);
@@ -535,9 +537,9 @@ public class TestApp extends TestCommon {
 
         run();
         metrics = getMetrics();
-        // 31 = 13 metrics from java.lang + the 5 gauges we are explicitly collecting + 9 gauges implicitly collected
-        // + 2 multi-value + 2 counter, see jmx.yaml in the test/resources folder
-        assertEquals(30, metrics.size());
+        // 31 = 13 metrics from java.lang + the 6 gauges we are explicitly collecting + 9 gauges implicitly collected
+        // + 1 multi-value + 2 counter, see jmx.yaml in the test/resources folder
+        assertEquals(31, metrics.size());
 
 
         // Previous metrics
@@ -550,6 +552,7 @@ public class TestApp extends TestCommon {
         assertMetric("test.boolean", 1.0, commonTags, 5);
         assertMetric("test.defaulted", 32.0, commonTags, 5);
         assertMetric("subattr.this.is.0", 0.0, commonTags, 5);
+        assertMetric("subattr.defaulted", 42.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.atomic42", 42.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.atomic4242", 4242.0, commonTags, 5);
         assertMetric("jmx.org.datadog.jmxfetch.test.object1337", 13.37, commonTags, 5);

--- a/src/test/resources/jmx.yaml
+++ b/src/test/resources/jmx.yaml
@@ -30,6 +30,11 @@ instances:
                     Hashmap.thisiscounter:
                         metric_type: counter
                         alias: subattr.counter
+                    Hashmap.shouldBeDefaulted:
+                        metric_type: gauge
+                        alias: subattr.defaulted
+                        values:
+                          default: 42
                     ShouldBeConverted:
                         metric_type: gauge
                         alias: test.converted


### PR DESCRIPTION
It's currently not possible to define value conversions for map entries e.g.

    somemap.field1:
      values:
        default: 42

This PR adds support for it.