### PR TITLE
adds backoff

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -365,10 +365,18 @@ public class App {
 
                     if (numberOfMetrics == 0) {
                         instanceMessage = "Instance " + instance + " didn't return any metrics";
-                        LOGGER.warn(instanceMessage);
                         instanceStatus = Status.STATUS_ERROR;
                         scStatus = Status.STATUS_ERROR;
-                        brokenInstances.add(instance);
+                        if (tryN < maxRetry) {
+                    		instanceMessage += " queuing for a retry";
+                    			// add the failed instance if there are more to add
+                    			retryInstances.add(instance);
+                    			continue;
+	                    } else {
+	                    		// Only declare it broken once it's run (and failed) four times
+	                    		brokenInstances.add(instance);
+	                    }
+                        LOGGER.warn(instanceMessage);
                     } else if (instance.isLimitReached()) {
                         instanceMessage = "Number of returned metrics is too high for instance: "
                                 + instance.getName()

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -48,8 +48,8 @@ public class App {
     private static final String AD_LEGACY_CONFIG_SEP = "#### SERVICE-DISCOVERY ####";
     private static final String AD_CONFIG_TERM = "#### AUTO-DISCOVERY TERM ####";
     private static final String AD_LEGACY_CONFIG_TERM = "#### SERVICE-DISCOVERY TERM ####";
-    private static int backoffLow = 1;
-    private static int backoffHigh = 1000;
+    private static int backoffJitterLow = 100;
+    private static int backoffJitterHigh = 1000;
     private static int maxRetry = 4;
     private static int loopCounter;
     Random rand = new Random();
@@ -334,8 +334,8 @@ public class App {
         			retryInstances = new ArrayList<Instance>();
         			it = runInstances.iterator();
                 if (tryN < maxRetry) {
-                		int backoff = (int) Math.round(Math.pow(2, tryN) * 1000);
-                		backoff += rand.nextInt(backoffHigh) + backoffLow;
+                		int backoff = (int) Math.round(Math.pow(2, tryN) * 500);
+                		backoff += rand.nextInt(backoffJitterHigh) + backoffJitterLow;
                 		try {
 							Thread.sleep(backoff);
 						} catch (InterruptedException e1) {


### PR DESCRIPTION
When there is a connection failure, we should not immediately declare the app broken. Instead, we should retry it with some backoff, only adding it to the list of the broken after it has failed four times