### PR TITLE
set a minimum number of metrics to collect

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -237,7 +237,7 @@ public class Instance {
             }
         }
         if (this.minReturnedMetrics < metrics.size()) {
-        	  this.refreshNextRun = true;
+        	this.refreshNextRun = true;
         }
         return metrics;
     }

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -237,7 +237,7 @@ public class Instance {
             }
         }
         if (this.minReturnedMetrics < metrics.size()) {
-        		this.refreshNextRun = true;
+        	    this.refreshNextRun = true;
         }
         return metrics;
     }

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -87,10 +87,8 @@ public class Instance {
 
         this.minCollectionPeriod = (Integer) yaml.get("min_collection_interval");
         if (this.minCollectionPeriod == null && initConfig != null) {
-        		this.minCollectionPeriod = (Integer) initConfig.get("min_collection_interval");
+        	this.minCollectionPeriod = (Integer) initConfig.get("min_collection_interval");
         }
-        
-        	this.minimumNumberOfMetrics = (Integer) initConfig.get("min_number_of_metrics");
 
         this.lastCollectionTime = 0;
         this.lastRefreshTime = 0;
@@ -102,6 +100,11 @@ public class Instance {
             this.maxReturnedMetrics = (Integer) maxReturnedMetrics;
         }
 
+        Object minimumNumberOfMetrics = this.yaml.get("min_number_of_metrics");
+        if (minimumNumberOfMetrics != null) {
+            this.minimumNumberOfMetrics = (Integer) minimumNumberOfMetrics;
+        }
+        
         // Generate an instance name that will be send as a tag with the metrics
         if (this.instanceName == null) {
             if (this.yaml.get(PROCESS_NAME_REGEX) != null) {

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -52,7 +52,7 @@ public class Instance {
     private Connection connection;
     private AppConfig appConfig;
     private Boolean cassandraAliasing;
-    private Integer minimumNumberOfMetrics = 0;
+    private Integer minReturnedMetrics = 0;
     private Boolean refreshNextRun = false;
 
 
@@ -100,9 +100,9 @@ public class Instance {
             this.maxReturnedMetrics = (Integer) maxReturnedMetrics;
         }
 
-        Object minimumNumberOfMetrics = this.yaml.get("min_number_of_metrics");
-        if (minimumNumberOfMetrics != null) {
-            this.minimumNumberOfMetrics = (Integer) minimumNumberOfMetrics;
+        Object minReturnedMetrics = this.yaml.get("min_returned_metrics");
+        if (minReturnedMetrics != null) {
+            this.minReturnedMetrics = (Integer) minReturnedMetrics;
         }
         
         // Generate an instance name that will be send as a tag with the metrics
@@ -236,7 +236,7 @@ public class Instance {
                 }
             }
         }
-        if (this.minimumNumberOfMetrics < metrics.size()) {
+        if (this.minReturnedMetrics < metrics.size()) {
         		this.refreshNextRun = true;
         }
         return metrics;

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -237,7 +237,7 @@ public class Instance {
             }
         }
         if (this.minReturnedMetrics < metrics.size()) {
-        	    this.refreshNextRun = true;
+        	  this.refreshNextRun = true;
         }
         return metrics;
     }


### PR DESCRIPTION
If JMXfetch is unable to collect a minimum number of metrics from an app, it will refresh the beans at the beginning of the next run, rather than relying upon the number that it has cached. 

This is in response to a number of people who have found that it is annoying to have to bump the refresh period just to handle issues when the app being monitored is restarting.