### PR TITLE
[rate] add canonical_rate + feature flag for the feature

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -345,7 +345,7 @@ public class App {
                 }
 
                 if(numberOfMetrics > 0)
-                    reporter.sendMetrics(metrics, instance.getName());
+                    reporter.sendMetrics(metrics, instance.getName(), instance.getCanonicalRateConfig());
 
             } catch (IOException e) {
                 instanceMessage = "Unable to refresh bean list for instance " + instance;

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -156,6 +156,23 @@ public class Instance {
         }
     }
 
+    public boolean getCanonicalRateConfig() {
+        Object canonical = null;
+        if (this.initConfig != null) {
+            canonical = this.initConfig.get("canonical_rate");
+        }
+
+        if (canonical == null) {
+            return false;
+        }
+
+        if (canonical instanceof Boolean) {
+            return ((Boolean)canonical).booleanValue();
+        }
+
+        return false;
+    }
+
     public Connection getConnection(LinkedHashMap<String, Object> connectionParams, boolean forceNewConnection) throws IOException {
         if (connection == null || !connection.isAlive()) {
             LOGGER.info("Connection closed or does not exist. Creating a new connection!");

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -35,7 +35,7 @@ public abstract class Reporter {
         ratesAggregator.put(instanceName, new HashMap<String, HashMap<String, Object>>());
     }
 
-    public void sendMetrics(LinkedList<HashMap<String, Object>> metrics, String instanceName) {
+    public void sendMetrics(LinkedList<HashMap<String, Object>> metrics, String instanceName, boolean canonicalRate) {
         HashMap<String, HashMap<String, Object>> instanceRatesAggregator;
         if (ratesAggregator.containsKey(instanceName)) {
             instanceRatesAggregator = ratesAggregator.get(instanceName);
@@ -88,7 +88,10 @@ public abstract class Reporter {
                 long now = System.currentTimeMillis();
                 double rate = 1000 * (currentValue - oldValue) / (now - oldTs);
 
-                if (!Double.isNaN(rate) && !Double.isInfinite(rate) && rate >= 0) {
+                boolean submit = (!Double.isNaN(rate) && !Double.isInfinite(rate));
+                submit &= (rate >= 0 | !canonicalRate);
+
+                if  (submit) {
                     sendMetricPoint(metricType, metricName, rate, tags);
                 }
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -88,7 +88,7 @@ public abstract class Reporter {
                 long now = System.currentTimeMillis();
                 double rate = 1000 * (currentValue - oldValue) / (now - oldTs);
 
-                if (!Double.isNaN(rate) && !Double.isInfinite(rate)) {
+                if (!Double.isNaN(rate) && !Double.isInfinite(rate) && rate >= 0) {
                     sendMetricPoint(metricType, metricName, rate, tags);
                 }
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -88,11 +88,13 @@ public abstract class Reporter {
                 long now = System.currentTimeMillis();
                 double rate = 1000 * (currentValue - oldValue) / (now - oldTs);
 
-                boolean submit = (!Double.isNaN(rate) && !Double.isInfinite(rate));
-                submit &= (rate >= 0 | !canonicalRate);
+                boolean sane = (!Double.isNaN(rate) && !Double.isInfinite(rate));
+                boolean submit = (rate >= 0 || !canonicalRate);
 
-                if  (submit) {
+                if  (sane && submit) {
                     sendMetricPoint(metricType, metricName, rate, tags);
+                } else if (sane) {
+                    LOGGER.info("Canonical rate option set, and negative rate (counter reset) - not submitting.");
                 }
 
                 instanceRatesAggregator.get(key).put("ts", now);

--- a/src/test/java/org/datadog/jmxfetch/SimpleTestJavaApp.java
+++ b/src/test/java/org/datadog/jmxfetch/SimpleTestJavaApp.java
@@ -81,6 +81,10 @@ public class SimpleTestJavaApp implements SimpleTestJavaAppMBean {
         shouldBeCounter += inc;
     }
 
+    public void decrementCounter(int dec) {
+        shouldBeCounter -= dec;
+    }
+
     public void incrementHashMapCounter(int inc) {
         hashmap.put("thisiscounter", hashmap.get("thisiscounter") + inc);
     }

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -561,7 +561,87 @@ public class TestApp extends TestCommon {
         assertMetric("subattr.counter", 0.95, 1, commonTags, 5);
         assertMetric("test.counter", 0.95, 1, commonTags, 5);
 
-        // Drop counter values when they are lower than previous values
+        assertCoverage();
+    }
+
+    /**
+     * Test Canonical Rates.
+     *
+     */
+    @Test
+    public void testAppCanonicalRate() throws Exception {
+        // We expose a few metrics through JMX
+        SimpleTestJavaApp testApp = new SimpleTestJavaApp();
+        registerMBean( testApp, "org.datadog.jmxfetch.test:type=SimpleTestJavaApp");
+
+        // We do a first collection
+        initApplication("jmx_canonical.yaml");
+
+        run();
+        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+
+        // 28 = 13 metrics from java.lang + the 5 gauges we are explicitly collecting + 9 gauges implicitly collected
+        // + 1 multi-value, see jmx.yaml in the test/resources folder
+        assertEquals(28, metrics.size());
+
+
+        // We test for the presence and the value of the metrics we want to collect
+        List<String> commonTags = Arrays.asList(
+            "instance:jmx_test_instance",
+            "env:stage",
+            "newTag:test");
+
+        assertMetric("this.is.100", 100.0, commonTags, Arrays.asList("foo","gorch","bar:baz") , 8);
+        assertMetric("jmx.org.datadog.jmxfetch.test.number_big", 1.2345678890123457E20, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.long42424242",4.2424242E7, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.int424242", 424242.0, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.should_be1000", 1000.0, commonTags, 5);
+        assertMetric("test.converted", 5.0, commonTags, 5);
+        assertMetric("test.boolean", 1.0, commonTags, 5);
+        assertMetric("test.defaulted", 32.0, commonTags, 5);
+        assertMetric("subattr.this.is.0", 0.0, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.atomic42", 42.0, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.atomic4242", 4242.0, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.object1337", 13.37, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.primitive_float", 123.4f, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.instance_float", 567.8f, commonTags, 5);
+        assertMetric("multiattr.foo", 1.0, commonTags, Arrays.asList("foo:1", "toto:tata"), 7);
+
+        assertCoverage();
+
+        // We run a second collection. The counter should now be present
+        run();
+        metrics = getMetrics();
+        // 30 = 13 metrics from java.lang + the 5 gauges we are explicitly collecting + 9 gauges implicitly collected
+        // + 1 multi-value + 2 counter, see jmx.yaml in the test/resources folder
+        assertEquals(30, metrics.size());
+
+
+        // We test for the same metrics but this time, the counter should be here
+        // Previous metrics
+        assertMetric("this.is.100", 100.0, commonTags, 8);
+        assertMetric("jmx.org.datadog.jmxfetch.test.number_big", 1.2345678890123457E20, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.long42424242",4.2424242E7, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.int424242", 424242.0, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.should_be1000", 1000.0, commonTags, 5);
+        assertMetric("test.converted", 5.0, commonTags, 5);
+        assertMetric("test.boolean", 1.0, commonTags, 5);
+        assertMetric("test.defaulted", 32.0, commonTags, 5);
+        assertMetric("subattr.this.is.0", 0.0, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.atomic42", 42.0, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.atomic4242", 4242.0, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.object1337", 13.37, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.primitive_float", 123.4f, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.instance_float", 567.8f, commonTags, 5);
+        assertMetric("multiattr.foo", 1.0, commonTags, Arrays.asList("foo:1", "toto:tata"), 7);
+
+        // Counters
+        assertMetric("subattr.counter", 0.0, commonTags, 5);
+        assertMetric("test.counter", 0.0, commonTags, 5);
+        assertCoverage();
+
+        // We run a 3rd collection but this time we decrement the counter
+        Thread.sleep(5000);
         testApp.decrementCounter(5);
 
         run();
@@ -578,6 +658,7 @@ public class TestApp extends TestCommon {
         Thread.sleep(5000);
         testApp.incrementCounter(5);
         testApp.incrementHashMapCounter(5);
+        testApp.populateTabularData(2);
 
         run();
         metrics = getMetrics();
@@ -605,6 +686,7 @@ public class TestApp extends TestCommon {
         assertMetric("test.counter", 0.95, 1, commonTags, 5);
         assertCoverage();
     }
+
     /**
      * Test JMX Service Discovery.
      *

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -560,6 +560,49 @@ public class TestApp extends TestCommon {
         // Counter (verify rate metrics within range)
         assertMetric("subattr.counter", 0.95, 1, commonTags, 5);
         assertMetric("test.counter", 0.95, 1, commonTags, 5);
+
+        // Drop counter values when they are lower than previous values
+        testApp.decrementCounter(5);
+
+        run();
+        metrics = getMetrics();
+        assertEquals(29, metrics.size());
+
+        // The metric should be back in the next cycle.
+        run();
+        metrics = getMetrics();
+        assertEquals(30, metrics.size());
+        assertMetric("test.counter", 0.0, commonTags, 5);
+
+        // Check that they are working again
+        Thread.sleep(5000);
+        testApp.incrementCounter(5);
+        testApp.incrementHashMapCounter(5);
+
+        run();
+        metrics = getMetrics();
+        assertEquals(30, metrics.size());
+
+        // Previous metrics
+        assertMetric("this.is.100", 100.0, commonTags, 8);
+        assertMetric("jmx.org.datadog.jmxfetch.test.number_big", 1.2345678890123457E20, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.long42424242",4.2424242E7, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.int424242", 424242.0, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.should_be1000", 1000.0, commonTags, 5);
+        assertMetric("test.converted", 5.0, commonTags, 5);
+        assertMetric("test.boolean", 1.0, commonTags, 5);
+        assertMetric("test.defaulted", 32.0, commonTags, 5);
+        assertMetric("subattr.this.is.0", 0.0, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.atomic42", 42.0, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.atomic4242", 4242.0, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.object1337", 13.37, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.primitive_float", 123.4f, commonTags, 5);
+        assertMetric("jmx.org.datadog.jmxfetch.test.instance_float", 567.8f, commonTags, 5);
+        assertMetric("multiattr.foo", 2.0, commonTags, Arrays.asList("foo:2", "toto:tata"), 7);
+
+        // Counter (verify rate metrics within range)
+        assertMetric("subattr.counter", 0.95, 1, commonTags, 5);
+        assertMetric("test.counter", 0.95, 1, commonTags, 5);
         assertCoverage();
     }
     /**

--- a/src/test/resources/jmx_canonical.yaml
+++ b/src/test/resources/jmx_canonical.yaml
@@ -1,0 +1,54 @@
+init_config:
+    canonical_rate: true
+
+instances:
+    -   process_name_regex: .*surefire.*
+        refresh_beans: 4
+        name: jmx_test_instance
+        tags:
+            - "env:stage"
+            - "newTag:test"
+        conf:
+            - include:
+               domain: org.datadog.jmxfetch.test
+               attribute:
+                    ShouldBe100:
+                        metric_type: gauge
+                        alias: this.is.100
+                        tags:
+                            - "foo"
+                            - "bar:baz"
+                            - gorch
+                    ShouldBeCounter:
+                        metric_type: counter
+                        alias: test.counter
+                    ShouldBeBoolean:
+                        metric_type: gauge
+                        alias: test.boolean
+                    Hashmap.thisis0:
+                        metric_type: gauge
+                        alias: subattr.this.is.0
+                    Hashmap.thisiscounter:
+                        metric_type: counter
+                        alias: subattr.counter
+                    ShouldBeConverted:
+                        metric_type: gauge
+                        alias: test.converted
+                        values:
+                          ShouldBe0: 0
+                          ShouldBe5: 5
+                    ShouldBeDefaulted:
+                        metric_type: gauge
+                        alias: test.defaulted
+                        values:
+                          default: 32
+                    Tabulardata.foo:
+                        metric_type: gauge
+                        alias: multiattr.foo
+                        tags:
+                          foo: $foo
+                          toto: $toto
+                        limit: 1
+                        sort: desc
+            - include:
+               domain: org.datadog.jmxfetch.test


### PR DESCRIPTION
This PR adds a feature flag to enable canonical rate behavior for counters/rates such that a negative rate would not be reported. A legit negative rate would typically represent a metric that _should_ be reported as a `gauge`. Because the former inconsistent behavior has been present in jmxfetch for a while, and to avoid breaking alerts and dashboards, we will put this behind a feature flag for now.

Based off #146  