### PR TITLE
[agent6] add support for submission of JMX statuses to agent6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: precise
+
 language: java
 jdk:
 - oraclejdk8

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 		<jcommander.version>1.35</jcommander.version>
 		<junit.version>4.11</junit.version>
 		<log4j.version>1.2.17</log4j.version>
+        <gson.version>1.4</gson.version>
         <mockito.version>2.2.27</mockito.version>
 		<maven-surefire-plugin.version>2.9</maven-surefire-plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -65,6 +66,11 @@
 			<artifactId>java-dogstatsd-client</artifactId>
 			<version>${java-dogstatsd-client.version}</version>
 		</dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
 		<dependency>
 			<groupId>log4j</groupId>
 			<artifactId>log4j</artifactId>

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -306,7 +306,7 @@ public class App {
                 doIteration();
             } else {
                 LOGGER.warn("No instance could be initiated. Retrying initialization.");
-                appConfig.getStatus().flush();
+                appConfig.getStatus().flush(appConfig.getIPCPort());
                 configs = getConfigs(appConfig);
                 init(true);
             }
@@ -425,7 +425,7 @@ public class App {
         }
 
         try {
-            appConfig.getStatus().flush();
+            appConfig.getStatus().flush(appConfig.getIPCPort());
         } catch (Exception e) {
             LOGGER.error("Unable to flush stats.", e);
         }

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -106,6 +106,12 @@ class AppConfig {
             required = true)
     private List<String> action = null;
 
+    @Parameter(names = {"--ipc_port", "-I"},
+            description = "IPC port",
+            validateWith = PositiveIntegerValidator.class,
+            required = false)
+    private int ipcPort = 0;
+
     public String getAction() {
         return this.action.get(0);
     }
@@ -128,6 +134,10 @@ class AppConfig {
 
     public int getCheckPeriod() {
         return checkPeriod;
+    }
+
+    public int getIPCPort() {
+        return ipcPort;
     }
 
     public boolean getAutoDiscoveryEnabled() {

--- a/src/main/java/org/datadog/jmxfetch/Status.java
+++ b/src/main/java/org/datadog/jmxfetch/Status.java
@@ -140,9 +140,8 @@ public class Status {
 
             //add reuqest header
             con.setRequestMethod("POST");
-            //con.setRequestProperty("User-Agent", USER_AGENT);
             con.setRequestProperty("Content-Type", "application/json");
-            con.setRequestProperty("Session-Token", this.token);
+            con.setRequestProperty("Authorization", "Bearer "+ this.token);
 
             con.setDoOutput(true);
             DataOutputStream wr = new DataOutputStream(con.getOutputStream());

--- a/src/main/java/org/datadog/jmxfetch/Status.java
+++ b/src/main/java/org/datadog/jmxfetch/Status.java
@@ -3,10 +3,21 @@ package org.datadog.jmxfetch;
 import java.io.File;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.lang.System;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import javax.net.ssl.HttpsURLConnection;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.log4j.Logger;
 import org.yaml.snakeyaml.Yaml;
+import com.google.gson.Gson;
 
 public class Status {
 
@@ -17,8 +28,11 @@ public class Status {
     private final static String INITIALIZED_CHECKS = "initialized_checks";
     private final static String FAILED_CHECKS = "failed_checks";
     private HashMap<String, Object> instanceStats;
+    private TrustManager[] dummyTrustManager;
+    private SSLContext sc;
     private String statusFileLocation;
     private boolean isEnabled;
+    private String token;
 
     public Status() {
         this(null);
@@ -30,8 +44,29 @@ public class Status {
 
     void configure(String statusFileLocation) {
         this.statusFileLocation = statusFileLocation;
-        this.isEnabled = this.statusFileLocation != null;
         this.instanceStats = new HashMap<String, Object>();
+        try {
+            this.token = System.getenv("SESSION_TOKEN");
+            dummyTrustManager = new TrustManager[] {
+                new X509TrustManager() {
+                    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                        return null;
+                    }
+                    public void checkClientTrusted(java.security.cert.X509Certificate[] certs, String authType) {
+                    }
+
+                    public void checkServerTrusted(java.security.cert.X509Certificate[] certs, String authType) {
+                    }
+                }
+            };
+            sc = SSLContext.getInstance("SSL");
+            sc.init(null, this.dummyTrustManager, new java.security.SecureRandom());
+            HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+        } catch (Exception e) {
+            LOGGER.debug("session token unavailable - not setting");
+            this.token = "";
+        }
+        this.isEnabled = (this.statusFileLocation != null || this.token != "");
         this.clearStats();
     }
 
@@ -87,15 +122,62 @@ public class Status {
         return yaml.dump(status);
     }
 
-    public void flush() {
+    private String generateJson() {
+        Gson gson = new Gson();
+        HashMap<String, Object> status = new HashMap<String, Object>();
+        status.put("timestamp", System.currentTimeMillis());
+        status.put("checks", this.instanceStats);
+        return gson.toJson(status);
+    }
+
+    private boolean postRequest(String body, int port) {
+        int responseCode = 0;
+        try {
+            String url = "https://localhost:" + port + "/agent/jmxstatus";
+
+            URL uri = new URL(url);
+            HttpsURLConnection con = (HttpsURLConnection) uri.openConnection();
+
+            //add reuqest header
+            con.setRequestMethod("POST");
+            //con.setRequestProperty("User-Agent", USER_AGENT);
+            con.setRequestProperty("Content-Type", "application/json");
+            con.setRequestProperty("Session-Token", this.token);
+
+            con.setDoOutput(true);
+            DataOutputStream wr = new DataOutputStream(con.getOutputStream());
+            wr.writeBytes(body);
+            wr.flush();
+            wr.close();
+
+            responseCode = con.getResponseCode();
+
+        } catch (Exception e) {
+            LOGGER.info("problem creating http request: " + e.toString());
+        }
+        return (responseCode >= 200 && responseCode < 300);
+    }
+
+    public void flush(int port) {
         if (isEnabled()) {
-            String yaml = generateYaml();
-            try {
-                File f = new File(this.statusFileLocation);
-                LOGGER.debug("Writing status to temp yaml file: " + f.getAbsolutePath());
-                FileUtils.writeStringToFile(f, yaml);
-            } catch (Exception e) {
-                LOGGER.warn("Cannot write status to temp file: " + e.getMessage());
+            if (port > 0) {
+                String json = generateJson();
+                try {
+                    if (!this.postRequest(json, port)) {
+                        LOGGER.debug("Problem submitting JSON status: " + json);
+                    }
+                } catch (Exception e) {
+                    LOGGER.warn("Could not post status: " + e.getMessage());
+                }
+            } else {
+                String yaml = generateYaml();
+                try {
+                    File f = new File(this.statusFileLocation);
+                    LOGGER.debug("Writing status to temp yaml file: " + f.getAbsolutePath());
+                    FileUtils.writeStringToFile(f, yaml);
+                } catch (Exception e) {
+                    LOGGER.warn("Cannot write status to temp file: " + e.getMessage());
+                }
             }
         }
         this.clearStats();


### PR DESCRIPTION
Submits JMX status to Agent6. Implements backward compatibility with agent5.

## Note
We currently use self-signed certificates on agent6, so we're actually skipping certificate verification on the client. This will be removed once we get that covered.  