### PR TITLE
Make --conf_directory arg not required

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -50,7 +50,7 @@ class AppConfig {
 
     @Parameter(names = {"--conf_directory", "-D"},
             description = "Absolute path to the conf.d directory",
-            required = true)
+            required = false)
     private String confdDirectory;
 
     @Parameter(names = {"--tmp_directory", "-T"},


### PR DESCRIPTION
The `confdDirectory` field is only used in `getConfigs` in order to fetch YAML files by name (specifically, it only gets used if `config.getYamlFileList()` is not null, and this only occurs if YAML files were passed via a named pipe): https://github.com/DataDog/jmxfetch/blob/c36514e8e5b26c433884d1b985091c8ad05d07a6/src/main/java/org/datadog/jmxfetch/App.java#L501

Thanks to https://github.com/DataDog/jmxfetch/pull/156, the collection of configurations via named pipes has been deprecated, so we shouldn't force this option to be used.