### PR TITLE
Adds support for bean regex tagging

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Filter.java
+++ b/src/main/java/org/datadog/jmxfetch/Filter.java
@@ -124,7 +124,6 @@ class Filter {
 
     public HashMap<String, String> getAdditionalTags() {
         // Return additional tags
-
         if (this.additionalTags == null) {
             if (filter.get("tags") == null){
                 this.additionalTags = new HashMap<String, String>();

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -100,8 +100,8 @@ public abstract class JMXAttribute {
         if (include != null) {
             for (Map.Entry<String, String> tag : include.getAdditionalTags().entrySet()) {
             		String alias = this.replaceByAlias(tag.getValue());
-            		if (alias != "" || alias != null) {
-            			this.defaultTagsList.add(tag.getKey() + ":" + this.replaceByAlias(tag.getValue()));
+            		if ((alias.trim().length() > 0) && alias != null) {
+            			this.defaultTagsList.add(tag.getKey() + ":" + alias);
             		} else {
                     LOGGER.warn("Unable to apply tag " + tag.getKey() + " - with unknown alias");
             		}
@@ -305,7 +305,7 @@ public abstract class JMXAttribute {
 
             if(m.matches()) {
             	for (int i = 0; i<= m.groupCount(); i++) { 
-            		this.beanParameters.put(""+i, m.group(i));
+            		this.beanParameters.put(Integer.toString(i), m.group(i));
                 }
                 return true;
             }

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -99,7 +99,12 @@ public abstract class JMXAttribute {
         Filter include = this.matchingConf.getInclude();
         if (include != null) {
             for (Map.Entry<String, String> tag : include.getAdditionalTags().entrySet()) {
-                this.defaultTagsList.add(tag.getKey() + ":" + this.replaceByAlias(tag.getValue()));
+            		String alias = this.replaceByAlias(tag.getValue());
+            		if (alias != "" || alias != null) {
+            			this.defaultTagsList.add(tag.getKey() + ":" + this.replaceByAlias(tag.getValue()));
+            		} else {
+                    LOGGER.warn("Unable to apply tag " + tag.getKey() + " - with unknown alias");
+            		}
             }
         }
     }

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -103,12 +103,11 @@ public abstract class JMXAttribute {
             		if ((alias.trim().length() > 0) && alias != null) {
             			this.defaultTagsList.add(tag.getKey() + ":" + alias);
             		} else {
-                    LOGGER.warn("Unable to apply tag " + tag.getKey() + " - with unknown alias");
+            			LOGGER.warn("Unable to apply tag " + tag.getKey() + " - with unknown alias");
             		}
             }
         }
     }
-   
 
     public static HashMap<String, String> getBeanParametersHash(String beanParametersString) {
         String[] beanParameters = beanParametersString.split(",");

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -299,8 +299,8 @@ public abstract class JMXAttribute {
             Matcher m = beanRegex.matcher(beanStringName);
 
             if(m.matches()) {
-            		for (int i = 0; i<= m.groupCount(); i++) { 
-            			this.beanParameters.put(""+i, m.group(i));
+            	for (int i = 0; i<= m.groupCount(); i++) { 
+            		this.beanParameters.put(""+i, m.group(i));
                 }
                 return true;
             }

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -103,6 +103,7 @@ public abstract class JMXAttribute {
             }
         }
     }
+   
 
     public static HashMap<String, String> getBeanParametersHash(String beanParametersString) {
         String[] beanParameters = beanParametersString.split(",");
@@ -295,7 +296,12 @@ public abstract class JMXAttribute {
         }
 
         for (Pattern beanRegex : beanRegexes) {
-            if(beanRegex.matcher(beanStringName).matches()) {
+            Matcher m = beanRegex.matcher(beanStringName);
+
+            if(m.matches()) {
+            		for (int i = 0; i<= m.groupCount(); i++) { 
+            			this.beanParameters.put(""+i, m.group(i));
+                }
                 return true;
             }
         }


### PR DESCRIPTION
Adds support for using the bean_regex syntax to capture groups for tags. 

We currently support pulling in common attributes out of bean names, but this introduces the ability to specify any custom substring of a bean name to utilize as a tag on the associated attributes. 

Ex:

```
init_config:
  conf:
    - include:
	bean_regex: 'Catalina:type=(.*?),*host=(.*?),context=(.*),*'
        attribute:
          spareNotFoundEntries:
            metric_type: gauge
            alias: tomcat.spareNotFound
          cacheMaxSize:
            metric_type: gauge
            alias: tomcat.cacheMax
        tags:
             TypeRegex: $1
             HostRegex: $2
             contextRegex: $3
             optional: tag
```

This will submit the metric `tomcat.spareNotFound` with tags `hostRegex:<beanParameter>` ,`TypeRegex:<beanParameter>`, and `contextRegex<beanParameter>` as well as the tag with key `optional` and value `tag`

If group 3 in this example didn't exist, this logs a warning and doesn't apply the `contextRegex` tag to the metric.