### PR TITLE
Add read timeout for how long we query beans

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -61,7 +61,7 @@ public class RemoteConnection extends Connection {
         }
         
         //Set an RMI timeout so we don't get stuck waiting for a bean to report a value
-        System.setProperty("sun.rmi.transport.tcp.responseTimeout", DEFAULT_RMI_RESPONSE_TIMEOUT);
+        System.setProperty("sun.rmi.transport.tcp.responseTimeout", rmi_timeout);
         
         createConnection();
 

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -21,7 +21,7 @@ public class RemoteConnection extends Connection {
     private String rmi_timeout;
     private static final String TRUST_STORE_PATH_KEY = "trust_store_path";
     private static final String TRUST_STORE_PASSWORD_KEY = "trust_store_password";
-    private static final String DEFAULT_RMI_RESPONSE_TIMEOUT = "600000"; //Match the refresh_beans default
+    private static final String DEFAULT_RMI_RESPONSE_TIMEOUT = "15000"; //Match the collection period default
     private final static Logger LOGGER = Logger.getLogger(Connection.class.getName());
 
     public RemoteConnection(LinkedHashMap<String, Object> connectionParams)
@@ -35,10 +35,10 @@ public class RemoteConnection extends Connection {
         user = (String) connectionParams.get("user");
         password = (String) connectionParams.get("password");
         jmx_url = (String) connectionParams.get("jmx_url");
-        	rmi_timeout = (String) connectionParams.get("refresh_beans");
-        	if (rmi_timeout == null) {
-        		rmi_timeout = DEFAULT_RMI_RESPONSE_TIMEOUT;
-        	}
+        rmi_timeout = (String) connectionParams.get("rmi_client_timeout");
+        if (rmi_timeout == null) {
+            rmi_timeout = DEFAULT_RMI_RESPONSE_TIMEOUT;
+        }
         if (connectionParams.containsKey("path")){
             path = (String) connectionParams.get("path");
         }

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -20,6 +20,7 @@ public class RemoteConnection extends Connection {
     private String jmx_url;
     private static final String TRUST_STORE_PATH_KEY = "trust_store_path";
     private static final String TRUST_STORE_PASSWORD_KEY = "trust_store_password";
+    private static final String DEFAULT_RMI_RESPONSE_TIMEOUT = "5000";
     private final static Logger LOGGER = Logger.getLogger(Connection.class.getName());
 
     public RemoteConnection(LinkedHashMap<String, Object> connectionParams)
@@ -53,6 +54,10 @@ public class RemoteConnection extends Connection {
             }
 
         }
+        
+        //Set an RMI timeout so we don't get stuck waiting for a bean to report a value
+        System.setProperty("sun.rmi.transport.tcp.responseTimeout", DEFAULT_RMI_RESPONSE_TIMEOUT);
+        
         createConnection();
 
     }

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -21,7 +21,7 @@ public class RemoteConnection extends Connection {
     private String rmi_timeout;
     private static final String TRUST_STORE_PATH_KEY = "trust_store_path";
     private static final String TRUST_STORE_PASSWORD_KEY = "trust_store_password";
-    private static final String DEFAULT_RMI_RESPONSE_TIMEOUT = "15000";
+    private static final String DEFAULT_RMI_RESPONSE_TIMEOUT = "600000"; //Match the refresh_beans default
     private final static Logger LOGGER = Logger.getLogger(Connection.class.getName());
 
     public RemoteConnection(LinkedHashMap<String, Object> connectionParams)

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -18,9 +18,10 @@ public class RemoteConnection extends Connection {
     private String password;
     private String path = "jmxrmi";
     private String jmx_url;
+    private String rmi_timeout;
     private static final String TRUST_STORE_PATH_KEY = "trust_store_path";
     private static final String TRUST_STORE_PASSWORD_KEY = "trust_store_password";
-    private static final String DEFAULT_RMI_RESPONSE_TIMEOUT = "5000";
+    private static final String DEFAULT_RMI_RESPONSE_TIMEOUT = "15000";
     private final static Logger LOGGER = Logger.getLogger(Connection.class.getName());
 
     public RemoteConnection(LinkedHashMap<String, Object> connectionParams)
@@ -34,6 +35,10 @@ public class RemoteConnection extends Connection {
         user = (String) connectionParams.get("user");
         password = (String) connectionParams.get("password");
         jmx_url = (String) connectionParams.get("jmx_url");
+        	rmi_timeout = (String) connectionParams.get("refresh_beans");
+        	if (rmi_timeout == null) {
+        		rmi_timeout = DEFAULT_RMI_RESPONSE_TIMEOUT;
+        	}
         if (connectionParams.containsKey("path")){
             path = (String) connectionParams.get("path");
         }


### PR DESCRIPTION
Adds in the [`sun.rmi.transport.tcp.responseTimeout`](https://docs.oracle.com/javase/6/docs/technotes/guides/rmi/sunrmiproperties.html) system property before starting the RMI connection. 

Customer experienced a blocking bean that caused JMXFetch to hang indefinitely (order of magnitude hours) This should help reduce cases like that and allow JMXFetch to continue grabbing the remaining metrics. 