### PR TITLE
Accept RMI timeout as integer in addition to just string

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -37,15 +37,14 @@ public class RemoteConnection extends Connection {
             rmi_timeout = (String) connectionParams.get("rmi_client_timeout");
         } catch(ClassCastException e) {
             rmi_timeout = Integer.toString((Integer) connectionParams.get("rmi_client_timeout"));
+        } catch(NullPointerException e) {
+        		rmi_timeout = DEFAULT_RMI_RESPONSE_TIMEOUT;
         }
 
         user = (String) connectionParams.get("user");
         password = (String) connectionParams.get("password");
         jmx_url = (String) connectionParams.get("jmx_url");
-        rmi_timeout = (String) connectionParams.get("rmi_client_timeout");
-        if (rmi_timeout == null) {
-            rmi_timeout = DEFAULT_RMI_RESPONSE_TIMEOUT;
-        }
+
         if (connectionParams.containsKey("path")){
             path = (String) connectionParams.get("path");
         }

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -32,6 +32,13 @@ public class RemoteConnection extends Connection {
         } catch(ClassCastException e) {
             port = Integer.parseInt((String) connectionParams.get("port"));
         }
+
+        try{
+            rmi_timeout = (String) connectionParams.get("rmi_client_timeout");
+        } catch(ClassCastException e) {
+            rmi_timeout = Integer.toString((Integer) connectionParams.get("rmi_client_timeout"));
+        }
+
         user = (String) connectionParams.get("user");
         password = (String) connectionParams.get("password");
         jmx_url = (String) connectionParams.get("jmx_url");

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -36,9 +36,11 @@ public class RemoteConnection extends Connection {
         try{
             rmi_timeout = (String) connectionParams.get("rmi_client_timeout");
         } catch(ClassCastException e) {
-            rmi_timeout = Integer.toString((Integer) connectionParams.get("rmi_client_timeout"));
-        } catch(NullPointerException e) {
-        		rmi_timeout = DEFAULT_RMI_RESPONSE_TIMEOUT;
+            rmi_timeout = Integer.toString((Integer) connectionParams.get("rmi_client_timeout"));    
+        } 
+        
+        if (rmi_timeout == null) {
+            rmi_timeout = DEFAULT_RMI_RESPONSE_TIMEOUT;
         }
 
         user = (String) connectionParams.get("user");


### PR DESCRIPTION
Allow user to specify RMI timeout as an int in the yaml and we will convert to string if necessary.