### PR TITLE
Allow the troubleshooting commands to use the IPC endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changes
 =======
 
+# 0.20.0 / Unreleased
+
+### Changes
+
+* [FEATURE] Configs can now be given to jmxfetch using the https endpoint when running list_* troubleshooting commands. See [#171][].
+
 # 0.19.0 / 03/19/2018
 
 ### Changes

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -136,6 +136,11 @@ public class App {
 
         App app = new App(config);
 
+        // Get config from the ipc endpoint for "list_*" actions
+        if (!config.getAction().equals(AppConfig.ACTION_COLLECT)) {
+            app.getJSONConfigs();
+        }
+
         // Initiate JMX Connections, get attributes that match the yaml configuration
         app.init(false);
 
@@ -623,8 +628,6 @@ public class App {
     public void init(boolean forceNewConnection) {
         clearInstances(instances);
         clearInstances(brokenInstances);
-
-        Reporter reporter = appConfig.getReporter();
 
         Iterator<Entry<String, YamlParser>> it = configs.entrySet().iterator();
         Iterator<Entry<String, YamlParser>> itSD = adPipeConfigs.entrySet().iterator();

--- a/src/main/java/org/datadog/jmxfetch/HttpClient.java
+++ b/src/main/java/org/datadog/jmxfetch/HttpClient.java
@@ -107,7 +107,7 @@ public class HttpClient {
             con.setRequestMethod(method.toUpperCase());
             con.setRequestProperty("Authorization", "Bearer "+ this.token);
             con.setRequestProperty("User-Agent", USER_AGENT);
-            if (method.toUpperCase() == "GET") {
+            if (method.toUpperCase().equals("GET")) {
                 con.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
             } else {
                 con.setRequestProperty("Content-Type", "application/json");


### PR DESCRIPTION
 This PR makes it possible to give configs to `list_*` commands using the HTTPS IPC endpoint.