### PR TITLE
Adds test for bean regex tag feature

### DIFF
--- a/src/test/resources/jmx_bean_regex_tags.yaml
+++ b/src/test/resources/jmx_bean_regex_tags.yaml
@@ -1,0 +1,16 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        conf:
+            - include:
+                 bean_regex: org.datadog.jmxfetch.test:type=SimpleTestJavaApp,scope=Co\|olScope,host=(.*),component=.*
+                 attribute:
+                     ShouldBe100:
+                         metric_type: gauge
+                         alias: this.is.100
+                 tags:
+                     hosttag: $1
+                     nonExistantTag: $2
+                     nonRegexTag: value


### PR DESCRIPTION
Adds a unit test for the JMX Bean Regex tagging feature where users can now specify regex based tags when using `bean_regex`. Supplements - https://github.com/DataDog/jmxfetch/pull/167

Additional Notes:
Cleans up some unused imports