### PR TITLE
fix jmx service checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,8 @@ jdk:
 - oraclejdk7
 - openjdk7
 
+install: mvn install -Dhttps.protocols=TLSv1.2 -DskipTests=true -Dmaven.javadoc.skip=true -B -V
+script: mvn test -B -Dhttps.protocols=TLSv1.2
+
 addons:
   hostname: dd-jmxfetch-testhost

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -669,8 +669,9 @@ public class App {
                 HashMap<String, Object> checkConfig = (HashMap<String, Object>) adJSONConfigs.get(check);
                 LinkedHashMap<String, Object> initConfig = (LinkedHashMap<String, Object>) checkConfig.get("init_config");
                 ArrayList<LinkedHashMap<String, Object>> configInstances = (ArrayList<LinkedHashMap<String, Object>>) checkConfig.get("instances");
+                String checkName =  (String) checkConfig.get("check_name");
                 for (LinkedHashMap<String, Object> configInstance : configInstances) {
-                    instantiate(configInstance, initConfig, check, appConfig, forceNewConnection);
+                    instantiate(configInstance, initConfig, checkName, appConfig, forceNewConnection);
                 }
             }
         }


### PR DESCRIPTION
## What does this PR do

JMXfetch used the name of the configuration instead of the check name in the configuration to send service checks. 
The recent refactor on datadog-agent that allowed having multiple configs for jmx by giving name different name exposed the issue and broke service checks for jmx. This fixes it.