### PR TITLE
circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - attach_workspace:
           at: .
 
-      - run: mvn validate jar:jar source:jar deploy:deploy --settings ./settings.xml
+      - run: mvn validate jar:jar source:jar assembly:single deploy:deploy -e --settings ./settings.xml
         
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,79 @@
+# Java Maven CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-java/ for more details
+#
+version: 2
+
+defaults: &defaults
+  docker:
+    - image: circleci/openjdk:8-jdk
+
+  working_directory: ~/jmxfetch
+
+  environment:
+    MAVEN_OPTS: -Xmx3200m
+
+cache_keys: &cache_keys
+  # Reset the cache approx every release
+  keys:
+    - jmxfetch-{{ checksum "pom.xml" }}-{{ .Branch }}-{{ .Revision }}
+    - jmxfetch-{{ checksum "pom.xml" }}-{{ .Branch }}
+    - jmxfetch-{{ checksum "pom.xml" }}
+
+jobs:
+  build:
+    <<: *defaults
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          <<: *cache_keys
+
+      - run: mvn install
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: jmxfetch-{{ checksum "pom.xml" }}-{{ .Branch }}-{{ .Revision }}
+
+      - store_test_results:
+          path: ./target/surefire-reports/
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - target
+
+  deploy:
+    <<: *defaults
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          <<: *cache_keys
+
+      - attach_workspace:
+          at: .
+
+      - run: mvn validate jar:jar deploy:deploy --settings ./settings.xml
+        
+workflows:
+  version: 2
+  build_test_deploy:
+    jobs:
+    - build:
+        filters:
+          tags:
+            only: /.*/
+    - deploy:
+        requires:
+          - build
+        filters:
+          branches:
+            ignore: /.*/
+          tags:
+            only: /^\d+\.\d+\.\d+/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
       - attach_workspace:
           at: .
 
-      - run: mvn validate jar:jar deploy:deploy --settings ./settings.xml
+      - run: mvn validate jar:jar source:jar deploy:deploy --settings ./settings.xml
         
 workflows:
   version: 2

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,8 @@
 
         <maven-surefire-plugin.version>2.9</maven-surefire-plugin.version>
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -170,7 +172,21 @@
                 </configuration>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven-source-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <artifactId>maven-assembly-plugin</artifactId>
+                <version>${maven-assembly-plugin.version}</version>
                 <configuration>
                     <archive>
                         <manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>datadog</groupId>
+    <groupId>com.datadoghq</groupId>
     <artifactId>jmxfetch</artifactId>
     <version>0.21.0</version>
     <packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -31,8 +31,17 @@
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+	<bintray.repo>datadog/datadog-maven</bintray.repo>
+	<bintray.package>jmxfetch</bintray.package>
     </properties>
 
+    <distributionManagement>
+        <repository>
+            <id>bintray-jmxfetch</id>
+            <url>https://api.bintray.com/maven/${bintray.repo}/${bintray.package}/;publish=1</url>
+        </repository>
+    </distributionManagement>
     <dependencies>
         <dependency>
             <groupId>com.beust</groupId>

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<settings xsi:schemaLocation='http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd'
+          xmlns='http://maven.apache.org/SETTINGS/1.0.0' xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'>
+    <servers>
+        <server>
+	    <id>bintray-jmxfetch</id>
+            <username>${env.BINTRAY_USER}</username>
+            <password>${env.BINTRAY_API_KEY}</password>
+        </server>
+    </servers>
+</settings>


### PR DESCRIPTION
This is a POC PR to use circleci to build jmxfetch.  This builds on top of #180.

The idea is that we will no longer use https://github.com/DataDog/docker-jmxfetch-build and build jmxfetch directly from this repo.
It also adds publishing to bintray similarly to dd-java-tracer. Currently to test repo, but this may be changed.
This would potentially change the release flow since `docker-jmxfetch-build` is no longer involved and built artifact can be picked up from bintray. We also would need to publish it to maven central (I think this is a manual step).