### PR TITLE
add support for rmi registry connection over ssl

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -23,6 +23,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
+import javax.management.remote.rmi.RMIConnectorServer;
+import javax.rmi.ssl.SslRMIClientSocketFactory;
 import javax.security.auth.login.FailedLoginException;
 
 import org.apache.log4j.Appender;

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -23,8 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.management.remote.rmi.RMIConnectorServer;
-import javax.rmi.ssl.SslRMIClientSocketFactory;
 import javax.security.auth.login.FailedLoginException;
 
 import org.apache.log4j.Appender;

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -100,7 +100,7 @@ public class RemoteConnection extends Connection {
 
         HashMap<String, Object> environment = new HashMap<String, Object>();
 
-        if(connectionParams.containsKey("rmi_ssl") && (Boolean) connectionParams.get("rmi_ssl")) {
+        if(connectionParams.containsKey("rmi_registry_ssl") && (Boolean) connectionParams.get("rmi_registry_ssl")) {
             SslRMIClientSocketFactory csf = new SslRMIClientSocketFactory();
             environment.put("com.sun.jndi.rmi.factory.socket", csf);
             environment.put(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, csf);


### PR DESCRIPTION
### Purpose of this PR

We were previously only supporting SSL for connections to RMI servers and not for connections to the RMI registry. 

Users will most likely want to authenticate their JMX clients using 2-way ssl as this is recommended here https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html. 
This means we also need to use a keystore for the client, which is why I added two new config options.

### Motivation

Client request