### PR TITLE
Default JVM metrics for GC pools, class load count, and descriptors

### DIFF
--- a/src/main/resources/org/datadog/jmxfetch/default-jmx-metrics.yaml
+++ b/src/main/resources/org/datadog/jmxfetch/default-jmx-metrics.yaml
@@ -49,3 +49,94 @@
         alias: jvm.cpu_load.system
         metric_type: gauge
 
+# Classloading
+- include:
+    domain: java.lang
+    type: ClassLoading
+    attribute:
+      LoadedClassCount:
+        alias: jvm.loaded_classes
+        metric_type: gauge
+
+# Open File Descriptors
+- include:
+    domain: java.lang
+    type: OperatingSystem
+    attribute:
+      OpenFileDescriptorCount:
+        alias: jvm.os.open_file_descriptors
+        metric_type: gauge
+
+# GC Memory Pools
+- include:
+    domain: java.lang
+    type: MemoryPool
+    name: PS Eden Space
+    attribute:
+      Usage.used:
+        alias: jvm.gc.eden_size
+        metric_type: gauge
+- include:
+    domain: java.lang
+    type: MemoryPool
+    name: Par Eden Space
+    attribute:
+      Usage.used:
+        alias: jvm.gc.eden_size
+        metric_type: gauge
+- include:
+    domain: java.lang
+    type: MemoryPool
+    name: G1 Eden Space
+    attribute:
+      Usage.used:
+        alias: jvm.gc.eden_size
+        metric_type: gauge
+- include:
+    domain: java.lang
+    type: MemoryPool
+    name: PS Survivor Space
+    attribute:
+      Usage.used:
+        alias: jvm.gc.survivor_size
+        metric_type: gauge
+- include:
+    domain: java.lang
+    type: MemoryPool
+    name: Par Survivor Space
+    attribute:
+      Usage.used:
+        alias: jvm.gc.survivor_size
+        metric_type: gauge
+- include:
+    domain: java.lang
+    type: MemoryPool
+    name: G1 Survivor Space
+    attribute:
+      Usage.used:
+        alias: jvm.gc.survivor_size
+        metric_type: gauge
+- include:
+    domain: java.lang
+    type: MemoryPool
+    name: PS Old Gen
+    attribute:
+      Usage.used:
+        alias: jvm.gc.old_gen_size
+        metric_type: gauge
+- include:
+    domain: java.lang
+    type: MemoryPool
+    name: CMS Old Gen
+    attribute:
+      Usage.used:
+        alias: jvm.gc.old_gen_size
+        metric_type: gauge
+- include:
+    domain: java.lang
+    type: MemoryPool
+    name: G1 Old Gen
+    attribute:
+      Usage.used:
+        alias: jvm.gc.old_gen_size
+        metric_type: gauge


### PR DESCRIPTION
For our APM JMX graphs we're interested in adding charts for specific GC pools (eden, old gen, etc), class load counts, and open file descriptors.

Couple of questions:

* Does it make sense to put these changes here (in core JMX)?
* Process-wise, does it work to propose built-in metric changes like this (through a PR)?