### PR TITLE
[release] Prepare upcoming 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 Changes
 =======
 
-# 0.23.0 / Unreleased 
+# 0.24.0 / 2018-12-10
+
+### Changes
+
+* [FEATURE] Add support for direct local jmx connections. See [#201][]
+
+# 0.23.0 / 2018-11-30
 
 ### Changes
 
@@ -9,95 +15,95 @@ Changes
 * [FEATURE] Default JVM metrics for GC pools, class load count, and descriptors. See [#198][]
 * [BUGFIX] Hide new GC metrics behind a flag. See [#197][]
 
-# 0.22.0 / 19-10-2018
+# 0.22.0 / 2018-10-19
 
 ### Changes
 
 * [FEATURE] Provide a way to pass extra tags when jmxfetch is used as a library. See [#191][].
 
-# 0.21.0 / 10-10-2018
+# 0.21.0 / 2018-10-10
 
 ### Changes
 
 * [FEATURE] Adds support for rmi registry connection over SSL and client authentication. See [#185][].
 * [IMPROVEMENT] jmxfetch can now be used as a library. See [#180][].
 
-# 0.20.2 / 09-03-2018
+# 0.20.2 / 2018-09-03
 
 ### Changes
 
 * [SECURITY] Bump FasterXML to 2.9.6. See [#178][], [CVE-2018-7489](https://nvd.nist.gov/vuln/detail/CVE-2018-7489) and [CVE-2018-5968](https://nvd.nist.gov/vuln/detail/CVE-2018-5968).
 
-# 0.20.1 / 06-26-2018
+# 0.20.1 / 2018-06-26
 
 ### Changes
 
 * [BUGFIX] Use provided check name in the JSON as the instance check name. See [#174][].
 
-# 0.20.0 / 04-30-2018
+# 0.20.0 / 2018-04-30
 
 ### Changes
 
 * [FEATURE] Configs can now be given to jmxfetch using the https endpoint when running list_* troubleshooting commands. See [#171][].
 * [IMPROVEMENT] Parameter `rmi_client_timeout` can now be given as an integer. See [#170][].
 
-# 0.19.0 / 03-19-2018
+# 0.19.0 / 2018-03-19
 
 ### Changes
 
 * [FEATURE] Ability to specify tags on metrics based on regex groupings of bean names. See [#167][].
 * [IMPROVEMENT] Set TCP response timeout to ensure JMXFetch doesn't hang on broken beans. See [#168][].
 
-# 0.18.2 / 02-13-2018
+# 0.18.2 / 2018-02-13
 
 #### Changes
 
 * [IMPROVEMENT] Logs are now output to stdout if no log file is configured. See [#164][].
 
-# 0.18.1 / 12-05-2017
+# 0.18.1 / 2017-12-05
 
 #### Changes
 
 * [BUGFIX] confd is now an optional parameter. See [#161][]
 
-# 0.18.0 / 10-11-2017
+# 0.18.0 / 2017-10-11
 
 #### Changes
 
 * [FEATURE] Collect instance configurations via API. See [#156][]
 
-# 0.17.0 / 09-20-2017
+# 0.17.0 / 2017-09-20
 
 #### Changes
 
 * [FEATURE] Add support for submission of JMX statuses to REST API. See [#155][]
 * [IMPROVEMENT] Rates: add canonical_rate + feature flag for the feature. See [#154][] (Thanks [@arrawatia][])
 
-# 0.16.0 / 08-21-2017
+# 0.16.0 / 2017-08-21
 
 #### Changes
 
 * [BUGFIX] Increase maximum length of instance configs pulled from Auto-Discovery pipe. See [#147][]
 * [IMPROVEMENT] Touch JMXFetch launch file on boot-up. See [#143][]
 
-# 0.15.0 / 07-10-2017
+# 0.15.0 / 2017-07-10
 
 #### Changes
 
 * [FEATURE] Transition to auto-discovery nomenclature, support legacy SD. See [#142][]
 * [IMPROVEMENT] Auto_discovery: process templates larger than the page buffer size. See [#145][]
 
-# 0.14.0 / 05-31-2017
+# 0.14.0 / 2017-05-31
 
 #### Changes
 * [FEATURE] Add support for `min_collection_interval`. See [#135][] and [#140][]
 
-# 0.13.1 / 04-18-2017
+# 0.13.1 / 2017-04-18
 
 #### Changes
 * [BUGFIX] Service_discovery: fix race condition preventing SD initialization. See [#135][]
 
-# 0.13.0 / 03-22-2017
+# 0.13.0 / 2017-03-22
 
 #### Changes
 * [BUGFIX] Allow specifying no alias on detailed attribute. See [#133][]
@@ -114,12 +120,12 @@ Changes
 * [FEATURE] Support user tag value substitution by attribute name. See [#117][].
 * [IMPROVEMENT] Print exception messages on Attach API connection failures. See [#122][] (Thanks [@aoking][])
 
-# 0.12.0 / 09-27-2016˙
+# 0.12.0 / 2016-09-27
 
 #### Changes
 * [BUGFIX] Fix `list_not_matching_attributes` action to return all "not matching" attributes. See [#102][] (Thanks [@nwillems][])
 
-# 0.11.0 / 05-23-2016
+# 0.11.0 / 2016-05-23
 
 #### Changes
 * [BUGFIX] Report properly beans with ':' in the name. See [#90][], [#91][], [#95][] (Thanks [@bluestix][])
@@ -128,13 +134,13 @@ Changes
 * [FEATURE] Add user tags to service checks. See [#96][]
 * [FEATURE] Allow group name substitutions in attribute/alias parameters. See [#94][], [#97][] (Thanks [@alz][])
 
-# 0.10.0 / 03-23-2016
+# 0.10.0 / 2016-03-23
 
 #### Changes
 * [FEATURE] Allow configuration of StatsD host. See [#85][]
 * [IMPROVEMENT] Re-throw IOException caught at the instance-level to handle them properly. See [#83][]
 
-# 0.9.0 / 11-05-2015
+# 0.9.0 / 2015-11-05
 
 #### Changes
 * [BUGFIX] Fix bean name matching logic: `OR`→`AND`. See [#81][]
@@ -143,7 +149,7 @@ Changes
 * [FEATURE] Support custom JMX Service URL to connect to, on a per-instance basis. See [#80][]
 * [IMPROVEMENT] Assign generic alias if not defined. See [#78][]
 
-# 0.8.0 / 09-17-2015
+# 0.8.0 / 2015-09-17
 
 #### Changes
 * [BUGFIX] Do not send service check warnings on metric limit violation. See [#73][]
@@ -153,41 +159,41 @@ Changes
 * [IMPROVEMENT] Memory saving by limiting MBeans queries to certain scopes. See [#63][]
 * [IMPROVEMENT] Memory saving by query bean names instead of full bean objects. See [#71][]
 
-# 0.7.0 / 06-04-2015
+# 0.7.0 / 2015-06-04
 
 #### Changes
 * [BUGFIX] Rename 'host' bean parameter to 'bean_host' in tags to avoid conflicts. See [#59][]
 * [ENHANCEMENT] Add option to exit JMXFetch when a specified file is created. See [#58][]
 
-# 0.6.0 / 05-20-2015
+# 0.6.0 / 2015-05-20
 
 #### Changes
 * [ENHANCEMENT] Format service check names prefix names to strip non alphabetic characters. See [#53][]
 * [FEATURE] Write the number of service check sent to status file. See [#54][]
 
-# 0.5.2 / 04-08-2015
+# 0.5.2 / 2015-04-08
 
 #### Changes
 * [ENHANCEMENT] Only send instance name in service check tags. See [#51][]
 
-# 0.5.1 / 04-02-2015
+# 0.5.1 / 2015-04-02
 
 #### Changes
 * [BUGFIX] Fix bad regression with `Status` type. See [#49][]
 
-# 0.5.0 / 03-16-2015
+# 0.5.0 / 2015-03-16
 
 #### Changes
 * [FEATURE] Send service checks for JMX integrations
 * [FEATURE] Support list of filters instead of simple filters: See [#20][]
 
-# 0.4.1 / 02-11-2014
+# 0.4.1 / 2014-02-11
 
 #### Changes
 * [BUGFIX] Memory leak fix when fetching attributes value is failing. See [#30][]
 * [FEATURE/BUGFIX] Fetch more JVM (Non)Heap variables by default. See [bd8915c2f1eec794f406414b678ce6110407dce1](https://github.com/DataDog/jmxfetch/commit/bd8915c2f1eec794f406414b678ce6110407dce1)
 
-# 0.3.0 / 03-25-2014
+# 0.3.0 / 2014-03-25
 
 #### Changes
 * [BUGFIX] Refresh JMX tree: See [4374b92cbf1b93d88fa5bd9d7339907e16a2da4a](https://github.com/DataDog/jmxfetch/commit/4374b92cbf1b93d88fa5bd9d7339907e16a2da4a)
@@ -271,6 +277,7 @@ Changes
 [#191]: https://github.com/DataDog/jmxfetch/issues/191
 [#197]: https://github.com/DataDog/jmxfetch/issues/197
 [#198]: https://github.com/DataDog/jmxfetch/issues/198
+[#201]: https://github.com/DataDog/jmxfetch/issues/201
 [@alz]: https://github.com/alz
 [@aoking]: https://github.com/aoking
 [@arrawatia]: https://github.com/arrawatia

--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ mvn test
 # To run:
 ```
 Get help on usage:
-java -jar jmxfetch-0.23.0-jar-with-dependencies.jar --help
+java -jar jmxfetch-0.24.0-jar-with-dependencies.jar --help
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.datadoghq</groupId>
     <artifactId>jmxfetch</artifactId>
-    <version>0.23.0</version>
+    <version>0.24.0</version>
     <packaging>jar</packaging>
 
     <name>jmxfetch</name>


### PR DESCRIPTION
Also, take the opportunity to normalize all the release dates in the changelog to a consistent YYYY-MM-DD format.