### PR TITLE
add monotonic_count support

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -437,6 +437,7 @@ public class App {
 
             // Clearing rates aggregator so we won't compute wrong rates if we can reconnect
             reporter.clearRatesAggregator(instance.getName());
+            reporter.clearCountersAggregator(instance.getName());
 
             LOGGER.warn(
                     "Instance "

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -103,7 +103,7 @@ public abstract class Reporter {
             // rates
             if ("gauge".equals(metricType) || "histogram".equals(metricType)) {
                 sendMetricPoint(metricType, metricName, currentValue, tags);
-            } else if ("count".equals(metricType)) {
+            } else if ("monotonic_count".equals(metricType)) {
                 String key = generateId(metric);
                 if (!instanceCountersAggregator.containsKey(key)) {
                     instanceCountersAggregator.put(key,  currentValue.longValue());
@@ -119,8 +119,8 @@ public abstract class Reporter {
 
                 instanceCountersAggregator.put(key, currentValue.longValue());
 
-                if (delta < 0 && canonicalRate) {
-                    LOGGER.info("Counter " + metricName + " has been reset and canonical rate is enabled - not submitting.");
+                if (delta < 0) {
+                    LOGGER.info("Counter " + metricName + " has been reset - not submitting.");
                     continue;
                 }
                 sendMetricPoint(metricType, metricName, delta, tags);

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -43,13 +43,12 @@ public abstract class Reporter {
         ratesAggregator.put(instanceName, new HashMap<String, HashMap<String, Object>>());
     }
 
+    /** Clears the counter aggregator for the provided instance name.  */
     public void clearCountersAggregator(String instanceName) {
         countersAggregator.put(instanceName, new HashMap<String, Long>());
     }
 
-    /**
-     * Submits the metrics in the implementing reporter. 
-     * */
+    /** Submits the metrics in the implementing reporter. */
     public void sendMetrics(
             LinkedList<HashMap<String, Object>> metrics,
             String instanceName,

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -117,13 +117,14 @@ public abstract class Reporter {
                     continue;
                 }
 
+                instanceCountersAggregator.put(key, currentValue.longValue());
+
                 if (delta < 0 && canonicalRate) {
-                    LOGGER.debug("Counter " + metricName + " has been reset and canonical rate is enabled - not submitting.");
+                    LOGGER.info("Counter " + metricName + " has been reset and canonical rate is enabled - not submitting.");
                     continue;
                 }
-
                 sendMetricPoint(metricType, metricName, delta, tags);
-                instanceCountersAggregator.put(key, currentValue.longValue());
+
             } else { // The metric should be 'counter'
                 String key = generateId(metric);
                 if (!instanceRatesAggregator.containsKey(key)) {

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -42,6 +42,7 @@ public abstract class Reporter {
     public void clearRatesAggregator(String instanceName) {
         ratesAggregator.put(instanceName, new HashMap<String, HashMap<String, Object>>());
     }
+
     public void clearCountersAggregator(String instanceName) {
         countersAggregator.put(instanceName, new HashMap<String, Long>());
     }
@@ -113,7 +114,7 @@ public abstract class Reporter {
                 long oldValue = instanceCountersAggregator.get(key);
                 long delta = currentValue.longValue() - oldValue;
 
-                if(Double.isNaN(delta) || Double.isInfinite(delta)) {
+                if (Double.isNaN(delta) || Double.isInfinite(delta)) {
                     continue;
                 }
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -39,7 +39,7 @@ public class StatsdReporter extends Reporter {
             this.statsDClient.stop();
             init();
         }
-        if (metricType.equals("count")) {
+        if (metricType.equals("monotonic_count")) {
             statsDClient.count(metricName, (long) value, tags);
         } else if (metricType.equals("histogram")) {
             statsDClient.histogram(metricName, value, tags);

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -39,7 +39,9 @@ public class StatsdReporter extends Reporter {
             this.statsDClient.stop();
             init();
         }
-        if (metricType.equals("histogram")) {
+        if (metricType.equals("gauge_delta")) {
+            statsDClient.count(metricName, (long) value, tags);
+        } else if (metricType.equals("histogram")) {
             statsDClient.histogram(metricName, value, tags);
         } else {
             statsDClient.gauge(metricName, value, tags);

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -39,7 +39,7 @@ public class StatsdReporter extends Reporter {
             this.statsDClient.stop();
             init();
         }
-        if (metricType.equals("gauge_delta")) {
+        if (metricType.equals("count")) {
             statsDClient.count(metricName, (long) value, tags);
         } else if (metricType.equals("histogram")) {
             statsDClient.histogram(metricName, value, tags);

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -716,7 +716,55 @@ public class TestApp extends TestCommon {
         assertCoverage();
     }
 
-    /** Test JMX Service Discovery. */
+    /**
+     * Test counts.
+     */
+    @Test
+    public void testAppCount() throws Exception {
+        // We expose a few metrics through JMX
+        SimpleTestJavaApp testApp = new SimpleTestJavaApp();
+        registerMBean( testApp, "org.datadog.jmxfetch.test:type=SimpleTestJavaApp");
+
+        initApplication("jmx_count.yaml");
+
+        // First collection should not contain our count
+        run();
+        metrics = getMetrics();
+        assertEquals(13, metrics.size());
+
+        // Since our count is still equal to 0, we should report a delta equal to 0
+        run();
+        metrics = getMetrics();
+        assertEquals(14, metrics.size());
+        assertMetric("test.counter", 0, Collections.<String>emptyList(), 3);
+
+        // For the 3rd collection we increment the count to 5 so we should get a +5 delta
+        testApp.incrementCounter(5);
+        run();
+        metrics = getMetrics();
+        assertEquals(14, metrics.size());
+        assertMetric("test.counter", 5, Collections.<String>emptyList(), 3);
+
+        // For the 4th collection we decrement the count by 8 so we should get a -8 delta
+        testApp.decrementCounter(8);
+        run();
+        metrics = getMetrics();
+        assertEquals(14, metrics.size());
+        assertMetric("test.counter", -8, Collections.<String>emptyList(), 3);
+
+        // For the 5th collection we increment the count by 3 so we should get a +3 delta
+        testApp.incrementCounter(3);
+        run();
+        metrics = getMetrics();
+        assertEquals(14, metrics.size());
+        assertMetric("test.counter", 3, Collections.<String>emptyList(), 3);
+
+        assertCoverage();
+    }
+
+    /** 
+     * Test JMX Service Discovery.
+     * */
     @Test
     public void testServiceDiscovery() throws Exception {
         // We expose a few metrics through JMX

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -745,20 +745,6 @@ public class TestApp extends TestCommon {
         assertEquals(14, metrics.size());
         assertMetric("test.counter", 5, Collections.<String>emptyList(), 3);
 
-        // For the 4th collection we decrement the count by 8 so we should get a -8 delta
-        testApp.decrementCounter(8);
-        run();
-        metrics = getMetrics();
-        assertEquals(14, metrics.size());
-        assertMetric("test.counter", -8, Collections.<String>emptyList(), 3);
-
-        // For the 5th collection we increment the count by 3 so we should get a +3 delta
-        testApp.incrementCounter(3);
-        run();
-        metrics = getMetrics();
-        assertEquals(14, metrics.size());
-        assertMetric("test.counter", 3, Collections.<String>emptyList(), 3);
-
         assertCoverage();
     }
 

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;

--- a/src/test/resources/jmx_count.yaml
+++ b/src/test/resources/jmx_count.yaml
@@ -1,0 +1,13 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        refresh_beans: 4
+        name: jmx_test_instance
+        conf:
+            - include:
+               domain: org.datadog.jmxfetch.test
+               attribute:
+                    ShouldBeCounter:
+                        metric_type: count
+                        alias: test.counter

--- a/src/test/resources/jmx_count.yaml
+++ b/src/test/resources/jmx_count.yaml
@@ -9,5 +9,5 @@ instances:
                domain: org.datadog.jmxfetch.test
                attribute:
                     ShouldBeCounter:
-                        metric_type: count
+                        metric_type: monotonic_count
                         alias: test.counter


### PR DESCRIPTION
### What does this PR do

Adds the ability to jmxfetch to consume "monotonic_counts". This new metric type for jmxfetch is going to be almost identical to the agent checks `monotonic_count`:

> Submit the sampled raw value of your counter. Don’t normalize the values to a rate, or calculate the deltas before submitting. If the value of your counter ever decreases between submissions the resulting stored value for that submission is 0
https://docs.datadoghq.com/developers/metrics/counts/

The only difference with agent checks is that the value will be stored as a `rate` in the backend. Functionality wise this should not have any impact.

This will allow jmxfetch to monitor counters that increase over time like the total number of request received by a web server and most importantly store them as counts in Datadog.

### Notes

This is based on a POC from @mirkoprescha  that you can find here: https://github.com/DataDog/jmxfetch/pull/190.