### PR TITLE
Replace $value by the JMX value

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -506,7 +506,6 @@ public abstract class JMXAttribute {
             // Same as above
         }
 
-
         return alias;
     }
 

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -503,6 +503,12 @@ public abstract class JMXAttribute {
         // Attribute & domain
         alias = alias.replace("$attribute", fullAttributeName);
         alias = alias.replace("$domain", domain);
+        try {
+            alias = alias.replace("$value", getJmxValue().toString());
+        } catch (Exception e) {
+            // If we haven't been able to get the value, it wasn't replaced.
+        }
+
 
         return alias;
     }

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -15,12 +15,7 @@ import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.management.AttributeNotFoundException;
-import javax.management.InstanceNotFoundException;
-import javax.management.MBeanAttributeInfo;
-import javax.management.MBeanException;
-import javax.management.ObjectName;
-import javax.management.ReflectionException;
+import javax.management.*;
 
 import org.apache.log4j.Logger;
 
@@ -505,8 +500,10 @@ public abstract class JMXAttribute {
         alias = alias.replace("$domain", domain);
         try {
             alias = alias.replace("$value", getJmxValue().toString());
-        } catch (Exception e) {
+        } catch (JMException e) {
             // If we haven't been able to get the value, it wasn't replaced.
+        } catch (IOException e) {
+            // Same as above
         }
 
 

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -502,8 +502,10 @@ public abstract class JMXAttribute {
             alias = alias.replace("$value", getJmxValue().toString());
         } catch (JMException e) {
             // If we haven't been able to get the value, it wasn't replaced.
+            LOGGER.warn("Unable to replace $value for attribute " + fullAttributeName);
         } catch (IOException e) {
             // Same as above
+            LOGGER.warn("Unable to replace $value for attribute " + fullAttributeName);
         }
 
         return alias;

--- a/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JMXAttribute.java
@@ -502,10 +502,10 @@ public abstract class JMXAttribute {
             alias = alias.replace("$value", getJmxValue().toString());
         } catch (JMException e) {
             // If we haven't been able to get the value, it wasn't replaced.
-            LOGGER.warn("Unable to replace $value for attribute " + fullAttributeName);
+            LOGGER.warn("Unable to replace $value for attribute " + fullAttributeName, e);
         } catch (IOException e) {
             // Same as above
-            LOGGER.warn("Unable to replace $value for attribute " + fullAttributeName);
+            LOGGER.warn("Unable to replace $value for attribute " + fullAttributeName, e);
         }
 
         return alias;

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -87,8 +87,8 @@ public class TestApp extends TestCommon {
 
         // Assertions
 
-        // 15 metrics = 13 from `java.lang` + 2 from the user configuration file
-        assertEquals(15, metrics.size());
+        // 16 metrics = 13 from `java.lang` + 3 from the user configuration file
+        assertEquals(16, metrics.size());
 
         // Metric aliases are generated from `alias_match`
         List<String> tags = Arrays.asList(
@@ -100,6 +100,7 @@ public class TestApp extends TestCommon {
 
         assertMetric("this.is.100.bar.baz", tags, 4);
         assertMetric("org.datadog.jmxfetch.test.baz.hashmap.thisis0", tags, 4);
+        assertMetric("this.is.thousand.1000.0", 1000, tags, 4);
     }
 
     /**
@@ -736,17 +737,6 @@ public class TestApp extends TestCommon {
         assertEquals(61, metrics.size());
 
         List<String> tags = Arrays.asList(
-                "type:SimpleTestJavaApp",
-                "scope:CoolScope",
-                "instance:jmx_test_instance",
-                "jmx_domain:org.datadog.jmxfetch.test",
-                "bean_host:localhost",
-                "component"
-        );
-
-        assertMetric("this.is.thousand.1000.0", 1000, tags, 6);
-
-        tags = Arrays.asList(
             "type:SimpleTestJavaApp",
             "scope:CoolScope",
             "instance:jmx_test_instance",
@@ -809,7 +799,7 @@ public class TestApp extends TestCommon {
         LinkedList<HashMap<String, Object>> metrics = getMetrics();
         ArrayList<Instance> instances = getInstances();
 
-        assertEquals(31, metrics.size());
+        assertEquals(33, metrics.size());
 
         // 2(jmx_alias_match)  + 1 (jmx_sd_pipe_longname discards one)
         assertEquals(2, instances.size());

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -733,10 +733,20 @@ public class TestApp extends TestCommon {
         LinkedList<HashMap<String, Object>> metrics = getMetrics();
 
         // 14 = 13 metrics from java.lang + 1 metric explicitly defined in the yaml config file
-        assertEquals(59, metrics.size());
-
+        assertEquals(61, metrics.size());
 
         List<String> tags = Arrays.asList(
+                "type:SimpleTestJavaApp",
+                "scope:CoolScope",
+                "instance:jmx_test_instance",
+                "jmx_domain:org.datadog.jmxfetch.test",
+                "bean_host:localhost",
+                "component"
+        );
+
+        assertMetric("this.is.thousand.1000.0", 1000, tags, 6);
+
+        tags = Arrays.asList(
             "type:SimpleTestJavaApp",
             "scope:CoolScope",
             "instance:jmx_test_instance",

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -87,8 +87,8 @@ public class TestApp extends TestCommon {
 
         // Assertions
 
-        // 16 metrics = 13 from `java.lang` + 3 from the user configuration file
-        assertEquals(16, metrics.size());
+        // 17 metrics = 13 from `java.lang` + 4 from the user configuration file
+        assertEquals(17, metrics.size());
 
         // Metric aliases are generated from `alias_match`
         List<String> tags = Arrays.asList(
@@ -101,6 +101,7 @@ public class TestApp extends TestCommon {
         assertMetric("this.is.100.bar.baz", tags, 4);
         assertMetric("org.datadog.jmxfetch.test.baz.hashmap.thisis0", tags, 4);
         assertMetric("this.is.thousand.1000.0", 1000, tags, 4);
+        assertMetric("this.is.five.should_be5", 5, tags, 4);
     }
 
     /**
@@ -734,7 +735,7 @@ public class TestApp extends TestCommon {
         LinkedList<HashMap<String, Object>> metrics = getMetrics();
 
         // 14 = 13 metrics from java.lang + 1 metric explicitly defined in the yaml config file
-        assertEquals(61, metrics.size());
+        assertEquals(63, metrics.size());
 
         List<String> tags = Arrays.asList(
             "type:SimpleTestJavaApp",
@@ -799,7 +800,7 @@ public class TestApp extends TestCommon {
         LinkedList<HashMap<String, Object>> metrics = getMetrics();
         ArrayList<Instance> instances = getInstances();
 
-        assertEquals(33, metrics.size());
+        assertEquals(35, metrics.size());
 
         // 2(jmx_alias_match)  + 1 (jmx_sd_pipe_longname discards one)
         assertEquals(2, instances.size());

--- a/src/test/resources/jmx_alias_match.yaml
+++ b/src/test/resources/jmx_alias_match.yaml
@@ -13,6 +13,12 @@ instances:
                     ShouldBe1000:
                         metric_type: gauge
                         alias: this.is.thousand.$value
+                    ShouldBeConverted:
+                        metric_type: gauge
+                        alias: this.is.five.$value
+                        values:
+                            ShouldBe0: 0
+                            ShouldBe5: 5
                     Hashmap.thisis0:
                         metric_type: gauge
                         alias: $domain.$qux.$attribute

--- a/src/test/resources/jmx_alias_match.yaml
+++ b/src/test/resources/jmx_alias_match.yaml
@@ -10,6 +10,9 @@ instances:
                     ShouldBe100:
                         metric_type: gauge
                         alias: this.is.100.$foo.$qux
+                    ShouldBe1000:
+                      metric_type: gauge
+                      alias: this.is.thousand.$value
                     Hashmap.thisis0:
                         metric_type: gauge
                         alias: $domain.$qux.$attribute

--- a/src/test/resources/jmx_alias_match.yaml
+++ b/src/test/resources/jmx_alias_match.yaml
@@ -11,8 +11,8 @@ instances:
                         metric_type: gauge
                         alias: this.is.100.$foo.$qux
                     ShouldBe1000:
-                      metric_type: gauge
-                      alias: this.is.thousand.$value
+                        metric_type: gauge
+                        alias: this.is.thousand.$value
                     Hashmap.thisis0:
                         metric_type: gauge
                         alias: $domain.$qux.$attribute


### PR DESCRIPTION
This PR enables the use of metric value as part of the metric name.

This would probably be most useful for string value metrics together with value conversion so that the double value is submitted correctly to DD.