### PR TITLE
 Allow metrics configs to be loaded via resources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,7 @@
     </developers>
 
     <properties>
+        <maven.compiler.source>1.6</maven.compiler.source>
         <maven.compiler.target>1.6</maven.compiler.target>
 
         <commons-io.version>2.4</commons-io.version>
@@ -91,12 +92,6 @@
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
             <version>${commons-lang.version}</version>
-        </dependency>
-        <dependency>
-            <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>${apache-commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>com.datadoghq</groupId>

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -121,6 +121,8 @@ public class AppConfig {
 
     // This is used by things like APM agent to provide configuration from resources
     private List<String> instanceConfigResources;
+    // This is used by things like APM agent to provide metric configuration from resources
+    private List<String> metricConfigResources;
     // This is used by things like APM agent to provide metric configuration from files
     private List<String> metricConfigFiles;
     // This is used by things like APM agent to provide global override for bean refresh period
@@ -229,6 +231,10 @@ public class AppConfig {
         return instanceConfigResources;
     }
 
+    public List<String> getMetricConfigResources() {
+        return metricConfigResources;
+    }
+
     public List<String> getMetricConfigFiles() {
         return metricConfigFiles;
     }
@@ -246,6 +252,7 @@ public class AppConfig {
      */
     public static AppConfig create(
             List<String> instanceConfigResources,
+            List<String> metricConfigResources,
             List<String> metricConfigFiles,
             Integer checkPeriod,
             Integer refreshBeansPeriod,
@@ -256,6 +263,7 @@ public class AppConfig {
         AppConfig config = new AppConfig();
         config.action = ImmutableList.of(ACTION_COLLECT);
         config.instanceConfigResources = ImmutableList.copyOf(instanceConfigResources);
+        config.metricConfigResources = ImmutableList.copyOf(metricConfigResources);
         config.metricConfigFiles = ImmutableList.copyOf(metricConfigFiles);
         if (checkPeriod != null) {
             config.checkPeriod = checkPeriod;

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -1,5 +1,6 @@
 package org.datadog.jmxfetch;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -179,7 +180,8 @@ public class Instance {
         }
     }
 
-    private void loadMetricConfigFiles(AppConfig appConfig, LinkedList<Configuration> configurationList) {
+    @VisibleForTesting
+    static void loadMetricConfigFiles(AppConfig appConfig, LinkedList<Configuration> configurationList) {
         if (appConfig.getMetricConfigFiles() != null) {
             for (String fileName : appConfig.getMetricConfigFiles()) {
                 String yamlPath = new File(fileName).getAbsolutePath();
@@ -208,7 +210,8 @@ public class Instance {
         }
     }
 
-    private void loadMetricConfigResources(AppConfig config, LinkedList<Configuration> configurationList) {
+    @VisibleForTesting
+    static void loadMetricConfigResources(AppConfig config, LinkedList<Configuration> configurationList) {
         List<String> resourceConfigList = config.getMetricConfigResources();
         if (resourceConfigList != null) {
             ClassLoader classLoader = Thread.currentThread().getContextClassLoader();

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -4,7 +4,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.google.common.collect.Lists;
+import java.net.URL;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Arrays;
@@ -71,5 +75,28 @@ public class TestInstance extends TestCommon {
 			String[] tags = (String[]) sc.get("tags");
 			this.assertHostnameTags(Arrays.asList(tags));
         }
+	}
+
+	@Test
+	public void testLoadMetricConfigFiles() throws Exception {
+		URL defaultConfig = Instance.class.getResource("default-jmx-metrics.yaml");
+		AppConfig config = mock(AppConfig.class);
+		when(config.getMetricConfigFiles()).thenReturn(Lists.newArrayList(defaultConfig.getPath()));
+		LinkedList<Configuration> configurationList = new LinkedList<Configuration>();
+		Instance.loadMetricConfigFiles(config, configurationList);
+
+		assertEquals(2, configurationList.size());
+	}
+
+	@Test
+	public void testLoadMetricConfigResources() throws Exception {
+		URL defaultConfig = Instance.class.getResource("sample-metrics.yaml");
+		String configResource = defaultConfig.getPath().split("test-classes/")[1];
+		AppConfig config = mock(AppConfig.class);
+		when(config.getMetricConfigResources()).thenReturn(Lists.newArrayList(configResource));
+		LinkedList<Configuration> configurationList = new LinkedList<Configuration>();
+		Instance.loadMetricConfigResources(config, configurationList);
+
+		assertEquals(2, configurationList.size());
 	}
 }

--- a/src/test/java/org/datadog/jmxfetch/TestLogInitialization.java
+++ b/src/test/java/org/datadog/jmxfetch/TestLogInitialization.java
@@ -37,6 +37,7 @@ public class TestLogInitialization {
             return AppConfig.create(
                     ImmutableList.of("org/datadog/jmxfetch/dd-java-agent-jmx.yaml"),
                     Collections.<String>emptyList(),
+                    Collections.<String>emptyList(),
                     (int) TimeUnit.SECONDS.toMillis(30),
                     (int) TimeUnit.SECONDS.toMillis(30),
                     Collections.<String, String>emptyMap(),
@@ -50,6 +51,7 @@ public class TestLogInitialization {
         public AppConfig call() throws Exception {
             return AppConfig.create(
                     ImmutableList.of("org/datadog/jmxfetch/remote-jmx.yaml"),
+                    Collections.<String>emptyList(),
                     Collections.<String>emptyList(),
                     (int) TimeUnit.SECONDS.toMillis(30),
                     (int) TimeUnit.SECONDS.toMillis(30),

--- a/src/test/resources/org/datadog/jmxfetch/sample-metrics.yaml
+++ b/src/test/resources/org/datadog/jmxfetch/sample-metrics.yaml
@@ -1,0 +1,43 @@
+# Same as default-jmx-metrics.yaml but with the top level jmx_metrics to match standard metrics.yaml file structure.
+
+jmx_metrics:
+
+  # Memory
+  - include:
+      domain: java.lang
+      type: Memory
+      attribute:
+        HeapMemoryUsage.used:
+          alias: jvm.heap_memory
+          metric_type: gauge
+        HeapMemoryUsage.committed:
+          alias: jvm.heap_memory_committed
+          metric_type: gauge
+        HeapMemoryUsage.init:
+          alias: jvm.heap_memory_init
+          metric_type: gauge
+        HeapMemoryUsage.max:
+          alias: jvm.heap_memory_max
+          metric_type: gauge
+        NonHeapMemoryUsage.used:
+          alias: jvm.non_heap_memory
+          metric_type: gauge
+        NonHeapMemoryUsage.committed:
+          alias: jvm.non_heap_memory_committed
+          metric_type: gauge
+        NonHeapMemoryUsage.init:
+          alias: jvm.non_heap_memory_init
+          metric_type: gauge
+        NonHeapMemoryUsage.max:
+          alias: jvm.non_heap_memory_max
+          metric_type: gauge
+
+  # Threads
+  - include:
+      domain: java.lang
+      type: Threading
+      attribute:
+        ThreadCount:
+          alias: jvm.thread_count
+          metric_type: gauge
+


### PR DESCRIPTION
Metrics configs embedded inside the agent aren’t directly accessible on the file system.  Loading as a resource avoids having to copy to an external location.

These files should match the standard `metrics.yaml` format, and include `jmx_metrics` blocks at the top level.