### PR TITLE
Update jackson.core dep to 2.9.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <java-dogstatsd-client.version>2.1.0</java-dogstatsd-client.version>
         <jcommander.version>1.35</jcommander.version>
         <log4j.version>1.2.17</log4j.version>
-        <jackson.version>2.9.6</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
         <snakeyaml.version>1.13</snakeyaml.version>
 
         <junit.version>4.11</junit.version>


### PR DESCRIPTION
New version fixes https://nvd.nist.gov/vuln/detail/CVE-2018-1000873.

Jackson changelogs:
* https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.7
* https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.9.8

Shouldn't affect Java 7 compatibility.

I'll release this fix in JMXFetch v`0.24.1` as soon as it's merged