### PR TITLE
Upgrade java-dogstatsd-client to 2.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <commons-lang.version>2.6</commons-lang.version>
         <apache-commons-lang3.version>3.5</apache-commons-lang3.version>
         <guava.version>17.0</guava.version>
-        <java-dogstatsd-client.version>2.1.0</java-dogstatsd-client.version>
+        <java-dogstatsd-client.version>2.7</java-dogstatsd-client.version>
         <jcommander.version>1.35</jcommander.version>
         <log4j.version>1.2.17</log4j.version>
         <jackson.version>2.9.8</jackson.version>

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -44,16 +44,15 @@ public class StatsdReporter extends Reporter {
         }
     }
 
-    private int statusToInt(String status) {
+    private ServiceCheck.Status statusToServiceCheckStatus(String status) {
         if (status == Status.STATUS_OK) {
-            return 0;
+            return ServiceCheck.Status.OK;
         } else if (status == Status.STATUS_WARNING) {
-            return 1;
+            return ServiceCheck.Status.WARNING;
         } else if (status == Status.STATUS_ERROR) {
-            // critical
-            return 2;
+            return ServiceCheck.Status.CRITICAL;
         }
-        return 3;
+        return ServiceCheck.Status.UNKNOWN;
     }
 
     /** Submits service check. */
@@ -63,12 +62,13 @@ public class StatsdReporter extends Reporter {
             init();
         }
 
-        ServiceCheck sc =
-                new ServiceCheck(
-                        String.format("%s.can_connect", checkName),
-                        this.statusToInt(status),
-                        message,
-                        tags);
+        ServiceCheck sc = ServiceCheck.builder()
+                .withName(String.format("%s.can_connect", checkName))
+                .withStatus(this.statusToServiceCheckStatus(status))
+                .withMessage(message)
+                .withTags(tags)
+                .build();
+
         statsDClient.serviceCheck(sc);
     }
 


### PR DESCRIPTION
This PR upgrades java-dogstatsd-client from 2.1.0 to 2.7.

We'd like to take advantage of https://github.com/DataDog/java-dogstatsd-client/pull/42, in particular.
