### PR TITLE
Small logging + logic clean up of concurrent collection

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -450,7 +450,9 @@ public class App {
             }
 
             if (!collectionProcessor.ready()) {
-                LOGGER.warn("Executor has to be replaced, previous one hogging threads");
+                LOGGER.warn(
+                        "Executor has to be replaced for collection processor, "
+                        + "previous one hogging threads");
                 collectionProcessor.stop();
                 collectionProcessor.setThreadPoolExecutor(
                         Executors.newFixedThreadPool(appConfig.getThreadPoolSize()));
@@ -786,7 +788,6 @@ public class App {
         Iterator<Entry<String, YamlParser>> it = configs.entrySet().iterator();
         Iterator<Entry<String, YamlParser>> itPipeConfigs = adPipeConfigs.entrySet().iterator();
         while (it.hasNext() || itPipeConfigs.hasNext()) {
-            LOGGER.info("iterating statics...");
             Map.Entry<String, YamlParser> entry;
             boolean fromPipeIterator = false;
             if (it.hasNext()) {
@@ -884,7 +885,7 @@ public class App {
             processStatus(instanceInitTasks, statuses);
         } catch (Exception e) {
             // NADA
-            LOGGER.warn("critical issue initializing instances: " + e);
+            LOGGER.warn("Critical issue initializing instances: " + e);
         }
     }
 
@@ -973,9 +974,11 @@ public class App {
 
                 // All was good, add instance
                 instances.add(instance);
-                LOGGER.info("Recovered broken instance: " + idx);
+                LOGGER.info("Successfully initialized instance: " + instance.getName());
             } catch (Throwable e) {
-                LOGGER.info("Instance remains broken: " + instance.getName());
+                LOGGER.info(
+                    "Could not initialize instance: " + instance.getName()
+                    + ": " + e.toString());
                 instance.cleanUpAsync();
                 brokenInstanceMap.put(instance.toString(), instance);
             }

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -85,16 +85,12 @@ public class App {
         this.appConfig = appConfig;
 
         ExecutorService collectionThreadPool =
-                appConfig.getThreadPoolSize() >= 1
-                        ? Executors.newFixedThreadPool(appConfig.getThreadPoolSize())
-                        : Executors.newCachedThreadPool();
+                Executors.newFixedThreadPool(appConfig.getThreadPoolSize());
         collectionProcessor =
                 new TaskProcessor(collectionThreadPool, appConfig.getReporter());
 
         ExecutorService recoveryThreadPool =
-                appConfig.getReconnectionThreadPoolSize() >= 1
-                        ? Executors.newFixedThreadPool(appConfig.getReconnectionThreadPoolSize())
-                        : Executors.newCachedThreadPool();
+                Executors.newFixedThreadPool(appConfig.getReconnectionThreadPoolSize());
         recoveryProcessor = new TaskProcessor(recoveryThreadPool, appConfig.getReporter());
 
         // setup client

--- a/src/main/java/org/datadog/jmxfetch/InstanceInitializingTask.java
+++ b/src/main/java/org/datadog/jmxfetch/InstanceInitializingTask.java
@@ -12,8 +12,6 @@ class InstanceInitializingTask extends InstanceTask<Void> {
     @Override
     public Void call() throws Exception {
         // Try to reinit the connection and force to renew it
-        LOGGER.info("Trying to reconnect to: " + instance);
-
         instance.init(reconnect);
         return null;
     }

--- a/src/main/java/org/datadog/jmxfetch/tasks/TaskProcessor.java
+++ b/src/main/java/org/datadog/jmxfetch/tasks/TaskProcessor.java
@@ -38,7 +38,7 @@ public class TaskProcessor {
      * */
     public boolean ready() {
         ThreadPoolExecutor tpe = (ThreadPoolExecutor) threadPoolExecutor;
-        return !(tpe.getPoolSize() == tpe.getActiveCount());
+        return !(tpe.getMaximumPoolSize() == tpe.getActiveCount());
     }
 
     /**

--- a/src/test/java/org/datadog/jmxfetch/tasks/TestTaskProcessor.java
+++ b/src/test/java/org/datadog/jmxfetch/tasks/TestTaskProcessor.java
@@ -59,7 +59,7 @@ public class TestTaskProcessor {
             }
         } catch (Exception e){
             exc = e;
-        } 
+        }
 
         if (exc != null) {
             status.setThrowableStatus(exc);
@@ -82,13 +82,15 @@ public class TestTaskProcessor {
     }
 
     /**
-     * Test Task Processor 
+     * Test Task Processor
      */
     @Test
     public void testTaskProcessor() throws Throwable {
-    
+
         ExecutorService testThreadPool = Executors.newFixedThreadPool(2);
         TaskProcessor testProcessor = new TaskProcessor(testThreadPool, null);
+
+        assertTrue(testProcessor.ready());
 
         List<InstanceTask<Boolean>> instanceTestTasks = new ArrayList<InstanceTask<Boolean>>();
 
@@ -105,7 +107,7 @@ public class TestTaskProcessor {
                         return TestTaskProcessor.processTestResults(instance, future, reporter);
                     };
                 });
- 
+
         // this should all be green
         for (int i=0 ; i<statuses.size(); i++) {
 
@@ -119,11 +121,11 @@ public class TestTaskProcessor {
     }
 
     /**
-     * Test Timeout in Task Processor 
+     * Test Timeout in Task Processor
      */
     @Test
     public void testTaskProcessorTimeout() throws Throwable {
-    
+
         ExecutorService testThreadPool = Executors.newFixedThreadPool(2);
         TaskProcessor testProcessor = new TaskProcessor(testThreadPool, null);
 
@@ -142,7 +144,7 @@ public class TestTaskProcessor {
                         return TestTaskProcessor.processTestResults(instance, future, reporter);
                     };
                 });
- 
+
         // this should all be green
         for (int i=0 ; i<statuses.size(); i++) {
 


### PR DESCRIPTION
### What this PR does

See individual commit descriptions. Overall:

* fbf7423: improvements to log entries
* 88ed5d4: remove unused logic on `CachedThreadPool` creation, since the config code doesn't allow negative values for the number of threads at the moment. A future PR (for `0.27.0`) will allow negative values.
* 2180909: small fix to TaskProcessor readiness logic: before the first JMXFetch "iteration", `tpe.getPoolSize()` is `0`, so the app would consider the pool as not ready and print out warnings + recreate the thread pool as long the first collection isn't actually kicked off.

### Notes

`App.processFixedStatus` doesn't log anything at the moment, not sure whether logging from there would potentially spam a lot of logs, would appreciate suggestions on that.

Overall, 2180909 requires particular attention as it changes actual logic, but the other changes shouldn't require any QA.