### PR TITLE
Lower log level of log entry dumping all configs from AutoConfig

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -704,7 +704,7 @@ public class App {
                 return update;
             }
 
-            LOGGER.info("Received the following JSON configs: " + response.getResponseBody());
+            LOGGER.debug("Received the following JSON configs: " + response.getResponseBody());
 
             InputStream jsonInputStream = IOUtils.toInputStream(response.getResponseBody(), UTF_8);
             JsonParser parser = new JsonParser(jsonInputStream);


### PR DESCRIPTION
It's potentially a very large log entry, and it shouldn't be needed
at the info log level.

Was introduced in #199.