### PR TITLE
Only query the JMX value for alias if `$value` is configured

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
@@ -258,6 +258,7 @@ public abstract class JmxAttribute {
         }
     }
 
+    /** Gets the JMX Attribute info value. Makes a call through the connection */
     Object getJmxValue()
             throws AttributeNotFoundException, InstanceNotFoundException, MBeanException,
                     ReflectionException, IOException {
@@ -545,14 +546,18 @@ public abstract class JmxAttribute {
         // Attribute & domain
         alias = alias.replace("$attribute", fullAttributeName);
         alias = alias.replace("$domain", domain);
-        try {
-            alias = alias.replace("$value", getJmxValue().toString());
-        } catch (JMException e) {
-            // If we haven't been able to get the value, it wasn't replaced.
-            LOGGER.warn("Unable to replace $value for attribute " + fullAttributeName, e);
-        } catch (IOException e) {
-            // Same as above
-            LOGGER.warn("Unable to replace $value for attribute " + fullAttributeName, e);
+        if (alias.contains("$value")) {
+            // getJmxValue() hits the JMX target (potentially through remote network connection),
+            // so only call it if needed.
+            try {
+                alias = alias.replace("$value", getJmxValue().toString());
+            } catch (JMException e) {
+                // If we haven't been able to get the value, it wasn't replaced.
+                LOGGER.warn("Unable to replace $value for attribute " + fullAttributeName, e);
+            } catch (IOException e) {
+                // Same as above
+                LOGGER.warn("Unable to replace $value for attribute " + fullAttributeName, e);
+            }
         }
 
         return alias;


### PR DESCRIPTION
### What this PR does

Querying the value potentially has to query the remote JMX, so only do
it when necessary.

Introduced in #204 (`v0.25.0`), would make 1 call per attribute configured in the check config with an `alias`. This change reduces the number of calls to 1 per attribute with a configured `alias` that contains `$value`.

### Testing

#204 included tests, these still pass

### Notes

I haven't measured any noticeable performance impact of #204 on our staging environment (looked at JMX metric point frequency), so the present PR doesn't have to be shipped now IMO.