### PR TITLE
Don't print a stacktrace when failing to get a metric

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
@@ -253,7 +253,8 @@ public abstract class JmxAttribute {
         try {
             return this.getMetrics().size();
         } catch (Exception e) {
-            LOGGER.warn("Unable to get metrics from " + beanStringName + " - " + attributeName, e);
+            LOGGER.warn("Unable to get metrics from " + beanStringName + " - "
+                                                + attributeName + ": " + e.toString());
             return 0;
         }
     }

--- a/src/test/resources/jmx_cast.yaml
+++ b/src/test/resources/jmx_cast.yaml
@@ -1,0 +1,14 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        refresh_beans: 4
+        name: jmx_test_instance
+        conf:
+            - include:
+                domain: org.datadog.jmxfetch.test
+                attribute:
+                    ShouldBe100:
+                        metric_type: gauge
+                    ShouldBeDefaulted:
+                        metric_type: gauge


### PR DESCRIPTION
A multi-line stack trace was being printed to the log when a metric couldn't be retrieved, eg: because of a cast error. This makes the error fit into a single log line.

Before:
```
2019-04-11 17:59:46,641 | WARN | JmxAttribute | Unable to get metrics from org.datadog.jmxfetch.test:type=SimpleTestJavaApp - MyAwesomeMetric
java.lang.NumberFormatException: For input string: "ImNotANumber"
        at sun.misc.FloatingDecimal.readJavaFormatString(FloatingDecimal.java:2043)
        at sun.misc.FloatingDecimal.parseDouble(FloatingDecimal.java:110)
        at java.lang.Double.parseDouble(Double.java:538)
        at org.datadog.jmxfetch.JmxAttribute.castToDouble(JmxAttribute.java:301)
        at org.datadog.jmxfetch.JmxSimpleAttribute.getMetrics(JmxSimpleAttribute.java:45)
        at org.datadog.jmxfetch.JmxAttribute.getMetricsCount(JmxAttribute.java:254)
        at org.datadog.jmxfetch.Instance.getMatchingAttributes(Instance.java:562)
        at org.datadog.jmxfetch.Instance.init(Instance.java:361)
        at org.datadog.jmxfetch.InstanceInitializingTask.call(InstanceInitializingTask.java:15)
        at org.datadog.jmxfetch.InstanceInitializingTask.call(InstanceInitializingTask.java:3)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```

After:
```
2019-04-11 18:03:10,754 | WARN | JmxAttribute | Unable to get metrics from org.datadog.jmxfetch.test:type=SimpleTestJavaApp - MyAwesomeMetric: java.lang.NumberFormatException: For input string: "ImNotANumber"
```