### PR TITLE
Use Lombok Builder for AppConfig, Formalize jvm_direct Connection

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -830,7 +830,7 @@ public class App {
 
             for (LinkedHashMap<String, Object> configInstance : configInstances) {
                 if (appConfig.isTargetDirectInstances() != isDirectInstance(configInstance)) {
-                    log.debug("Skipping instance '{}'. targetDirectInstances={} jvm_direct={}",
+                    log.info("Skipping instance '{}'. targetDirectInstances={} != jvm_direct={}",
                             name,
                             appConfig.isTargetDirectInstances(),
                             isDirectInstance(configInstance));

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -829,10 +829,10 @@ public class App {
             }
 
             for (LinkedHashMap<String, Object> configInstance : configInstances) {
-                if (appConfig.isAllowDirectInstances() != isDirectInstance(configInstance)) {
-                    log.debug("Skipping instance '{}'. allowDirectInstances={} jvm_direct={}",
+                if (appConfig.isTargetDirectInstances() != isDirectInstance(configInstance)) {
+                    log.debug("Skipping instance '{}'. targetDirectInstances={} jvm_direct={}",
                             name,
-                            appConfig.isAllowDirectInstances(),
+                            appConfig.isTargetDirectInstances(),
                             isDirectInstance(configInstance));
                     continue;
                 }

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -110,7 +110,7 @@ public class App {
     public static void main(String[] args) {
 
         // Load the config from the args
-        AppConfig config = new AppConfig();
+        AppConfig config = AppConfig.builder().build();
         JCommander commander = null;
         try {
             // Try to parse the args using JCommander

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -1,5 +1,7 @@
 package org.datadog.jmxfetch;
 
+import static org.datadog.jmxfetch.Instance.isDirectInstance;
+
 import com.google.common.primitives.Bytes;
 
 import com.beust.jcommander.JCommander;
@@ -827,8 +829,16 @@ public class App {
             }
 
             for (LinkedHashMap<String, Object> configInstance : configInstances) {
+                if (appConfig.isAllowDirectInstances() != isDirectInstance(configInstance)) {
+                    log.debug("Skipping instance '{}'. allowDirectInstances={} jvm_direct={}",
+                            name,
+                            appConfig.isAllowDirectInstances(),
+                            isDirectInstance(configInstance));
+                    continue;
+                }
+
                 // Create a new Instance object
-                log.info("Instantiating instance for: " + name);
+                log.info("Instantiating instance for: {}", name);
                 Instance instance =
                         instantiate(
                                 configInstance,

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -1,8 +1,5 @@
 package org.datadog.jmxfetch;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 
@@ -12,7 +9,6 @@ import org.datadog.jmxfetch.converter.ExitWatcherConverter;
 import org.datadog.jmxfetch.converter.ReporterConverter;
 import org.datadog.jmxfetch.reporter.ConsoleReporter;
 import org.datadog.jmxfetch.reporter.Reporter;
-import org.datadog.jmxfetch.reporter.ReporterFactory;
 import org.datadog.jmxfetch.validator.Log4JLevelValidator;
 import org.datadog.jmxfetch.validator.PositiveIntegerValidator;
 import org.datadog.jmxfetch.validator.ReporterValidator;
@@ -209,7 +205,7 @@ public class AppConfig {
      * If set to true, other instances will be ignored.
      */
     @Builder.Default
-    private boolean allowDirectInstances = false;
+    private boolean targetDirectInstances = false;
 
     // This is used by things like APM agent to provide configuration from resources
     private List<String> instanceConfigResources;
@@ -346,8 +342,8 @@ public class AppConfig {
         return getTmpDirectory() + "/" + AD_LAUNCH_FILE;
     }
 
-    public boolean isAllowDirectInstances() {
-        return allowDirectInstances;
+    public boolean isTargetDirectInstances() {
+        return targetDirectInstances;
     }
 
     public List<String> getInstanceConfigResources() {

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -204,6 +204,13 @@ public class AppConfig {
     @Builder.Default
     private int ipcPort = 0;
 
+    /**
+     * Boolean setting to determine whether to ignore jvm_direct instances.
+     * If set to true, other instances will be ignored.
+     */
+    @Builder.Default
+    private boolean allowDirectInstances = false;
+
     // This is used by things like APM agent to provide configuration from resources
     private List<String> instanceConfigResources;
     // This is used by things like APM agent to provide metric configuration from resources
@@ -337,6 +344,10 @@ public class AppConfig {
 
     public String getJmxLaunchFile() {
         return getTmpDirectory() + "/" + AD_LAUNCH_FILE;
+    }
+
+    public boolean isAllowDirectInstances() {
+        return allowDirectInstances;
     }
 
     public List<String> getInstanceConfigResources() {

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -6,6 +6,8 @@ import com.google.common.collect.ImmutableMap;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 
+import lombok.Builder;
+import lombok.ToString;
 import org.datadog.jmxfetch.converter.ExitWatcherConverter;
 import org.datadog.jmxfetch.converter.ReporterConverter;
 import org.datadog.jmxfetch.reporter.ConsoleReporter;
@@ -20,6 +22,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 
+@Builder
+@ToString
 @Parameters(separators = "=")
 public class AppConfig {
     public static final String ACTION_COLLECT = "collect";
@@ -69,6 +73,7 @@ public class AppConfig {
             description = "Level of verbosity",
             validateWith = Log4JLevelValidator.class,
             required = false)
+    @Builder.Default
     private String logLevel = "INFO";
 
     @Parameter(
@@ -87,6 +92,7 @@ public class AppConfig {
             names = {"--tmp_directory", "-T"},
             description = "Absolute path to a temporary directory",
             required = false)
+    @Builder.Default
     private String tmpDirectory = "/tmp";
 
     @Parameter(
@@ -110,6 +116,7 @@ public class AppConfig {
             description = "Sleeping time during two iterations in ms",
             validateWith = PositiveIntegerValidator.class,
             required = false)
+    @Builder.Default
     private int checkPeriod = 15000;
 
     @Parameter(
@@ -117,6 +124,7 @@ public class AppConfig {
             description = "The size of the thread pool",
             validateWith = PositiveIntegerValidator.class,
             required = false)
+    @Builder.Default
     private int threadPoolSize = DEFAULT_THREAD_POOL_SIZE;
 
     @Parameter(
@@ -124,6 +132,7 @@ public class AppConfig {
             description = "The size of the reconnection thread pool",
             validateWith = PositiveIntegerValidator.class,
             required = false)
+    @Builder.Default
     private int reconnectionThreadPoolSize = DEFAULT_THREAD_POOL_SIZE;
 
     @Parameter(
@@ -131,6 +140,7 @@ public class AppConfig {
             description = "The concurrent collection timeout in seconds",
             validateWith = PositiveIntegerValidator.class,
             required = false)
+    @Builder.Default
     private int collectionTimeout = DEFAULT_COLLECTION_TO_S;
 
     @Parameter(
@@ -138,18 +148,21 @@ public class AppConfig {
             description = "The reconnection timeout in seconds",
             validateWith = PositiveIntegerValidator.class,
             required = false)
+    @Builder.Default
     private int reconnectionTimeout = DEFAULT_RECONNECTION_TO_S;
 
     @Parameter(
             names = {"--ad_enabled", "--sd_enabled", "-w"},
             description = "Enable Auto Discovery.",
             required = false)
+    @Builder.Default
     private boolean adEnabled = false;
 
     @Parameter(
             names = {"--ad_pipe", "--sd_pipe", "-P"},
             description = "Auto Discovery pipe name.",
             required = false)
+    @Builder.Default
     private String adPipe = AD_PIPE_NAME;
 
     @Parameter(
@@ -166,6 +179,7 @@ public class AppConfig {
                             + "(default to null = no exit on file)",
             converter = ExitWatcherConverter.class,
             required = false)
+    @Builder.Default
     private ExitWatcher exitWatcher = new ExitWatcher();
 
     @Parameter(
@@ -174,7 +188,7 @@ public class AppConfig {
                     + "list_everything, list_collected_attributes, list_matching_attributes, "
                     + "list_not_matching_attributes, list_limited_attributes, list_jvms]",
             required = true)
-    private List<String> action = null;
+    private List<String> action;
 
     @Parameter(
             names = {"--ipc_host", "-H"},
@@ -187,6 +201,7 @@ public class AppConfig {
             description = "IPC port",
             validateWith = PositiveIntegerValidator.class,
             required = false)
+    @Builder.Default
     private int ipcPort = 0;
 
     // This is used by things like APM agent to provide configuration from resources
@@ -200,6 +215,7 @@ public class AppConfig {
     // This is used by things like APM agent to provide tags that should be set with all metrics
     private Map<String, String> globalTags;
 
+    @Builder.Default
     private Status status = new Status();
 
     /** Updates the status and returns a boolean describing if the status was indeed updated.. */
@@ -341,32 +357,5 @@ public class AppConfig {
 
     public Map<String, String> getGlobalTags() {
         return globalTags;
-    }
-
-    /** Factory method used by dd-tracer-agent to run jmxfetch in the same process. */
-    public static AppConfig create(
-            List<String> instanceConfigResources,
-            List<String> metricConfigResources,
-            List<String> metricConfigFiles,
-            Integer checkPeriod,
-            Integer refreshBeansPeriod,
-            Map<String, String> globalTags,
-            String reporter,
-            String logLocation,
-            String logLevel) {
-        AppConfig config = new AppConfig();
-        config.action = ImmutableList.of(ACTION_COLLECT);
-        config.instanceConfigResources = ImmutableList.copyOf(instanceConfigResources);
-        config.metricConfigResources = ImmutableList.copyOf(metricConfigResources);
-        config.metricConfigFiles = ImmutableList.copyOf(metricConfigFiles);
-        if (checkPeriod != null) {
-            config.checkPeriod = checkPeriod;
-        }
-        config.refreshBeansPeriod = refreshBeansPeriod;
-        config.globalTags = ImmutableMap.copyOf(globalTags);
-        config.reporter = ReporterFactory.getReporter(reporter);
-        config.logLocation = logLocation;
-        config.logLevel = logLevel;
-        return config;
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -374,7 +374,9 @@ public class Instance {
     /** Returns a string representation for the instance. */
     @Override
     public String toString() {
-        if (this.instanceMap.get(PROCESS_NAME_REGEX) != null) {
+        if (isDirectInstance(instanceMap)) {
+            return "jvm_direct";
+        } else if (this.instanceMap.get(PROCESS_NAME_REGEX) != null) {
             return "process_regex: `" + this.instanceMap.get(PROCESS_NAME_REGEX) + "`";
         } else if (this.instanceMap.get("jmx_url") != null) {
             return (String) this.instanceMap.get("jmx_url");

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -56,6 +56,7 @@ public class Instance {
     private static final int MAX_RETURNED_METRICS = 350;
     private static final int DEFAULT_REFRESH_BEANS_PERIOD = 600;
     public static final String PROCESS_NAME_REGEX = "process_name_regex";
+    public static final String JVM_DIRECT = "jvm_direct";
     public static final String ATTRIBUTE = "Attribute: ";
 
     private static final ThreadLocal<Yaml> YAML =
@@ -209,6 +210,11 @@ public class Instance {
         loadDefaultConfig(gcMetricConfig);
     }
 
+    public static boolean isDirectInstance(LinkedHashMap<String, Object> configInstance) {
+        Object directInstance = configInstance.get(JVM_DIRECT);
+        return directInstance instanceof Boolean && (Boolean) directInstance;
+    }
+
     private void loadDefaultConfig(String configResourcePath) {
         ArrayList<LinkedHashMap<String, Object>> defaultConf =
                 (ArrayList<LinkedHashMap<String, Object>>)
@@ -221,8 +227,11 @@ public class Instance {
     @VisibleForTesting
     static void loadMetricConfigFiles(
             AppConfig appConfig, LinkedList<Configuration> configurationList) {
-        if (appConfig.getMetricConfigFiles() != null) {
-            for (String fileName : appConfig.getMetricConfigFiles()) {
+        List<String> metricConfigFiles = appConfig.getMetricConfigFiles();
+        if (metricConfigFiles != null && !metricConfigFiles.isEmpty()) {
+            log.warn("Loading files via metricConfigFiles setting is deprecated.  Please "
+                    + "migrate to using standard agent config files in the conf.d directory.");
+            for (String fileName : metricConfigFiles) {
                 String yamlPath = new File(fileName).getAbsolutePath();
                 FileInputStream yamlInputStream = null;
                 log.info("Reading metric config file " + yamlPath);

--- a/src/main/java/org/datadog/jmxfetch/JvmDirectConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/JvmDirectConnection.java
@@ -6,9 +6,9 @@ import java.io.IOException;
 import java.lang.management.ManagementFactory;
 
 @Slf4j
-public class LocalConnection extends Connection {
+public class JvmDirectConnection extends Connection {
 
-    public LocalConnection() throws IOException {
+    public JvmDirectConnection() throws IOException {
         createConnection();
     }
 

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -3,6 +3,7 @@ package org.datadog.jmxfetch;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -490,6 +491,7 @@ public class TestApp extends TestCommon {
         registerMBean(testApp, "org.datadog.jmxfetch.test:type=SimpleTestJavaApp");
 
         // We do a first collection
+        when(appConfig.isAllowDirectInstances()).thenReturn(true);
         initApplication("jmx.yaml");
 
         run();

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -491,7 +491,7 @@ public class TestApp extends TestCommon {
         registerMBean(testApp, "org.datadog.jmxfetch.test:type=SimpleTestJavaApp");
 
         // We do a first collection
-        when(appConfig.isAllowDirectInstances()).thenReturn(true);
+        when(appConfig.isTargetDirectInstances()).thenReturn(true);
         initApplication("jmx.yaml");
 
         run();

--- a/src/test/java/org/datadog/jmxfetch/TestCommon.java
+++ b/src/test/java/org/datadog/jmxfetch/TestCommon.java
@@ -32,7 +32,7 @@ import org.junit.After;
 import org.junit.BeforeClass;
 
 public class TestCommon {
-    AppConfig appConfig = spy(new AppConfig());
+    AppConfig appConfig = spy(AppConfig.builder().build());
     App app;
     MBeanServer mbs;
     ArrayList<ObjectName> objectNames = new ArrayList<ObjectName>();

--- a/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
+++ b/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
@@ -28,7 +28,7 @@ public class TestParsingJCommander {
     private static final String IPC_PORT = "5001";
 
     private static AppConfig testCommand(String[] params) throws ParameterException {
-        AppConfig appConfig = new AppConfig();
+        AppConfig appConfig = AppConfig.builder().build();
         new JCommander(appConfig, params);
         return appConfig;
     }

--- a/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
+++ b/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
@@ -20,7 +20,7 @@ public class TestServiceChecks extends TestCommon {
         registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:type=ServiceCheckTest");
 
         // We do a first collection
-        when(appConfig.isAllowDirectInstances()).thenReturn(true);
+        when(appConfig.isTargetDirectInstances()).thenReturn(true);
         initApplication("jmx.yaml");
 
         run();
@@ -155,7 +155,7 @@ public class TestServiceChecks extends TestCommon {
 
     @Test
     public void testServiceCheckCounter() throws Exception {
-        when(appConfig.isAllowDirectInstances()).thenReturn(true);
+        when(appConfig.isTargetDirectInstances()).thenReturn(true);
         initApplication("jmx.yaml");
 
         Reporter repo = getReporter();

--- a/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
+++ b/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -19,6 +20,7 @@ public class TestServiceChecks extends TestCommon {
         registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:type=ServiceCheckTest");
 
         // We do a first collection
+        when(appConfig.isAllowDirectInstances()).thenReturn(true);
         initApplication("jmx.yaml");
 
         run();
@@ -153,6 +155,7 @@ public class TestServiceChecks extends TestCommon {
 
     @Test
     public void testServiceCheckCounter() throws Exception {
+        when(appConfig.isAllowDirectInstances()).thenReturn(true);
         initApplication("jmx.yaml");
 
         Reporter repo = getReporter();

--- a/src/test/java/org/datadog/jmxfetch/tasks/TestTaskProcessor.java
+++ b/src/test/java/org/datadog/jmxfetch/tasks/TestTaskProcessor.java
@@ -24,8 +24,8 @@ import org.junit.BeforeClass;
 public class TestTaskProcessor {
     private static List<Instance> instances = null;
 
-	class TestSimpleTask extends InstanceTask<Boolean> {
-         TestSimpleTask(Instance instance) {
+    class TestSimpleTask extends InstanceTask<Boolean> {
+        TestSimpleTask(Instance instance) {
              super(instance);
         }
 

--- a/src/test/resources/jmx.yaml
+++ b/src/test/resources/jmx.yaml
@@ -1,7 +1,7 @@
 init_config:
 
 instances:
-    -   process_name_regex: .*surefire.*
+    -   jvm_direct: true
         refresh_beans: 4
         name: jmx_test_instance
         tags:


### PR DESCRIPTION
Based on #223, so focus on last two commits for review.

Will be used in `dd-java-agent`. A future release can completely remove the `metricConfigFiles` setting (but not `metricConfigResources`).