### PR TITLE
Bump guava version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <apache-commons-lang3.version>3.5</apache-commons-lang3.version>
-        <guava.version>17.0</guava.version>
+        <guava.version>27.1-android</guava.version> <!-- From the docs: If you need support for JDK 1.7 or Android, use the Android flavor. -->
         <java-dogstatsd-client.version>2.7</java-dogstatsd-client.version>
         <jcommander.version>1.35</jcommander.version>
         <log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION
Using the `-android` version because it's compatible with Java 7

"If you need support for JDK 1.7 or Android, use the Android flavor."
From: https://github.com/google/guava/blob/master/README.md