### PR TITLE
only log check names instead of their config

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -732,7 +732,7 @@ public class App {
                 update = true;
                 log.info("update is in order - updating timestamp: " + lastJsonConfigTs);
                 for (String checkName : adJsonConfigs.keySet()) {
-                    log.debug("check " + checkName + " will be run");
+                    log.debug("received config for check '" + checkName + "'");
                 }
             }
         } catch (JsonProcessingException e) {

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -723,8 +723,6 @@ public class App {
                 return update;
             }
 
-            log.debug("Received the following JSON configs: " + response.getResponseBody());
-
             InputStream jsonInputStream = IOUtils.toInputStream(response.getResponseBody(), UTF_8);
             JsonParser parser = new JsonParser(jsonInputStream);
             int timestamp = ((Integer) parser.getJsonTimestamp()).intValue();
@@ -733,6 +731,9 @@ public class App {
                 lastJsonConfigTs = timestamp;
                 update = true;
                 log.info("update is in order - updating timestamp: " + lastJsonConfigTs);
+                for (String checkName : adJsonConfigs.keySet()) {
+                    log.debug("check " + checkName + " will be run");
+                }
             }
         } catch (JsonProcessingException e) {
             log.error("error processing JSON response: " + e);


### PR DESCRIPTION
### What does this PR do

Log updated list of checkName (it's actually `<checkName>_<configHash>`) instead of the complete JSON configs. The check name should be enough to link it to a template and get all the relevant informations.

Note that we were previously logging even if there wasn't an update. This seems useless.