### PR TITLE
Fix JMX metric name for G1GC old generation statistics.

### DIFF
--- a/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
+++ b/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
@@ -82,6 +82,17 @@
 - include:
     domain: java.lang
     type: GarbageCollector
+    name: G1 Mixed Generation
+    attribute:
+      CollectionCount:
+        alias: jvm.gc.major_collection_count
+        metric_type: counter
+      CollectionTime:
+        alias: jvm.gc.major_collection_time
+        metric_type: counter
+- include:
+    domain: java.lang
+    type: GarbageCollector
     name: G1 Old Generation
     attribute:
       CollectionCount:

--- a/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
+++ b/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
@@ -82,7 +82,7 @@
 - include:
     domain: java.lang
     type: GarbageCollector
-    name: G1 Mixed Generation
+    name: G1 Old Generation
     attribute:
       CollectionCount:
         alias: jvm.gc.major_collection_count


### PR DESCRIPTION
Fixes #230 