### PR TITLE
[App] Fix help command

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -123,7 +123,7 @@ public class App {
         }
 
         // Display the version and quit
-        if (config.isVersion() || AppConfig.ACTION_HELP.equals(config.getAction())) {
+        if (config.isVersion() || AppConfig.ACTION_VERSION.equals(config.getAction())) {
             JCommander.getConsole().println("JMX Fetch " + getVersion());
             System.exit(0);
         }


### PR DESCRIPTION
### What does this PR do?

Fix the behavior of the `help` command so that it indeed prints the help text.

### Motivation

The `help` command returned the result of the `version` / `--version` commands
because of a copy/paste oversight (this didn't affect `--help`).