### PR TITLE
[circleci] Sync releases with mavencentral

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,18 @@ jobs:
       - attach_workspace:
           at: .
 
-      - run: mvn validate jar:jar source:jar javadoc:jar assembly:single deploy:deploy -e --settings ./settings.xml
-        
+      - run:
+          name: Deploy to bintray
+          command: mvn validate jar:jar source:jar javadoc:jar assembly:single deploy:deploy -e --settings ./settings.xml
+      - run:
+          name: Sync with mavencentral
+          command: |
+            VERSION=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)
+            curl -X POST -H "Content-Type: application/json" \
+            --user ${BINTRAY_USER}:${BINTRAY_API_KEY} \
+            --data "{\"username\":\"${SONATYPE_USER}\", \"password\":\"${SONATYPE_PWD}\"}" \
+            https://api.bintray.com/maven_central_sync/datadog/datadog-maven/jmxfetch/versions/$VERSION
+
 workflows:
   version: 2
   build_test_deploy:


### PR DESCRIPTION
### What does this PR do?

Adds a step in the deploy job that uses bintray's "Sync with Maven Central" feature to also release JMXFetch on Maven Central.

### Motivation 

Currently, the JMXFetch releases are only put on bintray.

### Additional Notes

It is possible to release the missing versions of JMXFetch to Maven Central manually by running locally the commands of the added step.