### PR TITLE
[docs] Use Agent 6 github repository link in description

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 # JMXFetch
 
 JMXFetch is the new tool to collect metrics from JMX Servers in order to be sent to Datadog (http://www.datadoghq.com)
-It is called by the Datadog Agent (https://github.com/Datadog/dd-agent) and sends metrics back to the Agent using the [Java `dogstatsd` library](https://github.com/datadog/java-dogstatsd-client).
+It is called by the Datadog Agent (https://github.com/Datadog/datadog-agent) and sends metrics back to the Agent using the [Java `dogstatsd` library](https://github.com/datadog/java-dogstatsd-client).
 
 # How to contribute code?
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
 
     <name>jmxfetch</name>
     <description>JMXFetch is the new tool to collect metrics from JMX Servers in order to be sent to Datadog
-        (http://www.datadoghq.com) It is called by the Datadog Agent (https://github.com/Datadog/dd-agent) and sends
-        metrics back to the Agent using the Java dogstatsd library.
+        (http://www.datadoghq.com) It is called by the Datadog Agent (https://github.com/Datadog/datadog-agent) and sends
+        metrics back to the Agent using the Java dogstatsd library (https://github.com/datadog/java-dogstatsd-client).
     </description>
     <url>https://github.com/DataDog/jmxfetch</url>
 


### PR DESCRIPTION
### What does this PR do?

Update the POM and Readme description to mention the current active `datadog-agent` repository.

### Motivation

Because it seems strange to mention the old repo in our Readme and in the package description that's publicly available.