### PR TITLE
Enable launch of jmxfetch app's executors as daemon, default to NO-daemon

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -293,7 +293,7 @@ public class App {
 
     /**
      * Builds an {@link ExecutorService} of the specified fixed size. Threads will be created
-     * and executed as daemons the if {@link AppConfig#isDaemon()} is true. Defaults to false.
+     * and executed as daemons if {@link AppConfig#isDaemon()} is true. Defaults to false.
      *
      * @param size The thread pool size
      * @return The create executor

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -208,8 +208,9 @@ public class AppConfig {
     private boolean targetDirectInstances = false;
 
     /**
-     * Boolean setting to determine whether to ignore jvm_direct instances.
-     * If set to true, other instances will be ignored.
+     * Boolean setting to determine whether internal executors are launched as daemons or not.
+     * This is usefull when JMXFetch is embedded in a client app, e.g. for the java tracer,
+     * so that the client app's exit doesn't block on the termination of these internal threads.
      */
     @Builder.Default
     private boolean daemon = false;

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -373,6 +373,9 @@ public class AppConfig {
         return globalTags;
     }
 
+    /**
+     * @return Whether or not internal threads will be run as daemon.
+     */
     public boolean isDaemon() {
         return daemon;
     }

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -207,6 +207,13 @@ public class AppConfig {
     @Builder.Default
     private boolean targetDirectInstances = false;
 
+    /**
+     * Boolean setting to determine whether to ignore jvm_direct instances.
+     * If set to true, other instances will be ignored.
+     */
+    @Builder.Default
+    private boolean daemon = false;
+
     // This is used by things like APM agent to provide configuration from resources
     private List<String> instanceConfigResources;
     // This is used by things like APM agent to provide metric configuration from resources
@@ -364,5 +371,9 @@ public class AppConfig {
 
     public Map<String, String> getGlobalTags() {
         return globalTags;
+    }
+
+    public boolean isDaemon() {
+        return daemon;
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -209,7 +209,7 @@ public class AppConfig {
 
     /**
      * Boolean setting to determine whether internal executors are launched as daemons or not.
-     * This is usefull when JMXFetch is embedded in a client app, e.g. for the java tracer,
+     * This is useful when JMXFetch is embedded in a client app, e.g. for the java tracer,
      * so that the client app's exit doesn't block on the termination of these internal threads.
      */
     @Builder.Default

--- a/src/main/java/org/datadog/jmxfetch/tasks/TaskProcessor.java
+++ b/src/main/java/org/datadog/jmxfetch/tasks/TaskProcessor.java
@@ -37,7 +37,7 @@ public class TaskProcessor {
      * */
     public boolean ready() {
         ThreadPoolExecutor tpe = (ThreadPoolExecutor) threadPoolExecutor;
-        return !(tpe.getMaximumPoolSize() == tpe.getActiveCount());
+        return !tpe.isTerminated() && !(tpe.getMaximumPoolSize() == tpe.getActiveCount());
     }
 
     /**


### PR DESCRIPTION
When embedding the jmxfetch app in dd-trce-java we noticed that even if
we run it in a thread marked as daemon, the jmxfetch app was not terminating
when the main method exited.

After some investigation we noticed that threads in tasks executors were
keeping the thread alive.

This PR DOES NOT change the default behavior, were executors are run as
non-daemons. Adds the possibility, though, to be configured to be
executed as daemon.