### PR TITLE
Update .travis.yml dist from precise to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: precise
+dist: xenial
 
 language: java
 


### PR DESCRIPTION
## What this PR does

Update linux distribution used for Travis runner.

## Motivation

Just saw this message on Travis build for `jmxfetch`:

>  This job is running on our Precise environment, which is in the process of being decommissioned. Please update to a newer Ubuntu version by specifying dist: xenial in your .travis.yml.

Example: https://travis-ci.com/DataDog/jmxfetch/jobs/213017660

![image](https://user-images.githubusercontent.com/49917914/60610701-b35edc00-9dc4-11e9-994f-45d7b21a4bce.png)
