### PR TITLE
Add the ability to list metrics

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -8,6 +8,7 @@ import lombok.ToString;
 import org.datadog.jmxfetch.converter.ExitWatcherConverter;
 import org.datadog.jmxfetch.converter.ReporterConverter;
 import org.datadog.jmxfetch.reporter.ConsoleReporter;
+import org.datadog.jmxfetch.reporter.JsonReporter;
 import org.datadog.jmxfetch.reporter.Reporter;
 import org.datadog.jmxfetch.validator.Log4JLevelValidator;
 import org.datadog.jmxfetch.validator.PositiveIntegerValidator;
@@ -27,6 +28,7 @@ public class AppConfig {
     public static final String ACTION_LIST_EVERYTHING = "list_everything";
     public static final String ACTION_LIST_COLLECTED = "list_collected_attributes";
     public static final String ACTION_LIST_MATCHING = "list_matching_attributes";
+    public static final String ACTION_LIST_WITH_METRICS = "list_with_metrics";
     public static final String ACTION_LIST_NOT_MATCHING = "list_not_matching_attributes";
     public static final String ACTION_LIST_LIMITED = "list_limited_attributes";
     public static final String ACTION_HELP = "help";
@@ -38,6 +40,7 @@ public class AppConfig {
                             ACTION_LIST_EVERYTHING,
                             ACTION_LIST_COLLECTED,
                             ACTION_LIST_MATCHING,
+                            ACTION_LIST_WITH_METRICS,
                             ACTION_LIST_NOT_MATCHING,
                             ACTION_LIST_LIMITED,
                             ACTION_HELP,
@@ -94,7 +97,8 @@ public class AppConfig {
     @Parameter(
             names = {"--reporter", "-r"},
             description =
-                    "Reporter to use: should be either \"statsd:[STATSD_PORT]\" or \"console\"",
+                    "Reporter to use: should be either \"statsd:[STATSD_PORT]\", "
+                     + "\"console\" or \"json\"",
             validateWith = ReporterValidator.class,
             converter = ReporterConverter.class,
             required = false)
@@ -182,7 +186,8 @@ public class AppConfig {
             description =
                     "Action to take, should be in [help, collect, "
                     + "list_everything, list_collected_attributes, list_matching_attributes, "
-                    + "list_not_matching_attributes, list_limited_attributes, list_jvms]",
+                    + "list_with_metrics, list_not_matching_attributes, "
+                    + "list_limited_attributes, list_jvms]",
             required = true)
     private List<String> action;
 
@@ -260,6 +265,10 @@ public class AppConfig {
 
     public boolean isConsoleReporter() {
         return reporter != null && (reporter instanceof ConsoleReporter);
+    }
+
+    public boolean isJsonReporter() {
+        return reporter != null && (reporter instanceof JsonReporter);
     }
 
     public boolean isHelp() {

--- a/src/main/java/org/datadog/jmxfetch/ConnectionFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/ConnectionFactory.java
@@ -28,7 +28,7 @@ public class ConnectionFactory {
             } catch (ClassNotFoundException e) {
                 throw new IOException(
                         "Unable to find tools.jar."
-                                + " Are you using a JDK and did you set the pass to tools.jar ?");
+                                + " Are you using a JDK and did you set the path to tools.jar ?");
             }
             log.info("Connecting using Attach API");
             return new AttachApiConnection(connectionParams);

--- a/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
@@ -223,7 +223,7 @@ public abstract class JmxAttribute {
         return metricName;
     }
 
-    /** Returns string reprensentation of JMX Attribute. */
+    /** Returns string representation of JMX Attribute. */
     @Override
     public String toString() {
         return "Bean name: "

--- a/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
@@ -1,0 +1,70 @@
+package org.datadog.jmxfetch.reporter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import lombok.extern.slf4j.Slf4j;
+
+import org.datadog.jmxfetch.Instance;
+import org.datadog.jmxfetch.JmxAttribute;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+@Slf4j
+public class JsonReporter extends Reporter {
+
+    private LinkedList<HashMap<String, Object>> metrics = new LinkedList<HashMap<String, Object>>();
+
+    protected void sendMetricPoint(
+            String metricType, String metricName, double value, String[] tags) {
+        long currentTime = System.currentTimeMillis() / 1000L;
+        List<Object> point = new ArrayList<Object>();
+        point.add(currentTime);
+        point.add(value);
+        List<Object> points = new ArrayList<Object>();
+        points.add(point);
+        HashMap<String, Object> metric = new HashMap<String, Object>();
+        metric.put("host", "default");
+        metric.put("interval", 0);
+        metric.put("source_type_name", "JMX");
+        metric.put("metric", metricName);
+        metric.put("points", points);
+        metric.put("tags", tags);
+        metric.put("type", metricType);
+        metrics.add(metric);
+    }
+
+    /** Use the service check callback to display the JSON. */
+    public void doSendServiceCheck(String checkName, String status, String message, String[] tags) {
+        HashMap<String, Object> aggregator = new HashMap<String, Object>();
+        aggregator.put("metrics", metrics);
+        HashMap<String, Object> serie = new HashMap<String, Object>();
+        serie.put("aggregator", aggregator);
+        List<Object> series = new ArrayList<Object>();
+        series.add(serie);
+
+        System.out.println("=== JSON ===");
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        try {
+            mapper.writeValue(System.out, series);
+        } catch (IOException e) {
+            log.error("Couln't produce JSON output");
+        }
+    }
+
+    public void displayMetricReached() {
+    }
+
+    public void displayMatchingAttributeName(JmxAttribute jmxAttribute, int rank, int limit) {
+    }
+
+    public void displayNonMatchingAttributeName(JmxAttribute jmxAttribute) {
+    }
+
+    public void displayInstanceName(Instance instance) {
+    }
+}

--- a/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
@@ -13,6 +13,8 @@ public class ReporterFactory {
         }
         if ("console".equals(type)) {
             return new ConsoleReporter();
+        } else if ("json".equals(type)) {
+            return new JsonReporter();
         } else if (type.startsWith("statsd:")) {
             String[] typeElements = type.split(":");
             String host = "localhost";

--- a/src/main/java/org/datadog/jmxfetch/validator/ReporterValidator.java
+++ b/src/main/java/org/datadog/jmxfetch/validator/ReporterValidator.java
@@ -22,11 +22,11 @@ public class ReporterValidator implements IParameterValidator {
             }
             return;
         }
-        if (!value.equals("console")) {
+        if (!value.equals("console") && !value.equals("json")) {
             throw new ParameterException(
                     "Parameter "
                             + name
-                            + " should be either 'console', 'statsd:[STATSD_PORT]' "
+                            + " should be either 'console', 'json', 'statsd:[STATSD_PORT]' "
                             + "or 'statsd:[STATSD_HOST]:[STATSD_PORT]'");
         }
     }

--- a/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
+++ b/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
@@ -212,7 +212,7 @@ public class TestParsingJCommander {
             fail("Should have failed because reporter is invalid");
         } catch (ParameterException pe) {
             assertEquals(
-                    "Parameter --reporter should be either 'console', 'statsd:[STATSD_PORT]' or 'statsd:[STATSD_HOST]:[STATSD_PORT]'",
+                    "Parameter --reporter should be either 'console', 'json', 'statsd:[STATSD_PORT]' or 'statsd:[STATSD_HOST]:[STATSD_PORT]'",
                     pe.getMessage());
         }
 
@@ -432,7 +432,7 @@ public class TestParsingJCommander {
             String expectedMessage =
                     "Main parameters are required (\"Action to take, should be in [help, collect, "
                             + "list_everything, list_collected_attributes, list_matching_attributes, "
-                            + "list_not_matching_attributes, list_limited_attributes, list_jvms]\")";
+			    + "list_with_metrics, list_not_matching_attributes, list_limited_attributes, list_jvms]\")";
             assertEquals(expectedMessage, pe.getMessage());
         }
 
@@ -451,7 +451,7 @@ public class TestParsingJCommander {
             String expectedMessage =
                     "Main parameters are required (\"Action to take, should be in [help, collect, "
                             + "list_everything, list_collected_attributes, list_matching_attributes, "
-                            + "list_not_matching_attributes, list_limited_attributes, list_jvms]\")";
+                            + "list_with_metrics, list_not_matching_attributes, list_limited_attributes, list_jvms]\")";
             assertEquals(expectedMessage, pe.getMessage());
         }
     }


### PR DESCRIPTION
This adds a new command and a new reporter to mimic the behavior of
`agent check`. The idea is to be able to parse the content the same way.