### PR TITLE
bump dogstatsd client to 2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
         <commons-lang.version>2.6</commons-lang.version>
         <apache-commons-lang3.version>3.5</apache-commons-lang3.version>
         <guava.version>27.1-android</guava.version> <!-- From the docs: If you need support for JDK 1.7 or Android, use the Android flavor. -->
-        <java-dogstatsd-client.version>2.7</java-dogstatsd-client.version>
+        <java-dogstatsd-client.version>2.8</java-dogstatsd-client.version>
         <jcommander.version>1.35</jcommander.version>
         <log4j.version>1.2.17</log4j.version>
         <jackson.version>2.9.9</jackson.version>

--- a/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
+++ b/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
@@ -430,7 +430,7 @@ public class TestParsingJCommander {
             fail("Should have failed because action was not provided.");
         } catch (ParameterException pe) {
             String expectedMessage =
-                    "Main parameters are required (\"Action to take, should be in [help, collect, "
+                    "Main parameters are required (\"Action to take, should be in [help, version, collect, "
                             + "list_everything, list_collected_attributes, list_matching_attributes, "
                             + "list_not_matching_attributes, list_limited_attributes, list_jvms]\")";
             assertEquals(expectedMessage, pe.getMessage());
@@ -449,7 +449,7 @@ public class TestParsingJCommander {
             fail("Should have failed because action is not a valid one");
         } catch (ParameterException pe) {
             String expectedMessage =
-                    "Main parameters are required (\"Action to take, should be in [help, collect, "
+                    "Main parameters are required (\"Action to take, should be in [help, version, collect, "
                             + "list_everything, list_collected_attributes, list_matching_attributes, "
                             + "list_not_matching_attributes, list_limited_attributes, list_jvms]\")";
             assertEquals(expectedMessage, pe.getMessage());


### PR DESCRIPTION
### What does this PR do ?

Bumps the dogstatsd client to version 2.8 in order to support origin detection over UDP in the java tracer.

Also fixes the tests