### PR TITLE
Use the name if provided to identify the instance in toString()

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -389,6 +389,8 @@ public class Instance {
             return "jvm_direct";
         } else if (this.instanceMap.get(PROCESS_NAME_REGEX) != null) {
             return "process_regex: `" + this.instanceMap.get(PROCESS_NAME_REGEX) + "`";
+        } else if (this.instanceMap.get("name") != null) {
+            return (String) this.instanceMap.get("name");
         } else if (this.instanceMap.get("jmx_url") != null) {
             return (String) this.instanceMap.get("jmx_url");
         } else {


### PR DESCRIPTION
When a JMX check is running on an `address:port` and no other identifiers is provided, the `address:port` is used as an identifier.

However, it could not be unique because we want to be able to run multiple JMX instances on the same JVM.

This PR modify the `Instance.toString()` method to use the name if one has been provided in the instance configuration, letting somebody run multiple instances of jmxfetch listening to the same JVM if a name is provided on the instances.

Would provide a clean workaround for #253 