### PR TITLE
Add Embedded mode

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -220,6 +220,14 @@ public class AppConfig {
     @Builder.Default
     private boolean daemon = false;
 
+    /**
+     * Boolean setting to determine whether JMXFetch is embedded in a client app, e.g. for the java
+     * tracer. This setting is uncoupled from daemon one, even though very similar. This setting
+     * is used to reduce number of threads used by assuming the JMX connection will be local.
+     */
+    @Builder.Default
+    private boolean embedded = false;
+
     // This is used by things like APM agent to provide configuration from resources
     private List<String> instanceConfigResources;
     // This is used by things like APM agent to provide metric configuration from resources
@@ -388,5 +396,9 @@ public class AppConfig {
      */
     public boolean isDaemon() {
         return daemon;
+    }
+
+    public boolean isEmbedded() {
+        return embedded;
     }
 }

--- a/src/test/java/org/datadog/jmxfetch/tasks/TestTaskProcessor.java
+++ b/src/test/java/org/datadog/jmxfetch/tasks/TestTaskProcessor.java
@@ -100,17 +100,7 @@ public class TestTaskProcessor {
                         return TestTaskProcessor.processTestResults(instance, future, reporter);
                     };
                 });
-
-        // this should all be green
-        for (int i=0 ; i<statuses.size(); i++) {
-
-            TaskStatusHandler status = statuses.get(i);
-
-            status.raiseForStatus();
-
-            // It should be true - both instances ready to collect
-            assertTrue((Boolean)status.getData());
-        }
+        assertAllStatusGreen(statuses);
     }
 
     /**
@@ -153,6 +143,34 @@ public class TestTaskProcessor {
                 // only third instance should timeout given test structure.
                 assertEquals(i, 2);
             }
+        }
+    }
+
+    @Test
+    public void embeddedTaskProcessor() throws Throwable {
+        // null executor means embedded mode
+        TaskProcessor testProcessor = new TaskProcessor(null, null);
+        List<InstanceTask<Boolean>> instanceTestTasks = new ArrayList<InstanceTask<Boolean>>();
+        for (Instance instance: instances) {
+            instanceTestTasks.add(new TestSimpleTask(instance));
+        }
+        List<TaskStatusHandler> statuses = testProcessor.processTasks(
+                instanceTestTasks, 0, TimeUnit.SECONDS,
+                new TaskMethod<Boolean>() {
+                    @Override
+                    public TaskStatusHandler invoke(Instance instance, Future<Boolean> future, Reporter reporter) {
+                        return TestTaskProcessor.processTestResults(instance, future, reporter);
+                    };
+                });
+        assertTrue(statuses.size() > 0);
+        assertAllStatusGreen(statuses);
+
+    }
+
+    private void assertAllStatusGreen(List<TaskStatusHandler> statuses) throws Throwable {
+        for (TaskStatusHandler status : statuses) {
+            status.raiseForStatus();
+            assertTrue((Boolean)status.getData());
         }
     }
 }


### PR DESCRIPTION
When JMXFetch is embedded into the client app through tracer agent for example, we want to have a special mode
to avoid creating thread pools that are only used for dealing with JMX remote connections
TaskProcessor is taking care of the case where there is no ThreadPoolExecutor and calling tasks by the calling thread