### PR TITLE
add entity-id by default to the dogstatsdclient

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -35,6 +35,10 @@ public class StatsdReporter extends Reporter {
 
     private void init() {
         initializationTime = System.currentTimeMillis();
+
+        // Only set the entityID to "none" if UDS communication is activated
+        String entityID = this.statsdPort == 0 ? "none" : null;
+
         /* Create the StatsDClient with "entity-id" set to "none" to avoid
            having dogstatsd server adding origin tags, when the connection is
            done with UDS. */
@@ -46,7 +50,7 @@ public class StatsdReporter extends Reporter {
                         Integer.MAX_VALUE,
                         new String[] {},
                         new LoggingErrorHandler(),
-                        "none");
+                        entityID);
     }
 
     protected void sendMetricPoint(

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -35,13 +35,18 @@ public class StatsdReporter extends Reporter {
 
     private void init() {
         initializationTime = System.currentTimeMillis();
+        /* Create the StatsDClient with "entity-id" set to "none" to avoid
+           having dogstatsd server adding origin tags, when the connection is
+           done with UDS. */
         statsDClient =
                 new NonBlockingStatsDClient(
                         null,
                         this.statsdHost,
                         this.statsdPort,
+                        Integer.MAX_VALUE,
                         new String[] {},
-                        new LoggingErrorHandler());
+                        new LoggingErrorHandler(),
+                        "none");
     }
 
     protected void sendMetricPoint(


### PR DESCRIPTION
Create the StatsDClient with "entity-id" set to "none" to avoid having dogstatsd server adding origin tags, when the connection is done with UDS.