### PR TITLE
Fix getTagsMap generic parameter handling

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -316,14 +316,14 @@ public class Instance {
             tags.putAll(appConfig.getGlobalTags());
         }
         if (tagsMap != null) {
-            try {
-                // Input has `Map` format
+            if (tagsMap instanceof Map) {
                 tags.putAll((Map<String, String>) tagsMap);
-            } catch (ClassCastException e) {
-                // Input has `List` format
+            } else if (tagsMap instanceof List) {
                 for (String tag : (List<String>) tagsMap) {
                     tags.put(tag, null);
                 }
+            } else {
+                log.warn("Unsupported type for tagsMap: " + tagsMap.getClass().getCanonicalName());
             }
         }
         return tags;


### PR DESCRIPTION
Instead of recovering on ClassCastException to fallback on List
handling, use instanceof to determine the type of tagsMap