### PR TITLE
Replace LinkedHashMap by HashMap or Map

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -35,7 +35,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
@@ -809,8 +808,8 @@ public class App {
     }
 
     private Instance instantiate(
-            LinkedHashMap<String, Object> instanceMap,
-            LinkedHashMap<String, Object> initConfig,
+            Map<String, Object> instanceMap,
+            Map<String, Object> initConfig,
             String checkName,
             AppConfig appConfig) {
 
@@ -859,8 +858,8 @@ public class App {
                 it.remove();
             }
 
-            ArrayList<LinkedHashMap<String, Object>> configInstances =
-                    ((ArrayList<LinkedHashMap<String, Object>>) yamlConfig.getYamlInstances());
+            ArrayList<Map<String, Object>> configInstances =
+                    ((ArrayList<Map<String, Object>>) yamlConfig.getYamlInstances());
             if (configInstances == null || configInstances.size() == 0) {
                 String warning = "No instance found in :" + name;
                 log.warn(warning);
@@ -868,7 +867,7 @@ public class App {
                 continue;
             }
 
-            for (LinkedHashMap<String, Object> configInstance : configInstances) {
+            for (Map<String, Object> configInstance : configInstances) {
                 if (appConfig.isTargetDirectInstances() != isDirectInstance(configInstance)) {
                     log.info("Skipping instance '{}'. targetDirectInstances={} != jvm_direct={}",
                             name,
@@ -882,7 +881,7 @@ public class App {
                 Instance instance =
                         instantiate(
                                 configInstance,
-                                (LinkedHashMap<String, Object>) yamlConfig.getInitConfig(),
+                                (Map<String, Object>) yamlConfig.getInitConfig(),
                                 name,
                                 appConfig);
                 newInstances.add(instance);
@@ -895,12 +894,12 @@ public class App {
             for (String check : adJsonConfigs.keySet()) {
                 HashMap<String, Object> checkConfig =
                         (HashMap<String, Object>) adJsonConfigs.get(check);
-                LinkedHashMap<String, Object> initConfig =
-                        (LinkedHashMap<String, Object>) checkConfig.get("init_config");
-                ArrayList<LinkedHashMap<String, Object>> configInstances =
-                        (ArrayList<LinkedHashMap<String, Object>>) checkConfig.get("instances");
+                Map<String, Object> initConfig =
+                        (Map<String, Object>) checkConfig.get("init_config");
+                ArrayList<Map<String, Object>> configInstances =
+                        (ArrayList<Map<String, Object>>) checkConfig.get("instances");
                 String checkName = (String) checkConfig.get("check_name");
-                for (LinkedHashMap<String, Object> configInstance : configInstances) {
+                for (Map<String, Object> configInstance : configInstances) {
                     log.info("Instantiating instance for: " + checkName);
                     Instance instance =
                             instantiate(configInstance, initConfig, checkName, appConfig);

--- a/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
+import java.util.Map;
 import javax.management.remote.JMXServiceURL;
 
 @Slf4j
@@ -15,14 +15,14 @@ public class AttachApiConnection extends Connection {
     private String processRegex;
 
     /** AttachApiConnection constructor for specified connection parameters. */
-    public AttachApiConnection(LinkedHashMap<String, Object> connectionParams) throws IOException {
+    public AttachApiConnection(Map<String, Object> connectionParams) throws IOException {
         processRegex = (String) connectionParams.get("process_name_regex");
         this.env = new HashMap<String, Object>();
         this.address = getAddress(connectionParams);
         createConnection();
     }
 
-    private JMXServiceURL getAddress(LinkedHashMap<String, Object> connectionParams)
+    private JMXServiceURL getAddress(Map<String, Object> connectionParams)
             throws IOException {
         JMXServiceURL address;
         try {

--- a/src/main/java/org/datadog/jmxfetch/Configuration.java
+++ b/src/main/java/org/datadog/jmxfetch/Configuration.java
@@ -4,14 +4,14 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
 public class Configuration {
 
-    private LinkedHashMap<String, Object> conf;
+    private Map<String, Object> conf;
     private Filter include;
     private Filter exclude;
 
@@ -20,13 +20,13 @@ public class Configuration {
      *
      * <p>Also provides helper methods to extract common information among filters.
      */
-    public Configuration(LinkedHashMap<String, Object> conf) {
+    public Configuration(Map<String, Object> conf) {
         this.conf = conf;
         this.include = new Filter(conf.get("include"));
         this.exclude = new Filter(conf.get("exclude"));
     }
 
-    public LinkedHashMap<String, Object> getConf() {
+    public Map<String, Object> getConf() {
         return conf;
     }
 
@@ -123,9 +123,9 @@ public class Configuration {
      * @param filtersByDomain filters by domain name
      * @return common bean key parameters by domain name
      */
-    private static HashMap<String, Set<String>> getCommonBeanKeysByDomain(
-            HashMap<String, LinkedList<Filter>> filtersByDomain) {
-        HashMap<String, Set<String>> beanKeysIntersectionByDomain =
+    private static Map<String, Set<String>> getCommonBeanKeysByDomain(
+            Map<String, LinkedList<Filter>> filtersByDomain) {
+        Map<String, Set<String>> beanKeysIntersectionByDomain =
                 new HashMap<String, Set<String>>();
 
         for (Entry<String, LinkedList<Filter>> filtersEntry : filtersByDomain.entrySet()) {
@@ -158,19 +158,19 @@ public class Configuration {
      * @param filtersByDomain filters by domain name
      * @return bean pattern (keys->values) by domain name
      */
-    private static HashMap<String, LinkedHashMap<String, String>> getCommonScopeByDomain(
-            HashMap<String, Set<String>> beanKeysByDomain,
-            HashMap<String, LinkedList<Filter>> filtersByDomain) {
+    private static Map<String, Map<String, String>> getCommonScopeByDomain(
+            Map<String, Set<String>> beanKeysByDomain,
+            Map<String, LinkedList<Filter>> filtersByDomain) {
         // Compute a common scope a among filters by domain name
-        HashMap<String, LinkedHashMap<String, String>> commonScopeByDomain =
-                new HashMap<String, LinkedHashMap<String, String>>();
+        Map<String, Map<String, String>> commonScopeByDomain =
+                new HashMap<String, Map<String, String>>();
 
         for (Entry<String, Set<String>> commonParametersByDomainEntry :
                 beanKeysByDomain.entrySet()) {
             String domainName = commonParametersByDomainEntry.getKey();
             Set<String> commonParameters = commonParametersByDomainEntry.getValue();
             LinkedList<Filter> filters = filtersByDomain.get(domainName);
-            LinkedHashMap<String, String> commonScope = new LinkedHashMap<String, String>();
+            Map<String, String> commonScope = new HashMap<String, String>();
 
             for (String parameter : commonParameters) {
                 // Check if all values associated with the parameters are the same
@@ -206,7 +206,7 @@ public class Configuration {
      * @return string pattern identifying the bean scope
      */
     private static String beanScopeToString(
-            String domain, LinkedHashMap<String, String> beanScope) {
+            String domain, Map<String, String> beanScope) {
         String result = "";
 
         // Domain
@@ -235,19 +235,19 @@ public class Configuration {
             LinkedList<Configuration> configurationList) {
         LinkedList<Configuration> includeConfigList =
                 getIncludeConfigurationList(configurationList);
-        HashMap<String, LinkedList<Filter>> includeFiltersByDomain =
+        Map<String, LinkedList<Filter>> includeFiltersByDomain =
                 getIncludeFiltersByDomain(includeConfigList);
-        HashMap<String, Set<String>> parametersIntersectionByDomain =
+        Map<String, Set<String>> parametersIntersectionByDomain =
                 getCommonBeanKeysByDomain(includeFiltersByDomain);
-        HashMap<String, LinkedHashMap<String, String>> commonBeanScopeByDomain =
+        Map<String, Map<String, String>> commonBeanScopeByDomain =
                 getCommonScopeByDomain(parametersIntersectionByDomain, includeFiltersByDomain);
 
         LinkedList<String> result = new LinkedList<String>();
 
-        for (Entry<String, LinkedHashMap<String, String>> beanScopeEntry :
+        for (Entry<String, Map<String, String>> beanScopeEntry :
                 commonBeanScopeByDomain.entrySet()) {
             String domain = beanScopeEntry.getKey();
-            LinkedHashMap<String, String> beanScope = beanScopeEntry.getValue();
+            Map<String, String> beanScope = beanScopeEntry.getValue();
 
             result.add(beanScopeToString(domain, beanScope));
         }

--- a/src/main/java/org/datadog/jmxfetch/ConnectionFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/ConnectionFactory.java
@@ -5,7 +5,7 @@ import static org.datadog.jmxfetch.Instance.isDirectInstance;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
-import java.util.LinkedHashMap;
+import java.util.Map;
 
 /** Singleton used to create connections to the MBeanServer. */
 @Slf4j
@@ -13,7 +13,7 @@ public class ConnectionFactory {
     public static final String PROCESS_NAME_REGEX = "process_name_regex";
 
     /** Factory method to create connections, both remote and local to the target JVM. */
-    public static Connection createConnection(LinkedHashMap<String, Object> connectionParams)
+    public static Connection createConnection(Map<String, Object> connectionParams)
             throws IOException {
         // This is used by dd-java-agent to enable directly connecting to the mbean server.
         // This works since jmxfetch is being run as a library inside the process being monitored.

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -3,7 +3,6 @@ package org.datadog.jmxfetch;
 import com.google.common.annotations.VisibleForTesting;
 
 import lombok.extern.slf4j.Slf4j;
-
 import org.datadog.jmxfetch.reporter.Reporter;
 import org.yaml.snakeyaml.Yaml;
 
@@ -17,7 +16,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -87,10 +85,10 @@ public class Instance {
     private long lastCollectionTime;
     private Integer minCollectionPeriod;
     private long lastRefreshTime;
-    private LinkedHashMap<String, Object> instanceMap;
-    private LinkedHashMap<String, Object> initConfig;
+    private Map<String, Object> instanceMap;
+    private Map<String, Object> initConfig;
     private String instanceName;
-    private LinkedHashMap<String, String> tags;
+    private Map<String, String> tags;
     private String checkName;
     private int maxReturnedMetrics;
     private boolean limitReached;
@@ -103,10 +101,10 @@ public class Instance {
     public Instance(Instance instance, AppConfig appConfig) {
         this(
                 instance.getInstanceMap() != null
-                        ? new LinkedHashMap<String, Object>(instance.getInstanceMap())
+                        ? new HashMap<String, Object>(instance.getInstanceMap())
                         : null,
                 instance.getInitConfig() != null
-                        ? new LinkedHashMap<String, Object>(instance.getInitConfig())
+                        ? new HashMap<String, Object>(instance.getInitConfig())
                         : null,
                 instance.getCheckName(),
                 appConfig);
@@ -115,14 +113,14 @@ public class Instance {
     /** Default constructor, builds an Instance from the provided instance map and init configs. */
     @SuppressWarnings("unchecked")
     public Instance(
-            LinkedHashMap<String, Object> instanceMap,
-            LinkedHashMap<String, Object> initConfig,
+            Map<String, Object> instanceMap,
+            Map<String, Object> initConfig,
             String checkName,
             AppConfig appConfig) {
         this.appConfig = appConfig;
         this.instanceMap =
-                instanceMap != null ? new LinkedHashMap<String, Object>(instanceMap) : null;
-        this.initConfig = initConfig != null ? new LinkedHashMap<String, Object>(initConfig) : null;
+                instanceMap != null ? new HashMap<String, Object>(instanceMap) : null;
+        this.initConfig = initConfig != null ? new HashMap<String, Object>(initConfig) : null;
         this.instanceName = (String) instanceMap.get("name");
         this.tags = getTagsMap(instanceMap.get("tags"), appConfig);
         this.checkName = checkName;
@@ -197,8 +195,8 @@ public class Instance {
         if (instanceConf == null) {
             log.warn("Cannot find a \"conf\" section in " + this.instanceName);
         } else {
-            for (LinkedHashMap<String, Object> conf :
-                    (ArrayList<LinkedHashMap<String, Object>>) (instanceConf)) {
+            for (Map<String, Object> conf :
+                    (ArrayList<Map<String, Object>>) (instanceConf)) {
                 configurationList.add(new Configuration(conf));
             }
         }
@@ -219,16 +217,16 @@ public class Instance {
         loadDefaultConfig(gcMetricConfig);
     }
 
-    public static boolean isDirectInstance(LinkedHashMap<String, Object> configInstance) {
+    public static boolean isDirectInstance(Map<String, Object> configInstance) {
         Object directInstance = configInstance.get(JVM_DIRECT);
         return directInstance instanceof Boolean && (Boolean) directInstance;
     }
 
     private void loadDefaultConfig(String configResourcePath) {
-        ArrayList<LinkedHashMap<String, Object>> defaultConf =
-                (ArrayList<LinkedHashMap<String, Object>>)
+        ArrayList<Map<String, Object>> defaultConf =
+                (ArrayList<Map<String, Object>>)
                         YAML.get().load(this.getClass().getResourceAsStream(configResourcePath));
-        for (LinkedHashMap<String, Object> conf : defaultConf) {
+        for (Map<String, Object> conf : defaultConf) {
             configurationList.add(new Configuration(conf));
         }
     }
@@ -246,10 +244,10 @@ public class Instance {
                 log.info("Reading metric config file " + yamlPath);
                 try {
                     yamlInputStream = new FileInputStream(yamlPath);
-                    ArrayList<LinkedHashMap<String, Object>> confs =
-                            (ArrayList<LinkedHashMap<String, Object>>)
+                    ArrayList<Map<String, Object>> confs =
+                            (ArrayList<Map<String, Object>>)
                                     YAML.get().load(yamlInputStream);
-                    for (LinkedHashMap<String, Object> conf : confs) {
+                    for (Map<String, Object> conf : confs) {
                         configurationList.add(new Configuration(conf));
                     }
                 } catch (FileNotFoundException e) {
@@ -282,13 +280,13 @@ public class Instance {
                     log.warn("Cannot find metric config resource" + resourceName);
                 } else {
                     try {
-                        LinkedHashMap<String, ArrayList<LinkedHashMap<String, Object>>> topYaml =
-                                (LinkedHashMap<String, ArrayList<LinkedHashMap<String, Object>>>)
+                        Map<String, ArrayList<Map<String, Object>>> topYaml =
+                                (Map<String, ArrayList<Map<String, Object>>>)
                                         YAML.get().load(inputStream);
-                        ArrayList<LinkedHashMap<String, Object>> jmxConf =
+                        ArrayList<Map<String, Object>> jmxConf =
                                 topYaml.get("jmx_metrics");
                         if (jmxConf != null) {
-                            for (LinkedHashMap<String, Object> conf : jmxConf) {
+                            for (Map<String, Object> conf : jmxConf) {
                                 configurationList.add(new Configuration(conf));
                             }
                         } else {
@@ -309,11 +307,11 @@ public class Instance {
     }
 
     /**
-     * Format the instance tags defined in the YAML configuration file to a `LinkedHashMap`.
+     * Format the instance tags defined in the YAML configuration file to a `HashMap`.
      * Supported inputs: `List`, `Map`.
      */
-    private static LinkedHashMap<String, String> getTagsMap(Object tagsMap, AppConfig appConfig) {
-        LinkedHashMap<String, String> tags = new LinkedHashMap<String, String>();
+    private static Map<String, String> getTagsMap(Object tagsMap, AppConfig appConfig) {
+        Map<String, String> tags = new HashMap<String, String>();
         if (appConfig.getGlobalTags() != null) {
             tags.putAll(appConfig.getGlobalTags());
         }
@@ -351,7 +349,7 @@ public class Instance {
 
     /** Returns the instance connection, creates one if not already connected. */
     public Connection getConnection(
-            LinkedHashMap<String, Object> connectionParams, boolean forceNewConnection)
+            Map<String, Object> connectionParams, boolean forceNewConnection)
             throws IOException {
         if (connection == null || !connection.isAlive()) {
             log.info(
@@ -680,11 +678,11 @@ public class Instance {
         return this.instanceName;
     }
 
-    LinkedHashMap<String, Object> getInstanceMap() {
+    Map<String, Object> getInstanceMap() {
         return this.instanceMap;
     }
 
-    LinkedHashMap<String, Object> getInitConfig() {
+    Map<String, Object> getInitConfig() {
         return this.initConfig;
     }
 

--- a/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
@@ -8,7 +8,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -52,8 +51,8 @@ public abstract class JmxAttribute {
     private String beanStringName;
     private HashMap<String, String> beanParameters;
     private String attributeName;
-    private LinkedHashMap<String, LinkedHashMap<Object, Object>> valueConversions =
-            new LinkedHashMap<String, LinkedHashMap<Object, Object>>();
+    private Map<String, Map<Object, Object>> valueConversions =
+            new HashMap<String, Map<Object, Object>>();
     protected String[] tags;
     private Configuration matchingConf;
     private LinkedList<String> defaultTagsList;
@@ -64,7 +63,7 @@ public abstract class JmxAttribute {
             ObjectName beanName,
             String instanceName,
             Connection connection,
-            HashMap<String, String> instanceTags,
+            Map<String, String> instanceTags,
             Boolean cassandraAliasing,
             boolean emptyDefaultHostname) {
         this.attribute = attribute;
@@ -145,7 +144,7 @@ public abstract class JmxAttribute {
     private LinkedList<String> getBeanParametersList(
             String instanceName,
             Map<String, String> beanParameters,
-            HashMap<String, String> instanceTags) {
+            Map<String, String> instanceTags) {
         LinkedList<String> beanTags = new LinkedList<String>();
         beanTags.add("instance:" + instanceName);
         beanTags.add("jmx_domain:" + domain);
@@ -403,20 +402,16 @@ public abstract class JmxAttribute {
     }
 
     @SuppressWarnings("unchecked")
-    HashMap<Object, Object> getValueConversions(String field) {
+    Map<Object, Object> getValueConversions(String field) {
         String fullAttributeName =
                 (field != null)
                         ? (getAttribute().getName() + "." + field)
                         : (getAttribute().getName());
         if (valueConversions.get(fullAttributeName) == null) {
             Object includedAttribute = matchingConf.getInclude().getAttribute();
-            if (includedAttribute instanceof LinkedHashMap<?, ?>) {
-                LinkedHashMap<String, LinkedHashMap<Object, Object>> attribute =
-                        ((LinkedHashMap<
-                                                String,
-                                                LinkedHashMap<
-                                                        String, LinkedHashMap<Object, Object>>>)
-                                        includedAttribute)
+            if (includedAttribute instanceof Map<?, ?>) {
+                Map<String, Map<Object, Object>> attribute =
+                        ((Map<String, Map<String, Map<Object, Object>>>) includedAttribute)
                                 .get(fullAttributeName);
 
                 if (attribute != null) {
@@ -424,7 +419,7 @@ public abstract class JmxAttribute {
                 }
             }
             if (valueConversions.get(fullAttributeName) == null) {
-                valueConversions.put(fullAttributeName, new LinkedHashMap<Object, Object>());
+                valueConversions.put(fullAttributeName, new HashMap<Object, Object>());
             }
         }
 
@@ -468,16 +463,16 @@ public abstract class JmxAttribute {
         String alias = null;
 
         Filter include = getMatchingConf().getInclude();
-        LinkedHashMap<String, Object> conf = getMatchingConf().getConf();
+        Map<String, Object> conf = getMatchingConf().getConf();
 
         String fullAttributeName =
                 (field != null)
                         ? (getAttribute().getName() + "." + field)
                         : (getAttribute().getName());
 
-        if (include.getAttribute() instanceof LinkedHashMap<?, ?>) {
-            LinkedHashMap<String, LinkedHashMap<String, String>> attribute =
-                    (LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute());
+        if (include.getAttribute() instanceof Map<?, ?>) {
+            Map<String, Map<String, String>> attribute =
+                    (Map<String, Map<String, String>>) (include.getAttribute());
             alias = getUserAlias(attribute, fullAttributeName);
         }
 
@@ -534,8 +529,7 @@ public abstract class JmxAttribute {
      * <p>Example: ``` bean: org.datadog.jmxfetch.test:foo=Bar,qux=Baz attribute: toto: alias:
      * my.metric.$foo.$attribute ``` returns a metric name `my.metric.bar.toto`
      */
-    private String getUserAlias(
-            LinkedHashMap<String, LinkedHashMap<String, String>> attribute,
+    private String getUserAlias(Map<String, Map<String, String>> attribute,
             String fullAttributeName) {
         String alias = attribute.get(fullAttributeName).get(ALIAS);
         if (alias == null) {
@@ -581,9 +575,9 @@ public abstract class JmxAttribute {
         Filter include = matchingConf.getInclude();
         if (include != null) {
             Object includeAttribute = include.getAttribute();
-            if (includeAttribute instanceof LinkedHashMap<?, ?>) {
-                LinkedHashMap<String, ArrayList<String>> attributeParams =
-                        ((LinkedHashMap<String, LinkedHashMap<String, ArrayList<String>>>)
+            if (includeAttribute instanceof Map<?, ?>) {
+                Map<String, ArrayList<String>> attributeParams =
+                        ((Map<String, Map<String, ArrayList<String>>>)
                                         includeAttribute)
                                 .get(attributeName);
                 if (attributeParams != null) {

--- a/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import javax.management.AttributeNotFoundException;
@@ -26,7 +25,7 @@ public class JmxComplexAttribute extends JmxAttribute {
             ObjectName beanName,
             String instanceName,
             Connection connection,
-            HashMap<String, String> instanceTags,
+            Map<String, String> instanceTags,
             boolean emptyDefaultHostname) {
         super(
                 attribute,
@@ -107,9 +106,9 @@ public class JmxComplexAttribute extends JmxAttribute {
         String metricType = null;
 
         Filter include = getMatchingConf().getInclude();
-        if (include.getAttribute() instanceof LinkedHashMap<?, ?>) {
-            LinkedHashMap<String, LinkedHashMap<String, String>> attribute =
-                    (LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute());
+        if (include.getAttribute() instanceof Map<?, ?>) {
+            Map<String, Map<String, String>> attribute =
+                    (Map<String, Map<String, String>>) (include.getAttribute());
             metricType = attribute.get(subAttributeName).get(METRIC_TYPE);
             if (metricType == null) {
                 metricType = attribute.get(subAttributeName).get("type");
@@ -143,8 +142,8 @@ public class JmxComplexAttribute extends JmxAttribute {
 
     private boolean matchSubAttribute(
             Filter params, String subAttributeName, boolean matchOnEmpty) {
-        if ((params.getAttribute() instanceof LinkedHashMap<?, ?>)
-                && ((LinkedHashMap<String, Object>) (params.getAttribute()))
+        if ((params.getAttribute() instanceof Map<?, ?>)
+                && ((Map<String, Object>) (params.getAttribute()))
                         .containsKey(subAttributeName)) {
             return true;
         } else if ((params.getAttribute() instanceof ArrayList<?>

--- a/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
@@ -3,8 +3,8 @@ package org.datadog.jmxfetch;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
+import java.util.Map;
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
 import javax.management.MBeanAttributeInfo;
@@ -22,7 +22,7 @@ public class JmxSimpleAttribute extends JmxAttribute {
             ObjectName beanName,
             String instanceName,
             Connection connection,
-            HashMap<String, String> instanceTags,
+            Map<String, String> instanceTags,
             boolean cassandraAliasing,
             Boolean emptyDefaultHostname) {
         super(
@@ -64,8 +64,8 @@ public class JmxSimpleAttribute extends JmxAttribute {
         Filter exclude = configuration.getExclude();
         if (exclude.getAttribute() == null) {
             return false;
-        } else if ((exclude.getAttribute() instanceof LinkedHashMap<?, ?>)
-                && ((LinkedHashMap<String, Object>) (exclude.getAttribute()))
+        } else if ((exclude.getAttribute() instanceof Map<?, ?>)
+                && ((Map<String, Object>) (exclude.getAttribute()))
                         .containsKey(getAttributeName())) {
             return true;
 
@@ -81,8 +81,8 @@ public class JmxSimpleAttribute extends JmxAttribute {
         if (include.getAttribute() == null) {
             return true;
 
-        } else if ((include.getAttribute() instanceof LinkedHashMap<?, ?>)
-                && ((LinkedHashMap<String, Object>) (include.getAttribute()))
+        } else if ((include.getAttribute() instanceof Map<?, ?>)
+                && ((Map<String, Object>) (include.getAttribute()))
                         .containsKey(getAttributeName())) {
             return true;
 
@@ -98,9 +98,9 @@ public class JmxSimpleAttribute extends JmxAttribute {
         Filter include = getMatchingConf().getInclude();
         if (metricType != null) {
             return metricType;
-        } else if (include.getAttribute() instanceof LinkedHashMap<?, ?>) {
-            LinkedHashMap<String, LinkedHashMap<String, String>> attribute =
-                    (LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute());
+        } else if (include.getAttribute() instanceof Map<?, ?>) {
+            Map<String, Map<String, String>> attribute =
+                    (Map<String, Map<String, String>>) (include.getAttribute());
             metricType = attribute.get(getAttributeName()).get(METRIC_TYPE);
             if (metricType == null) {
                 metricType = attribute.get(getAttributeName()).get("type");

--- a/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -35,7 +34,7 @@ public class JmxTabularAttribute extends JmxAttribute {
             ObjectName beanName,
             String instanceName,
             Connection connection,
-            HashMap<String, String> instanceTags,
+            Map<String, String> instanceTags,
             boolean emptyDefaultHostname) {
         super(
                 attribute,
@@ -119,7 +118,7 @@ public class JmxTabularAttribute extends JmxAttribute {
         Filter include = getMatchingConf().getInclude();
         if (include != null) {
             Object includeAttribute = include.getAttribute();
-            if (includeAttribute instanceof LinkedHashMap<?, ?>) {
+            if (includeAttribute instanceof Map<?, ?>) {
                 return (Map<String, ?>) ((Map) includeAttribute).get(key);
             }
         }
@@ -248,9 +247,9 @@ public class JmxTabularAttribute extends JmxAttribute {
         String metricType = null;
 
         Filter include = getMatchingConf().getInclude();
-        if (include.getAttribute() instanceof LinkedHashMap<?, ?>) {
-            LinkedHashMap<String, LinkedHashMap<String, String>> attribute =
-                    (LinkedHashMap<String, LinkedHashMap<String, String>>) (include.getAttribute());
+        if (include.getAttribute() instanceof Map<?, ?>) {
+            Map<String, Map<String, String>> attribute =
+                    (Map<String, Map<String, String>>) (include.getAttribute());
             metricType = attribute.get(subAttributeName).get(METRIC_TYPE);
             if (metricType == null) {
                 metricType = attribute.get(subAttributeName).get("type");
@@ -284,8 +283,8 @@ public class JmxTabularAttribute extends JmxAttribute {
 
     private boolean matchSubAttribute(
             Filter params, String subAttributeName, boolean matchOnEmpty) {
-        if ((params.getAttribute() instanceof LinkedHashMap<?, ?>)
-                && ((LinkedHashMap<String, Object>) (params.getAttribute()))
+        if ((params.getAttribute() instanceof Map<?, ?>)
+                && ((Map<String, Object>) (params.getAttribute()))
                         .containsKey(subAttributeName)) {
             return true;
         } else if ((params.getAttribute() instanceof ArrayList<?>

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -5,7 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
+import java.util.Map;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXServiceURL;
 import javax.management.remote.rmi.RMIConnectorServer;
@@ -29,7 +29,7 @@ public class RemoteConnection extends Connection {
             "15000"; // Match the collection period default
 
     /** RemoteConnection constructor for specified remote connection parameters. */
-    public RemoteConnection(LinkedHashMap<String, Object> connectionParams) throws IOException {
+    public RemoteConnection(Map<String, Object> connectionParams) throws IOException {
         host = (String) connectionParams.get("host");
         try {
             port = (Integer) connectionParams.get("port");
@@ -55,7 +55,7 @@ public class RemoteConnection extends Connection {
             path = (String) connectionParams.get("path");
         }
         env = getEnv(connectionParams);
-        address = getAddress(connectionParams);
+        address = getAddress();
 
         String trustStorePath;
         String trustStorePassword;
@@ -92,7 +92,7 @@ public class RemoteConnection extends Connection {
         createConnection();
     }
 
-    private HashMap<String, Object> getEnv(LinkedHashMap<String, Object> connectionParams) {
+    private HashMap<String, Object> getEnv(Map<String, Object> connectionParams) {
 
         HashMap<String, Object> environment = new HashMap<String, Object>();
 
@@ -107,7 +107,7 @@ public class RemoteConnection extends Connection {
         return environment;
     }
 
-    private JMXServiceURL getAddress(LinkedHashMap<String, Object> connectionParams)
+    private JMXServiceURL getAddress()
             throws MalformedURLException {
         if (this.jmxUrl != null) {
             return new JMXServiceURL(this.jmxUrl);


### PR DESCRIPTION
Configurations come mostly as LinkedHashMap from Yaml or Json parsers
But usage inside JMXFetch is mostly as HashMap.
As LinkedHashMap is heavier regarding memory footprint, we prefer to
avoid its usage by just replacing by HashMap. Also it does not seem
That order matters in the case of JMXFetch usage.
I have changed also the type to use Map interface as it will be easier
to change the implementation if required in the future without
changing this type everywhere.