### PR TITLE
Add a new command to test rate metrics

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -227,6 +227,9 @@ public class App {
         if (action.equals(AppConfig.ACTION_LIST_WITH_METRICS)) {
             app.displayMetrics();
         }
+        if (action.equals(AppConfig.ACTION_LIST_WITH_RATE_METRICS)) {
+            app.displayRateMetrics();
+        }
         return 0;
     }
 
@@ -381,6 +384,17 @@ public class App {
 
     /* Display metrics on the console report */
     void displayMetrics() {
+        doIteration();
+    }
+
+    /* Display metrics on the console report, including rate metrics */
+    void displayRateMetrics() {
+        doIteration();
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            log.warn(e.getMessage(), e);
+        }
         doIteration();
     }
 

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -29,6 +29,7 @@ public class AppConfig {
     public static final String ACTION_LIST_COLLECTED = "list_collected_attributes";
     public static final String ACTION_LIST_MATCHING = "list_matching_attributes";
     public static final String ACTION_LIST_WITH_METRICS = "list_with_metrics";
+    public static final String ACTION_LIST_WITH_RATE_METRICS = "list_with_rate_metrics";
     public static final String ACTION_LIST_NOT_MATCHING = "list_not_matching_attributes";
     public static final String ACTION_LIST_LIMITED = "list_limited_attributes";
     public static final String ACTION_HELP = "help";
@@ -41,6 +42,7 @@ public class AppConfig {
                             ACTION_LIST_COLLECTED,
                             ACTION_LIST_MATCHING,
                             ACTION_LIST_WITH_METRICS,
+                            ACTION_LIST_WITH_RATE_METRICS,
                             ACTION_LIST_NOT_MATCHING,
                             ACTION_LIST_LIMITED,
                             ACTION_HELP,
@@ -186,7 +188,7 @@ public class AppConfig {
             description =
                     "Action to take, should be in [help, version, collect, "
                     + "list_everything, list_collected_attributes, list_matching_attributes, "
-                    + "list_with_metrics, list_not_matching_attributes, "
+                    + "list_with_metrics, list_with_rate_metrics, list_not_matching_attributes, "
                     + "list_limited_attributes, list_jvms]",
             required = true)
     private List<String> action;

--- a/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
@@ -8,6 +8,7 @@ import org.datadog.jmxfetch.Instance;
 import org.datadog.jmxfetch.JmxAttribute;
 
 import java.io.IOException;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -39,6 +40,7 @@ public class JsonReporter extends Reporter {
 
     /** Use the service check callback to display the JSON. */
     public void doSendServiceCheck(String checkName, String status, String message, String[] tags) {
+        log.debug("Displaying JSON output");
         HashMap<String, Object> aggregator = new HashMap<String, Object>();
         aggregator.put("metrics", metrics);
         HashMap<String, Object> serie = new HashMap<String, Object>();
@@ -49,11 +51,14 @@ public class JsonReporter extends Reporter {
         System.out.println("=== JSON ===");
         ObjectMapper mapper = new ObjectMapper();
         mapper.enable(SerializationFeature.INDENT_OUTPUT);
+        StringWriter writer = new StringWriter();
         try {
-            mapper.writeValue(System.out, series);
+            mapper.writeValue(writer, series);
         } catch (IOException e) {
             log.error("Couln't produce JSON output");
         }
+        System.out.println(writer.toString());
+        metrics.clear();
     }
 
     public void displayMetricReached() {

--- a/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
+++ b/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
@@ -432,7 +432,7 @@ public class TestParsingJCommander {
             String expectedMessage =
                     "Main parameters are required (\"Action to take, should be in [help, version, collect, "
                             + "list_everything, list_collected_attributes, list_matching_attributes, "
-			    + "list_with_metrics, list_not_matching_attributes, list_limited_attributes, list_jvms]\")";
+                            + "list_with_metrics, list_with_rate_metrics, list_not_matching_attributes, list_limited_attributes, list_jvms]\")";
             assertEquals(expectedMessage, pe.getMessage());
         }
 
@@ -451,7 +451,7 @@ public class TestParsingJCommander {
             String expectedMessage =
                     "Main parameters are required (\"Action to take, should be in [help, version, collect, "
                             + "list_everything, list_collected_attributes, list_matching_attributes, "
-                            + "list_with_metrics, list_not_matching_attributes, list_limited_attributes, list_jvms]\")";
+                            + "list_with_metrics, list_with_rate_metrics, list_not_matching_attributes, list_limited_attributes, list_jvms]\")";
             assertEquals(expectedMessage, pe.getMessage());
         }
     }


### PR DESCRIPTION
For end to end testing, we use the `list_with_metrics` command. It only
does one iteration though, which means we don't have output for counters
and rates. This adds a new command running 2 iterations.