### PR TITLE
Replace LinkedList by ArrayList and or List

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Filter.java
+++ b/src/main/java/org/datadog/jmxfetch/Filter.java
@@ -1,15 +1,18 @@
 package org.datadog.jmxfetch;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
 class Filter {
     HashMap<String, Object> filter;
     Pattern domainRegex;
-    ArrayList<Pattern> beanRegexes = null;
-    ArrayList<String> excludeTags = null;
+    List<Pattern> beanRegexes = null;
+    List<String> excludeTags = null;
     HashMap<String, String> additionalTags = null;
 
     /**
@@ -37,8 +40,8 @@ class Filter {
         return filter.keySet();
     }
 
-    @SuppressWarnings({"unchecked", "serial"})
-    private static ArrayList<String> toStringArrayList(final Object toCast) {
+    @SuppressWarnings({"unchecked"})
+    private static List<String> toStringList(final Object toCast) {
         // Return object as an ArrayList wherever it's defined as
         // list or not
         //
@@ -49,20 +52,15 @@ class Filter {
         // ### OR
         // object: singleValue
         // ###
-        try {
-            return (ArrayList<String>) toCast;
-        } catch (ClassCastException e) {
-            return new ArrayList<String>() {
-                {
-                    add(((String) toCast));
-                }
-            };
+        if (toCast instanceof List) {
+            return (List<String>) toCast;
         }
+        return Collections.singletonList((String) toCast);
     }
 
-    public ArrayList<String> getBeanNames() {
+    public List<String> getBeanNames() {
         if (isEmptyBeanName()) {
-            return new ArrayList<String>();
+            return Collections.emptyList();
         }
         final Object beanNames =
                 (filter.get("bean") != null) ? filter.get("bean") : filter.get("bean_name");
@@ -77,44 +75,43 @@ class Filter {
         // ### OR
         // bean: org.datadog.jmxfetch.test:type=type=SimpleTestJavaApp
         // ###
-        return toStringArrayList(beanNames);
+        return toStringList(beanNames);
     }
 
-    private static ArrayList<Pattern> toPatternArrayList(final Object toCast) {
-        ArrayList<Pattern> patternArrayList = new ArrayList<Pattern>();
-        ArrayList<String> stringArrayList = toStringArrayList(toCast);
-        for (String string : stringArrayList) {
-            patternArrayList.add(Pattern.compile(string));
+    private static List<Pattern> toPatternList(final Object toCast) {
+        List<Pattern> patternList = new ArrayList<Pattern>();
+        List<String> stringList = toStringList(toCast);
+        for (String string : stringList) {
+            patternList.add(Pattern.compile(string));
         }
-
-        return patternArrayList;
+        return patternList;
     }
 
-    public ArrayList<Pattern> getBeanRegexes() {
+    public List<Pattern> getBeanRegexes() {
         // Return bean regexes as an ArrayList of Pattern whether it's defined as
         // a list or not
 
         if (this.beanRegexes == null) {
             if (filter.get("bean_regex") == null) {
-                this.beanRegexes = new ArrayList<Pattern>();
+                this.beanRegexes = Collections.emptyList();
             } else {
                 final Object beanRegexNames = filter.get("bean_regex");
-                this.beanRegexes = toPatternArrayList(beanRegexNames);
+                this.beanRegexes = toPatternList(beanRegexNames);
             }
         }
 
         return this.beanRegexes;
     }
 
-    public ArrayList<String> getExcludeTags() {
+    public List<String> getExcludeTags() {
         // Return excluded tags  as an ArrayList whether it's defined as a list or not
 
         if (this.excludeTags == null) {
             if (filter.get("exclude_tags") == null) {
-                this.excludeTags = new ArrayList<String>();
+                this.excludeTags = Collections.emptyList();
             } else {
                 final Object exclude_tags = filter.get("exclude_tags");
-                this.excludeTags = toStringArrayList(exclude_tags);
+                this.excludeTags = toStringList(exclude_tags);
             }
         }
 
@@ -154,7 +151,7 @@ class Filter {
         return filter.get("attribute");
     }
 
-    public ArrayList<String> getParameterValues(String parameterName) {
+    public List<String> getParameterValues(String parameterName) {
         // Return bean attributes values as an ArrayList wherever it's defined as
         // list or not
         //
@@ -166,7 +163,7 @@ class Filter {
         // bean_parameter: onlyOneType
         // ###
         final Object beanValues = filter.get(parameterName);
-        return toStringArrayList(beanValues);
+        return toStringList(beanValues);
     }
 
     public boolean isEmptyBeanName() {

--- a/src/main/java/org/datadog/jmxfetch/Filter.java
+++ b/src/main/java/org/datadog/jmxfetch/Filter.java
@@ -55,7 +55,7 @@ class Filter {
         if (toCast instanceof List) {
             return (List<String>) toCast;
         }
-        return Collections.singletonList((String) toCast);
+        return new ArrayList<String>(Arrays.asList((String) toCast));
     }
 
     public List<String> getBeanNames() {

--- a/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
@@ -55,11 +55,12 @@ public class JmxComplexAttribute extends JmxAttribute {
     }
 
     @Override
-    public LinkedList<HashMap<String, Object>> getMetrics()
+    public List<HashMap<String, Object>> getMetrics()
             throws AttributeNotFoundException, InstanceNotFoundException, MBeanException,
                     ReflectionException, IOException {
 
-        LinkedList<HashMap<String, Object>> metrics = new LinkedList<HashMap<String, Object>>();
+        List<HashMap<String, Object>> metrics = new ArrayList<HashMap<String, Object>>(
+                subAttributeList.entrySet().size());
 
         for (Map.Entry<String, HashMap<String, Object>> pair : subAttributeList.entrySet()) {
             String subAttribute = pair.getKey();
@@ -146,8 +147,8 @@ public class JmxComplexAttribute extends JmxAttribute {
                 && ((Map<String, Object>) (params.getAttribute()))
                         .containsKey(subAttributeName)) {
             return true;
-        } else if ((params.getAttribute() instanceof ArrayList<?>
-                && ((ArrayList<String>) (params.getAttribute())).contains(subAttributeName))) {
+        } else if ((params.getAttribute() instanceof List<?>
+                && ((List<String>) (params.getAttribute())).contains(subAttributeName))) {
             return true;
         } else if (params.getAttribute() == null) {
             return matchOnEmpty;

--- a/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
@@ -3,7 +3,7 @@ package org.datadog.jmxfetch;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import javax.management.AttributeNotFoundException;
 import javax.management.InstanceNotFoundException;
@@ -36,7 +36,7 @@ public class JmxSimpleAttribute extends JmxAttribute {
     }
 
     @Override
-    public LinkedList<HashMap<String, Object>> getMetrics()
+    public List<HashMap<String, Object>> getMetrics()
             throws AttributeNotFoundException, InstanceNotFoundException, MBeanException,
                     ReflectionException, IOException {
         HashMap<String, Object> metric = new HashMap<String, Object>();
@@ -45,7 +45,7 @@ public class JmxSimpleAttribute extends JmxAttribute {
         metric.put("value", castToDouble(getValue(), null));
         metric.put("tags", getTags());
         metric.put("metric_type", getMetricType());
-        LinkedList<HashMap<String, Object>> metrics = new LinkedList<HashMap<String, Object>>();
+        List<HashMap<String, Object>> metrics = new ArrayList<HashMap<String, Object>>(1);
         metrics.add(metric);
         return metrics;
     }
@@ -69,8 +69,8 @@ public class JmxSimpleAttribute extends JmxAttribute {
                         .containsKey(getAttributeName())) {
             return true;
 
-        } else if ((exclude.getAttribute() instanceof ArrayList<?>
-                && ((ArrayList<String>) (exclude.getAttribute())).contains(getAttributeName()))) {
+        } else if ((exclude.getAttribute() instanceof List<?>
+                && ((List<String>) (exclude.getAttribute())).contains(getAttributeName()))) {
             return true;
         }
         return false;
@@ -86,8 +86,8 @@ public class JmxSimpleAttribute extends JmxAttribute {
                         .containsKey(getAttributeName())) {
             return true;
 
-        } else if ((include.getAttribute() instanceof ArrayList<?>
-                && ((ArrayList<String>) (include.getAttribute())).contains(getAttributeName()))) {
+        } else if ((include.getAttribute() instanceof List<?>
+                && ((List<String>) (include.getAttribute())).contains(getAttributeName()))) {
             return true;
         }
 

--- a/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
@@ -10,7 +10,6 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import javax.management.AttributeNotFoundException;
@@ -126,12 +125,11 @@ public class JmxTabularAttribute extends JmxAttribute {
     }
 
     @Override
-    public LinkedList<HashMap<String, Object>> getMetrics()
+    public List<HashMap<String, Object>> getMetrics()
             throws AttributeNotFoundException, InstanceNotFoundException, MBeanException,
                     ReflectionException, IOException {
-        LinkedList<HashMap<String, Object>> metrics = new LinkedList<HashMap<String, Object>>();
-        HashMap<String, LinkedList<HashMap<String, Object>>> subMetrics =
-                new HashMap<String, LinkedList<HashMap<String, Object>>>();
+        HashMap<String, List<HashMap<String, Object>>> subMetrics =
+                new HashMap<String, List<HashMap<String, Object>>>();
 
         for (String dataKey : subAttributeList.keySet()) {
             HashMap<String, HashMap<String, Object>> subSub = subAttributeList.get(dataKey);
@@ -154,12 +152,14 @@ public class JmxTabularAttribute extends JmxAttribute {
 
                 String fullMetricKey = getAttributeName() + "." + metricKey;
                 if (!subMetrics.containsKey(fullMetricKey)) {
-                    subMetrics.put(fullMetricKey, new LinkedList<HashMap<String, Object>>());
+                    subMetrics.put(fullMetricKey, new ArrayList<HashMap<String, Object>>());
                 }
                 subMetrics.get(fullMetricKey).add(metric);
             }
         }
 
+        List<HashMap<String, Object>> metrics =
+                new ArrayList<HashMap<String, Object>>(subMetrics.keySet().size());
         for (String key : subMetrics.keySet()) {
             // only add explicitly included metrics
             if (getAttributesFor(key) != null) {
@@ -171,7 +171,7 @@ public class JmxTabularAttribute extends JmxAttribute {
     }
 
     private List<HashMap<String, Object>> sortAndFilter(
-            String metricKey, LinkedList<HashMap<String, Object>> metrics) {
+            String metricKey, List<HashMap<String, Object>> metrics) {
         Map<String, ?> attributes = getAttributesFor(metricKey);
         if (!attributes.containsKey("limit")) {
             return metrics;
@@ -287,8 +287,8 @@ public class JmxTabularAttribute extends JmxAttribute {
                 && ((Map<String, Object>) (params.getAttribute()))
                         .containsKey(subAttributeName)) {
             return true;
-        } else if ((params.getAttribute() instanceof ArrayList<?>
-                && ((ArrayList<String>) (params.getAttribute())).contains(subAttributeName))) {
+        } else if ((params.getAttribute() instanceof List<?>
+                && ((List<String>) (params.getAttribute())).contains(subAttributeName))) {
             return true;
         } else if (params.getAttribute() == null) {
             return matchOnEmpty;

--- a/src/main/java/org/datadog/jmxfetch/MetricCollectionTask.java
+++ b/src/main/java/org/datadog/jmxfetch/MetricCollectionTask.java
@@ -2,25 +2,27 @@ package org.datadog.jmxfetch;
 
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.List;
 
 @Slf4j
-class MetricCollectionTask extends InstanceTask<LinkedList<HashMap<String, Object>>> {
+class MetricCollectionTask extends InstanceTask<List<HashMap<String, Object>>> {
     MetricCollectionTask(Instance instance) {
         super(instance);
         setWarning("Unable to collect metrics or refresh bean list.");
     }
 
     @Override
-    public LinkedList<HashMap<String, Object>> call() throws Exception {
+    public List<HashMap<String, Object>> call() throws Exception {
 
         if (!instance.timeToCollect()) {
             log.debug(
                     "it is not time to collect, skipping run for instance: " + instance.getName());
 
             // Maybe raise an exception here instead...
-            return new LinkedList<HashMap<String, Object>>();
+            return Collections.emptyList();
         }
 
         return instance.getMetrics();

--- a/src/main/java/org/datadog/jmxfetch/Status.java
+++ b/src/main/java/org/datadog/jmxfetch/Status.java
@@ -7,8 +7,9 @@ import org.apache.commons.io.FileUtils;
 import org.yaml.snakeyaml.Yaml;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.List;
 
 @Slf4j
 public class Status {
@@ -81,15 +82,15 @@ public class Status {
             String message,
             String status,
             String key) {
-        LinkedList<HashMap<String, Object>> checkStats;
+        List<HashMap<String, Object>> checkStats;
         HashMap<String, Object> initializedChecks;
         initializedChecks = (HashMap<String, Object>) this.instanceStats.get(key);
         if (initializedChecks == null) {
             initializedChecks = new HashMap<String, Object>();
         }
-        checkStats = (LinkedList<HashMap<String, Object>>) initializedChecks.get(checkName);
+        checkStats = (List<HashMap<String, Object>>) initializedChecks.get(checkName);
         if (checkStats == null) {
-            checkStats = new LinkedList<HashMap<String, Object>>();
+            checkStats = new ArrayList<HashMap<String, Object>>();
         }
         HashMap<String, Object> instStats = new HashMap<String, Object>();
         if (instance != null) {

--- a/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
@@ -7,15 +7,15 @@ import lombok.extern.slf4j.Slf4j;
 import org.datadog.jmxfetch.Instance;
 import org.datadog.jmxfetch.JmxAttribute;
 
+import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.List;
 
 @Slf4j
 public class ConsoleReporter extends Reporter {
 
-    private LinkedList<HashMap<String, Object>> metrics = new LinkedList<HashMap<String, Object>>();
-    private LinkedList<HashMap<String, Object>> serviceChecks =
-            new LinkedList<HashMap<String, Object>>();
+    private List<HashMap<String, Object>> metrics = new ArrayList<HashMap<String, Object>>();
+    private List<HashMap<String, Object>> serviceChecks = new ArrayList<HashMap<String, Object>>();
 
     @Override
     protected void sendMetricPoint(
@@ -33,9 +33,9 @@ public class ConsoleReporter extends Reporter {
     }
 
     /** Returns list of metrics to report and clears stored metric map. */
-    public LinkedList<HashMap<String, Object>> getMetrics() {
-        LinkedList<HashMap<String, Object>> returnedMetrics =
-                new LinkedList<HashMap<String, Object>>();
+    public List<HashMap<String, Object>> getMetrics() {
+        List<HashMap<String, Object>> returnedMetrics =
+                new ArrayList<HashMap<String, Object>>(metrics.size());
         for (HashMap<String, Object> map : metrics) {
             returnedMetrics.add(new HashMap<String, Object>(map));
         }
@@ -61,9 +61,9 @@ public class ConsoleReporter extends Reporter {
     }
 
     /** Returns list of service checks to report and clears stored service check map.. */
-    public LinkedList<HashMap<String, Object>> getServiceChecks() {
-        LinkedList<HashMap<String, Object>> returnedServiceChecks =
-                new LinkedList<HashMap<String, Object>>();
+    public List<HashMap<String, Object>> getServiceChecks() {
+        List<HashMap<String, Object>> returnedServiceChecks =
+                new ArrayList<HashMap<String, Object>>(serviceChecks.size());
         for (HashMap<String, Object> map : serviceChecks) {
             returnedServiceChecks.add(new HashMap<String, Object>(map));
         }

--- a/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
@@ -10,21 +10,21 @@ import org.datadog.jmxfetch.JmxAttribute;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 public class JsonReporter extends Reporter {
 
-    private LinkedList<HashMap<String, Object>> metrics = new LinkedList<HashMap<String, Object>>();
+    private List<HashMap<String, Object>> metrics = new ArrayList<HashMap<String, Object>>();
 
     protected void sendMetricPoint(
             String metricType, String metricName, double value, String[] tags) {
         long currentTime = System.currentTimeMillis() / 1000L;
-        List<Object> point = new ArrayList<Object>();
+        List<Object> point = new ArrayList<Object>(2);
         point.add(currentTime);
         point.add(value);
-        List<Object> points = new ArrayList<Object>();
+        List<Object> points = new ArrayList<Object>(1);
         points.add(point);
         HashMap<String, Object> metric = new HashMap<String, Object>();
         metric.put("host", "default");
@@ -43,7 +43,7 @@ public class JsonReporter extends Reporter {
         aggregator.put("metrics", metrics);
         HashMap<String, Object> serie = new HashMap<String, Object>();
         serie.put("aggregator", aggregator);
-        List<Object> series = new ArrayList<Object>();
+        List<Map<String, Object>> series = new ArrayList<Map<String, Object>>(1);
         series.add(serie);
 
         System.out.println("=== JSON ===");

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -9,7 +9,7 @@ import org.datadog.jmxfetch.JmxAttribute;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.List;
 
 @Slf4j
 public abstract class Reporter {
@@ -47,7 +47,7 @@ public abstract class Reporter {
 
     /** Submits the metrics in the implementing reporter. */
     public void sendMetrics(
-            LinkedList<HashMap<String, Object>> metrics,
+            List<HashMap<String, Object>> metrics,
             String instanceName,
             boolean canonicalRate) {
         HashMap<String, HashMap<String, Object>> instanceRatesAggregator;

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import org.junit.Test;
 
@@ -54,7 +53,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // 14 = 13 metrics from java.lang + 1 metric explicitly defined in the yaml config file
         assertEquals(14, metrics.size());
@@ -80,7 +79,7 @@ public class TestApp extends TestCommon {
 
         // Collect metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // Assertions
 
@@ -113,7 +112,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // Assertions
 
@@ -147,7 +146,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // 14 = 2*13 metrics from java.lang + 2*1 metric explicitly defined in the yaml config file
         assertEquals(28, metrics.size());
@@ -186,7 +185,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // 14 = 13 metrics from java.lang + 1 metric explicitly defined in the yaml config file
         assertEquals(14, metrics.size());
@@ -210,7 +209,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // First filter 29 = 13 metrics from java.lang + 16 metrics implicitly defined
         assertEquals(29, metrics.size());
@@ -228,7 +227,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // First filter 14 = 13 metrics from java.lang + 2 metrics explicitly define- 1 implicitly
         // defined in the exclude section
@@ -248,7 +247,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // First filter 15 = 13 metrics from java.lang + 3 metrics explicitly defined - 1 implicitly
         // defined in exclude section
@@ -265,7 +264,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // 13 default metrics from java.lang
         assertEquals(13, metrics.size());
@@ -281,7 +280,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // First filter 14 = 13 metrics from java.lang + 1 metrics explicitly defined
         assertEquals(14, metrics.size());
@@ -297,7 +296,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // First filter 13 = 13 metrics from java.lang + 2 metrics explicitly defined - 2 explicitly
         // defined
@@ -314,7 +313,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // First filter 14 = 13 metrics from java.lang + 1 metrics explicitly defined
         assertEquals(14, metrics.size());
@@ -333,7 +332,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // First filter 15 = 13 metrics from java.lang + 2 metrics explicitly defined
         assertEquals(15, metrics.size());
@@ -352,7 +351,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // First filter 14 = 13 metrics from java.lang + 1 metrics explicitly defined
         assertEquals(14, metrics.size());
@@ -371,7 +370,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // First filter 14 = 13 metrics from java.lang + 1 metrics explicitly defined
         assertEquals(14, metrics.size());
@@ -402,7 +401,7 @@ public class TestApp extends TestCommon {
         initApplication("jmx_histogram.yaml");
 
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // We test for the presence and the value of the metrics we want to collect
         List<String> commonTags =
@@ -436,7 +435,7 @@ public class TestApp extends TestCommon {
         // We do a first collection
         initApplication("jmx_exclude_tags.yml");
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // We test for the presence and the value of the metrics we want to collect.
         // Tags "type", "newTag" and "env" should be excluded
@@ -460,7 +459,7 @@ public class TestApp extends TestCommon {
         // We do a first collection
         initApplication("jmx_additional_tags.yml");
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // We test for the presence and the value of the metrics we want to collect.
         // Tags "type", "newTag" and "env" should be excluded
@@ -495,7 +494,7 @@ public class TestApp extends TestCommon {
         initApplication("jmx.yaml");
 
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // 29 = 13 metrics from java.lang + the 6 gauges we are explicitly collecting + 9 gauges
         // implicitly collected
@@ -609,7 +608,7 @@ public class TestApp extends TestCommon {
         initApplication("jmx_canonical.yaml");
 
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // 28 = 13 metrics from java.lang + the 5 gauges we are explicitly collecting + 9 gauges
         // implicitly collected
@@ -769,7 +768,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // 14 = 13 metrics from java.lang + 1 metric explicitly defined in the yaml config file
         assertEquals(63, metrics.size());
@@ -836,8 +835,8 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
-        ArrayList<Instance> instances = getInstances();
+        List<HashMap<String, Object>> metrics = getMetrics();
+        List<Instance> instances = getInstances();
 
         assertEquals(35, metrics.size());
 
@@ -857,7 +856,7 @@ public class TestApp extends TestCommon {
         initApplication("jmx_cast.yaml");
 
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // 13 metrics from java.lang + 2 defined - 1 error
         assertEquals(14, metrics.size());

--- a/src/test/java/org/datadog/jmxfetch/TestCommon.java
+++ b/src/test/java/org/datadog/jmxfetch/TestCommon.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import javax.management.InstanceAlreadyExistsException;
@@ -35,9 +34,9 @@ public class TestCommon {
     AppConfig appConfig = spy(AppConfig.builder().build());
     App app;
     MBeanServer mbs;
-    ArrayList<ObjectName> objectNames = new ArrayList<ObjectName>();
-    LinkedList<HashMap<String, Object>> metrics;
-    LinkedList<HashMap<String, Object>> serviceChecks;
+    List<ObjectName> objectNames = new ArrayList<ObjectName>();
+    List<HashMap<String, Object>> metrics;
+    List<HashMap<String, Object>> serviceChecks;
 
     /** Setup logger. */
     @BeforeClass
@@ -143,7 +142,7 @@ public class TestCommon {
     }
 
     /** Return configured instances */
-    protected ArrayList<Instance> getInstances() {
+    protected List<Instance> getInstances() {
         return app.getInstances();
     }
 
@@ -153,12 +152,12 @@ public class TestCommon {
     }
 
     /** Return the metrics collected by JMXFetch. */
-    protected LinkedList<HashMap<String, Object>> getMetrics() {
+    protected List<HashMap<String, Object>> getMetrics() {
         return metrics;
     }
 
     /** Return the service checks collected by JMXFetch. */
-    protected LinkedList<HashMap<String, Object>> getServiceChecks() {
+    protected List<HashMap<String, Object>> getServiceChecks() {
         return ((ConsoleReporter) appConfig.getReporter()).getServiceChecks();
     }
 
@@ -330,8 +329,7 @@ public class TestCommon {
      */
     public void assertCoverage() {
         int totalMetrics = 0;
-        LinkedList<HashMap<String, Object>> untestedMetrics =
-                new LinkedList<HashMap<String, Object>>();
+        List<HashMap<String, Object>> untestedMetrics = new ArrayList<HashMap<String, Object>>();
 
         for (HashMap<String, Object> m : metrics) {
             String mName = (String) (m.get("name"));
@@ -361,7 +359,7 @@ public class TestCommon {
      * @return String report
      */
     private static String generateReport(
-            LinkedList<HashMap<String, Object>> untestedMetrics, int totalMetricsCount) {
+            List<HashMap<String, Object>> untestedMetrics, int totalMetricsCount) {
         StringBuilder sb = new StringBuilder();
 
         // Compute indicators

--- a/src/test/java/org/datadog/jmxfetch/TestConfiguration.java
+++ b/src/test/java/org/datadog/jmxfetch/TestConfiguration.java
@@ -11,14 +11,14 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 public class TestConfiguration {
-    static LinkedList<Configuration> configurations = new LinkedList<Configuration>();
+    static List<Configuration> configurations = new ArrayList<Configuration>();
     static JsonParser adConfigs;
 
     /**
@@ -33,13 +33,13 @@ public class TestConfiguration {
         String yamlPath = f.getAbsolutePath();
         FileInputStream yamlInputStream = new FileInputStream(yamlPath);
         YamlParser fileConfig = new YamlParser(yamlInputStream);
-        ArrayList<Map<String, Object>> configInstances =
-                ((ArrayList<Map<String, Object>>) fileConfig.getYamlInstances());
+        List<Map<String, Object>> configInstances =
+                ((List<Map<String, Object>>) fileConfig.getYamlInstances());
 
         for (Map<String, Object> config : configInstances) {
             Object yamlConf = config.get("conf");
             for (Map<String, Object> conf :
-                    (ArrayList<Map<String, Object>>) (yamlConf)) {
+                    (List<Map<String, Object>>) (yamlConf)) {
                 configurations.add(new Configuration(conf));
             }
         }
@@ -69,12 +69,12 @@ public class TestConfiguration {
         assertEquals(configurations.size(), 4);
         int nconfigs = 0;
         for (String check : configs.keySet()) {
-            ArrayList<Map<String, Object>> configInstances =
-                    ((ArrayList<Map<String, Object>>) adConfigs.getJsonInstances(check));
+            List<Map<String, Object>> configInstances =
+                    ((List<Map<String, Object>>) adConfigs.getJsonInstances(check));
             for (Map<String, Object> config : configInstances) {
                 Object jsonConf = config.get("conf");
                 for (Map<String, Object> conf :
-                        (ArrayList<Map<String, Object>>) (jsonConf)) {
+                        (List<Map<String, Object>>) (jsonConf)) {
                     configurations.add(new Configuration(conf));
                     nconfigs++;
                 }
@@ -100,12 +100,12 @@ public class TestConfiguration {
         // Private method reflection
         Method getIncludeFiltersByDomain =
                 Configuration.class.getDeclaredMethod(
-                        "getIncludeFiltersByDomain", LinkedList.class);
+                        "getIncludeFiltersByDomain", List.class);
         getIncludeFiltersByDomain.setAccessible(true);
 
         // Assert
-        HashMap<String, LinkedList<Filter>> filtersByDomain =
-                (HashMap<String, LinkedList<Filter>>)
+        HashMap<String, List<Filter>> filtersByDomain =
+                (HashMap<String, List<Filter>>)
                         getIncludeFiltersByDomain.invoke(null, configurations);
 
         // Only contains 'org.datadog.jmxfetch.test' domain
@@ -133,7 +133,7 @@ public class TestConfiguration {
         // Private method reflection
         Method getIncludeFiltersByDomain =
                 Configuration.class.getDeclaredMethod(
-                        "getIncludeFiltersByDomain", LinkedList.class);
+                        "getIncludeFiltersByDomain", List.class);
         getIncludeFiltersByDomain.setAccessible(true);
 
         Method getCommonBeanKeysByDomain =
@@ -141,8 +141,8 @@ public class TestConfiguration {
         getCommonBeanKeysByDomain.setAccessible(true);
 
         // Assert
-        HashMap<String, LinkedList<Filter>> filtersByDomain =
-                (HashMap<String, LinkedList<Filter>>)
+        HashMap<String, List<Filter>> filtersByDomain =
+                (HashMap<String, List<Filter>>)
                         getIncludeFiltersByDomain.invoke(null, configurations);
         HashMap<String, Set<String>> parametersIntersectionByDomain =
                 (HashMap<String, Set<String>>)
@@ -177,7 +177,7 @@ public class TestConfiguration {
         // Private method reflection
         Method getIncludeFiltersByDomain =
                 Configuration.class.getDeclaredMethod(
-                        "getIncludeFiltersByDomain", LinkedList.class);
+                        "getIncludeFiltersByDomain", List.class);
         getIncludeFiltersByDomain.setAccessible(true);
 
         Method getCommonBeanKeysByDomain =
@@ -190,8 +190,8 @@ public class TestConfiguration {
         getCommonScopeByDomain.setAccessible(true);
 
         // Assert
-        Map<String, LinkedList<Filter>> filtersByDomain =
-                (Map<String, LinkedList<Filter>>)
+        Map<String, List<Filter>> filtersByDomain =
+                (Map<String, List<Filter>>)
                         getIncludeFiltersByDomain.invoke(null, configurations);
         Map<String, Set<String>> parametersIntersectionByDomain =
                 (Map<String, Set<String>>)

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -9,9 +9,9 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.Lists;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
@@ -26,7 +26,7 @@ public class TestInstance extends TestCommon {
         initApplication("jmx_min_collection_period.yml");
 
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
         assertEquals(15, metrics.size());
 
         run();
@@ -62,14 +62,14 @@ public class TestInstance extends TestCommon {
         initApplication("jmx_empty_default_hostname.yaml");
         run();
 
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
         assertEquals(28, metrics.size());
         for (HashMap<String, Object> metric : metrics) {
             String[] tags = (String[]) metric.get("tags");
             this.assertHostnameTags(Arrays.asList(tags));
         }
 
-        LinkedList<HashMap<String, Object>> serviceChecks = getServiceChecks();
+        List<HashMap<String, Object>> serviceChecks = getServiceChecks();
         assertEquals(2, serviceChecks.size());
         for (HashMap<String, Object> sc : serviceChecks) {
             String[] tags = (String[]) sc.get("tags");
@@ -82,7 +82,7 @@ public class TestInstance extends TestCommon {
         URL defaultConfig = Instance.class.getResource("default-jmx-metrics.yaml");
         AppConfig config = mock(AppConfig.class);
         when(config.getMetricConfigFiles()).thenReturn(Lists.newArrayList(defaultConfig.getPath()));
-        LinkedList<Configuration> configurationList = new LinkedList<Configuration>();
+        List<Configuration> configurationList = new ArrayList<Configuration>();
         Instance.loadMetricConfigFiles(config, configurationList);
 
         assertEquals(2, configurationList.size());
@@ -94,7 +94,7 @@ public class TestInstance extends TestCommon {
         String configResource = defaultConfig.getPath().split("test-classes/")[1];
         AppConfig config = mock(AppConfig.class);
         when(config.getMetricConfigResources()).thenReturn(Lists.newArrayList(configResource));
-        LinkedList<Configuration> configurationList = new LinkedList<Configuration>();
+        List<Configuration> configurationList = new ArrayList<Configuration>();
         Instance.loadMetricConfigResources(config, configurationList);
 
         assertEquals(2, configurationList.size());

--- a/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
+++ b/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
@@ -8,7 +8,8 @@ import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedList;
+import java.util.List;
+
 import org.datadog.jmxfetch.reporter.Reporter;
 import org.junit.Test;
 
@@ -24,13 +25,13 @@ public class TestServiceChecks extends TestCommon {
         initApplication("jmx.yaml");
 
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> metrics = getMetrics();
 
         // Test that an OK service check status is sent
-        LinkedList<HashMap<String, Object>> serviceChecks = getServiceChecks();
+        List<HashMap<String, Object>> serviceChecks = getServiceChecks();
 
         assertEquals(1, serviceChecks.size());
-        HashMap<String, Object> sc = serviceChecks.getFirst();
+        HashMap<String, Object> sc = serviceChecks.get(0);
         assertNotNull(sc.get("name"));
         assertNotNull(sc.get("status"));
         assertNull(sc.get("message"));
@@ -64,12 +65,12 @@ public class TestServiceChecks extends TestCommon {
         run();
 
         // Test that an WARNING service check status is sent
-        LinkedList<HashMap<String, Object>> serviceChecks = getServiceChecks();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<HashMap<String, Object>> serviceChecks = getServiceChecks();
+        List<HashMap<String, Object>> metrics = getMetrics();
         assertTrue(metrics.size() >= 350);
 
         assertEquals(1, serviceChecks.size());
-        HashMap<String, Object> sc = serviceChecks.getFirst();
+        HashMap<String, Object> sc = serviceChecks.get(0);
         assertNotNull(sc.get("name"));
         assertNotNull(sc.get("status"));
 
@@ -99,10 +100,10 @@ public class TestServiceChecks extends TestCommon {
         initApplication("non_running_process.yaml");
 
         // Test that a CRITICAL service check status is sent on initialization
-        LinkedList<HashMap<String, Object>> serviceChecks = getServiceChecks();
+        List<HashMap<String, Object>> serviceChecks = getServiceChecks();
         assertEquals(1, serviceChecks.size());
 
-        HashMap<String, Object> sc = serviceChecks.getFirst();
+        HashMap<String, Object> sc = serviceChecks.get(0);
         assertNotNull(sc.get("name"));
         assertNotNull(sc.get("status"));
         assertNotNull(sc.get("message"));
@@ -129,7 +130,7 @@ public class TestServiceChecks extends TestCommon {
         serviceChecks = getServiceChecks();
         assertEquals(1, serviceChecks.size());
 
-        sc = serviceChecks.getFirst();
+        sc = serviceChecks.get(0);
         assertNotNull(sc.get("name"));
         assertNotNull(sc.get("status"));
         assertNotNull(sc.get("message"));


### PR DESCRIPTION
LinkedList are heavier regarding memory footprint, we prefer to void
its usage by just replacing by ArrayList.
I have changed also the type to use List interface as it will be
easier to change implementation if required.
Some lists are also pre-sized when possible.