### PR TITLE
Support sending a `service` tag

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -88,6 +88,7 @@ public class Instance {
     private Map<String, Object> instanceMap;
     private Map<String, Object> initConfig;
     private String instanceName;
+    private String service;
     private Map<String, String> tags;
     private String checkName;
     private int maxReturnedMetrics;
@@ -138,6 +139,14 @@ public class Instance {
         } else {
             // Allow global overrides
             this.refreshBeansPeriod = appConfig.getRefreshBeansPeriod();
+        }
+
+        this.service = (String) instanceMap.get("service");
+        if (this.service == null && initConfig != null) {
+            this.service = (String) initConfig.get("service");
+        }
+        if (this.service != null && this.service != "") {
+            this.tags.put("service", this.service);
         }
 
         this.minCollectionPeriod = (Integer) instanceMap.get("min_collection_interval");
@@ -666,6 +675,10 @@ public class Instance {
             }
         }
         tags.add("instance:" + this.instanceName);
+
+        if (this.service != null && this.service != "") {
+            tags.add("service:" + this.service);
+        }
 
         if (this.emptyDefaultHostname) {
             tags.add("host:");

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -142,7 +142,7 @@ public class Instance {
         }
 
         this.service = (String) instanceMap.get("service");
-        if (this.service == null && initConfig != null) {
+        if ((this.service == null || this.service == "") && initConfig != null) {
             this.service = (String) initConfig.get("service");
         }
         if (this.service != null && this.service != "") {

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -142,10 +142,10 @@ public class Instance {
         }
 
         this.service = (String) instanceMap.get("service");
-        if ((this.service == null || this.service == "") && initConfig != null) {
+        if ((this.service == null || this.service.isEmpty()) && initConfig != null) {
             this.service = (String) initConfig.get("service");
         }
-        if (this.service != null && this.service != "") {
+        if (this.service != null && !this.service.isEmpty()) {
             this.tags.put("service", this.service);
         }
 
@@ -676,7 +676,7 @@ public class Instance {
         }
         tags.add("instance:" + this.instanceName);
 
-        if (this.service != null && this.service != "") {
+        if (this.service != null && !this.service.isEmpty()) {
             tags.add("service:" + this.service);
         }
 

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -77,6 +77,53 @@ public class TestInstance extends TestCommon {
         }
     }
 
+    // assertServiceTag is used by testServiceTagGlobal and testServiceTagInstanceOverride
+    private void assertServiceTag(List<String> tagList, String service) throws Exception {
+        assertTrue(tagList.contains(new String("service:" + service)));
+    }
+
+    @Test
+    public void testServiceTagGlobal() throws Exception {
+        registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:foo=Bar,qux=Baz");
+        initApplication("jmx_service_tag_global.yaml");
+        run();
+
+        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        assertEquals(28, metrics.size());
+        for (HashMap<String, Object> metric : metrics) {
+            String[] tags = (String[]) metric.get("tags");
+            this.assertServiceTag(Arrays.asList(tags), "global");
+        }
+
+        LinkedList<HashMap<String, Object>> serviceChecks = getServiceChecks();
+        assertEquals(2, serviceChecks.size());
+        for (HashMap<String, Object> sc : serviceChecks) {
+            String[] tags = (String[]) sc.get("tags");
+            this.assertServiceTag(Arrays.asList(tags), "global");
+        }
+    }
+
+    @Test
+    public void testServiceTagInstanceOverride() throws Exception {
+        registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:foo=Bar,qux=Baz");
+        initApplication("jmx_service_tag_instance_override.yaml");
+        run();
+
+        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        assertEquals(28, metrics.size());
+        for (HashMap<String, Object> metric : metrics) {
+            String[] tags = (String[]) metric.get("tags");
+            this.assertServiceTag(Arrays.asList(tags), "override");
+        }
+
+        LinkedList<HashMap<String, Object>> serviceChecks = getServiceChecks();
+        assertEquals(2, serviceChecks.size());
+        for (HashMap<String, Object> sc : serviceChecks) {
+            String[] tags = (String[]) sc.get("tags");
+            this.assertServiceTag(Arrays.asList(tags), "override");
+        }
+    }
+
     @Test
     public void testLoadMetricConfigFiles() throws Exception {
         URL defaultConfig = Instance.class.getResource("default-jmx-metrics.yaml");

--- a/src/test/resources/jmx_service_tag_global.yaml
+++ b/src/test/resources/jmx_service_tag_global.yaml
@@ -1,0 +1,27 @@
+init_config:
+  service: global
+
+instances:
+  -   process_name_regex: .*surefire.*
+      name: jmx_test_1
+      tags:
+        - jmx:fetch
+      conf:
+          - include:
+             domain: org.datadog.jmxfetch.test
+             attribute:
+                  ShouldBe100:
+                      metric_type: gauge
+                      alias: this.is.100.$foo.$qux
+
+  -   process_name_regex: .*surefire.*
+      name: jmx_test_2
+      tags:
+        - jmx:fetch
+      conf:
+          - include:
+             domain: org.datadog.jmxfetch.test
+             attribute:
+                  ShouldBe100:
+                      metric_type: gauge
+                      alias: this.is.100.$foo.$qux

--- a/src/test/resources/jmx_service_tag_instance_override.yaml
+++ b/src/test/resources/jmx_service_tag_instance_override.yaml
@@ -1,0 +1,29 @@
+init_config:
+  service: global
+
+instances:
+  -   process_name_regex: .*surefire.*
+      name: jmx_test_1
+      service: override
+      tags:
+        - jmx:fetch
+      conf:
+          - include:
+             domain: org.datadog.jmxfetch.test
+             attribute:
+                  ShouldBe100:
+                      metric_type: gauge
+                      alias: this.is.100.$foo.$qux
+
+  -   process_name_regex: .*surefire.*
+      name: jmx_test_2
+      service: override
+      tags:
+        - jmx:fetch
+      conf:
+          - include:
+             domain: org.datadog.jmxfetch.test
+             attribute:
+                  ShouldBe100:
+                      metric_type: gauge
+                      alias: this.is.100.$foo.$qux


### PR DESCRIPTION
We want to feature the notion of service more prominently for integrations so that we can correlate metrics with logs and traces

See:

https://github.com/DataDog/datadog-agent/pull/4877
https://github.com/DataDog/datadog-agent/pull/4895