### PR TITLE
Replace Map metric by a Metric class

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -33,7 +33,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -489,8 +488,8 @@ public class App {
         loopCounter++;
 
         try {
-            List<InstanceTask<List<Map<String, Object>>>> getMetricsTasks =
-                    new ArrayList<InstanceTask<List<Map<String, Object>>>>(instances.size());
+            List<InstanceTask<List<Metric>>> getMetricsTasks =
+                    new ArrayList<InstanceTask<List<Metric>>>(instances.size());
 
             for (Instance instance : instances) {
                 getMetricsTasks.add(new MetricCollectionTask(instance));
@@ -510,11 +509,11 @@ public class App {
                             getMetricsTasks,
                             appConfig.getCollectionTimeout(),
                             TimeUnit.SECONDS,
-                            new TaskMethod<List<Map<String, Object>>>() {
+                            new TaskMethod<List<Metric>>() {
                                 @Override
                                 public TaskStatusHandler invoke(
                                         Instance instance,
-                                        Future<List<Map<String, Object>>> future,
+                                        Future<List<Metric>> future,
                                         Reporter reporter) {
                                     return App.processCollectionResults(instance, future, reporter);
                                 }
@@ -975,7 +974,7 @@ public class App {
 
     static TaskStatusHandler processCollectionResults(
             Instance instance,
-            Future<List<Map<String, Object>>> future,
+            Future<List<Metric>> future,
             Reporter reporter) {
 
         TaskStatusHandler status = new TaskStatusHandler();
@@ -985,8 +984,7 @@ public class App {
             int numberOfMetrics = 0;
 
             if (future.isDone()) {
-                List<Map<String, Object>> metrics;
-                metrics = future.get();
+                List<Metric> metrics = future.get();
                 numberOfMetrics = metrics.size();
 
                 status.setData(metrics);
@@ -1122,7 +1120,7 @@ public class App {
             String instanceMessage = null;
             String instanceStatus = Status.STATUS_OK;
             String scStatus = Status.STATUS_OK;
-            List<Map<String, Object>> metrics;
+            List<Metric> metrics;
 
             int numberOfMetrics = 0;
 
@@ -1135,7 +1133,7 @@ public class App {
                 status.raiseForStatus();
 
                 // If we get here all was good - metric count  available
-                metrics = (List<Map<String, Object>>) status.getData();
+                metrics = (List<Metric>) status.getData();
                 numberOfMetrics = metrics.size();
 
                 if (instance.isLimitReached()) {

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -403,7 +403,7 @@ public class Instance {
     }
 
     /** Returns a map of metrics collected. */
-    public List<Map<String, Object>> getMetrics() throws IOException {
+    public List<Metric> getMetrics() throws IOException {
 
         // We can force to refresh the bean list every x seconds in case of ephemeral beans
         // To enable this, a "refresh_beans" parameter must be specified in the yaml/json config
@@ -415,7 +415,7 @@ public class Instance {
             this.getMatchingAttributes();
         }
 
-        List<Map<String, Object>> metrics = new ArrayList<Map<String, Object>>();
+        List<Metric> metrics = new ArrayList<Metric>();
         Iterator<JmxAttribute> it = matchingAttributes.iterator();
 
         // increment the lastCollectionTime
@@ -424,9 +424,9 @@ public class Instance {
         while (it.hasNext()) {
             JmxAttribute jmxAttr = it.next();
             try {
-                List<Map<String, Object>> jmxAttrMetrics = jmxAttr.getMetrics();
-                for (Map<String, Object> m : jmxAttrMetrics) {
-                    m.put("check_name", this.checkName);
+                List<Metric> jmxAttrMetrics = jmxAttr.getMetrics();
+                for (Metric m : jmxAttrMetrics) {
+                    m.setCheckName(this.checkName);
                     metrics.add(m);
                 }
 

--- a/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
@@ -232,7 +232,7 @@ public abstract class JmxAttribute {
                 + attribute.getType();
     }
 
-    public abstract List<Map<String, Object>> getMetrics()
+    public abstract List<Metric> getMetrics()
             throws AttributeNotFoundException, InstanceNotFoundException, MBeanException,
                     ReflectionException, IOException;
 

--- a/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
@@ -2,7 +2,6 @@ package org.datadog.jmxfetch;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.management.AttributeNotFoundException;
@@ -36,16 +35,15 @@ public class JmxSimpleAttribute extends JmxAttribute {
     }
 
     @Override
-    public List<Map<String, Object>> getMetrics()
+    public List<Metric> getMetrics()
             throws AttributeNotFoundException, InstanceNotFoundException, MBeanException,
                     ReflectionException, IOException {
-        Map<String, Object> metric = new HashMap<String, Object>();
-
-        metric.put("alias", getAlias());
-        metric.put("value", castToDouble(getValue(), null));
-        metric.put("tags", getTags());
-        metric.put("metric_type", getMetricType());
-        List<Map<String, Object>> metrics = new ArrayList<Map<String, Object>>(1);
+        String alias = getAlias();
+        String metricType = getMetricType();
+        double value = castToDouble(getValue(), null);
+        String[] tags = getTags();
+        Metric metric = new Metric(alias, metricType, value, tags);
+        List<Metric> metrics = new ArrayList<Metric>(1);
         metrics.add(metric);
         return metrics;
     }

--- a/src/main/java/org/datadog/jmxfetch/Metric.java
+++ b/src/main/java/org/datadog/jmxfetch/Metric.java
@@ -1,0 +1,46 @@
+package org.datadog.jmxfetch;
+
+/**
+ * Metric carrier class.
+ */
+public class Metric {
+    private final String alias;
+    private final String metricType;
+    private final double value;
+    private final String[] tags;
+    private String checkName;
+
+    /**
+     * Metric constructor.
+     */
+    public Metric(String alias, String metricType, double value, String[] tags) {
+        this.alias = alias;
+        this.metricType = metricType;
+        this.value = value;
+        this.tags = tags;
+    }
+
+    public String getAlias() {
+        return alias;
+    }
+
+    public String getMetricType() {
+        return metricType;
+    }
+
+    public double getValue() {
+        return value;
+    }
+
+    public String[] getTags() {
+        return tags;
+    }
+
+    public String getCheckName() {
+        return checkName;
+    }
+
+    public void setCheckName(String checkName) {
+        this.checkName = checkName;
+    }
+}

--- a/src/main/java/org/datadog/jmxfetch/MetricCollectionTask.java
+++ b/src/main/java/org/datadog/jmxfetch/MetricCollectionTask.java
@@ -2,21 +2,18 @@ package org.datadog.jmxfetch;
 
 import lombok.extern.slf4j.Slf4j;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 @Slf4j
-class MetricCollectionTask extends InstanceTask<List<Map<String, Object>>> {
+class MetricCollectionTask extends InstanceTask<List<Metric>> {
     MetricCollectionTask(Instance instance) {
         super(instance);
         setWarning("Unable to collect metrics or refresh bean list.");
     }
 
     @Override
-    public List<Map<String, Object>> call() throws Exception {
+    public List<Metric> call() throws Exception {
 
         if (!instance.timeToCollect()) {
             log.debug(

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -90,16 +90,16 @@ public class TestInstance extends TestCommon {
         initApplication("jmx_service_tag_global.yaml");
         run();
 
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<Map<String, Object>> metrics = getMetrics();
         assertEquals(28, metrics.size());
-        for (HashMap<String, Object> metric : metrics) {
+        for (Map<String, Object> metric : metrics) {
             String[] tags = (String[]) metric.get("tags");
             this.assertServiceTag(Arrays.asList(tags), "global");
         }
 
-        LinkedList<HashMap<String, Object>> serviceChecks = getServiceChecks();
+        List<Map<String, Object>> serviceChecks = getServiceChecks();
         assertEquals(2, serviceChecks.size());
-        for (HashMap<String, Object> sc : serviceChecks) {
+        for (Map<String, Object> sc : serviceChecks) {
             String[] tags = (String[]) sc.get("tags");
             this.assertServiceTag(Arrays.asList(tags), "global");
         }
@@ -111,16 +111,16 @@ public class TestInstance extends TestCommon {
         initApplication("jmx_service_tag_instance_override.yaml");
         run();
 
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<Map<String, Object>> metrics = getMetrics();
         assertEquals(28, metrics.size());
-        for (HashMap<String, Object> metric : metrics) {
+        for (Map<String, Object> metric : metrics) {
             String[] tags = (String[]) metric.get("tags");
             this.assertServiceTag(Arrays.asList(tags), "override");
         }
 
-        LinkedList<HashMap<String, Object>> serviceChecks = getServiceChecks();
+        List<Map<String, Object>> serviceChecks = getServiceChecks();
         assertEquals(2, serviceChecks.size());
-        for (HashMap<String, Object> sc : serviceChecks) {
+        for (Map<String, Object> sc : serviceChecks) {
             String[] tags = (String[]) sc.get("tags");
             this.assertServiceTag(Arrays.asList(tags), "override");
         }


### PR DESCRIPTION
During collection process, metrics are collected as
Map<String, Object>, but keys are known and fixed so we can replace
this map to a POJO which will be lighter in term of memory footprint
and allocation.