### PR TITLE
Display the service check in the JsonReporter

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
@@ -39,8 +39,19 @@ public class JsonReporter extends Reporter {
 
     /** Use the service check callback to display the JSON. */
     public void doSendServiceCheck(String checkName, String status, String message, String[] tags) {
+        Map<String, Object> sc = new HashMap<String, Object>();
+        sc.put("check", checkName);
+        sc.put("host_name", "default");
+        sc.put("timestamp", System.currentTimeMillis() / 1000);
+        sc.put("status", status);
+        sc.put("message", message);
+        sc.put("tags", tags);
+
         Map<String, Object> aggregator = new HashMap<String, Object>();
         aggregator.put("metrics", metrics);
+        List<Object> serviceChecks = new ArrayList<Object>();
+        serviceChecks.add(sc);
+        aggregator.put("service_checks", serviceChecks);
         Map<String, Object> serie = new HashMap<String, Object>();
         serie.put("aggregator", aggregator);
         List<Map<String, Object>> series = new ArrayList<Map<String, Object>>(1);


### PR DESCRIPTION
We can add the service check in the output that we produce, that will
make it available in end to end testing.