### PR TITLE
Add class name and class regex filters

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Connection.java
+++ b/src/main/java/org/datadog/jmxfetch/Connection.java
@@ -50,6 +50,13 @@ public class Connection {
         return mbs.getMBeanInfo(beanName).getAttributes();
     }
 
+    /** Gets class for matching bean name. */
+    public String getClassForBean(ObjectName beanName)
+            throws InstanceNotFoundException, IntrospectionException, ReflectionException,
+            IOException {
+        return mbs.getMBeanInfo(beanName).getClassName();
+    }
+
     /** Queries beans on specific scope. Returns set of matching query names.. */
     public Set<ObjectName> queryNames(ObjectName name) throws IOException {
         String scope = (name != null) ? name.toString() : "*:*";

--- a/src/main/java/org/datadog/jmxfetch/Connection.java
+++ b/src/main/java/org/datadog/jmxfetch/Connection.java
@@ -50,7 +50,7 @@ public class Connection {
         return mbs.getMBeanInfo(beanName).getAttributes();
     }
 
-    /** Gets class for matching bean name. */
+    /** Gets class name for matching bean name. */
     public String getClassNameForBean(ObjectName beanName)
             throws InstanceNotFoundException, IntrospectionException, ReflectionException,
             IOException {

--- a/src/main/java/org/datadog/jmxfetch/Connection.java
+++ b/src/main/java/org/datadog/jmxfetch/Connection.java
@@ -51,7 +51,7 @@ public class Connection {
     }
 
     /** Gets class for matching bean name. */
-    public String getClassForBean(ObjectName beanName)
+    public String getClassNameForBean(ObjectName beanName)
             throws InstanceNotFoundException, IntrospectionException, ReflectionException,
             IOException {
         return mbs.getMBeanInfo(beanName).getClassName();

--- a/src/main/java/org/datadog/jmxfetch/Filter.java
+++ b/src/main/java/org/datadog/jmxfetch/Filter.java
@@ -8,6 +8,7 @@ import java.util.regex.Pattern;
 class Filter {
     HashMap<String, Object> filter;
     Pattern domainRegex;
+    Pattern classNameRegex;
     ArrayList<Pattern> beanRegexes = null;
     ArrayList<String> excludeTags = null;
     HashMap<String, String> additionalTags = null;
@@ -149,6 +150,23 @@ class Filter {
 
         return this.domainRegex;
     }
+
+    public String getClassName() {
+        return (String) filter.get("class");
+    }
+
+    public Pattern getClassNameRegex() {
+        if (this.filter.get("class_regex") == null) {
+            return null;
+        }
+
+        if (this.classNameRegex == null) {
+            this.classNameRegex = Pattern.compile((String) this.filter.get("class_regex"));
+        }
+
+        return this.classNameRegex;
+    }
+
 
     public Object getAttribute() {
         return filter.get("attribute");

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -495,7 +495,7 @@ public class Instance {
             String className;
 
             try {
-                className = connection.getClassForBean(beanName);
+                className = connection.getClassNameForBean(beanName);
                 log.debug("ClassName: " + className);
             } catch (Exception e) {
                 log.warn("Cannot get class name " + e.getMessage());

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -20,7 +20,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import javax.management.*;
+import javax.management.MBeanAttributeInfo;
+import javax.management.ObjectName;
 import javax.security.auth.login.FailedLoginException;
 
 @Slf4j

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -21,8 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import javax.management.MBeanAttributeInfo;
-import javax.management.ObjectName;
+import javax.management.*;
 import javax.security.auth.login.FailedLoginException;
 
 @Slf4j
@@ -477,7 +476,6 @@ public class Instance {
                 }
             }
             MBeanAttributeInfo[] attributeInfos;
-
             try {
                 // Get all the attributes for bean_name
                 log.debug("Getting attributes for bean: " + beanName);
@@ -491,6 +489,16 @@ public class Instance {
                 continue;
             } catch (Exception e) {
                 log.warn("Cannot get bean attributes " + e.getMessage());
+                continue;
+            }
+
+            String className;
+
+            try {
+                className = connection.getClassForBean(beanName);
+                log.debug("ClassName: " + className);
+            } catch (Exception e) {
+                log.warn("Cannot get class name " + e.getMessage());
                 continue;
             }
 
@@ -521,6 +529,7 @@ public class Instance {
                             new JmxSimpleAttribute(
                                     attributeInfo,
                                     beanName,
+                                    className,
                                     instanceName,
                                     connection,
                                     tags,
@@ -537,6 +546,7 @@ public class Instance {
                             new JmxComplexAttribute(
                                     attributeInfo,
                                     beanName,
+                                    className,
                                     instanceName,
                                     connection,
                                     tags,
@@ -552,6 +562,7 @@ public class Instance {
                             new JmxTabularAttribute(
                                     attributeInfo,
                                     beanName,
+                                    className,
                                     instanceName,
                                     connection,
                                     tags,

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -477,30 +477,24 @@ public class Instance {
                     break;
                 }
             }
+            String className;
             MBeanAttributeInfo[] attributeInfos;
             try {
+                log.debug("Getting class name for bean: " + beanName);
+                className = connection.getClassNameForBean(beanName);
+
                 // Get all the attributes for bean_name
                 log.debug("Getting attributes for bean: " + beanName);
                 attributeInfos = connection.getAttributesForBean(beanName);
             } catch (IOException e) {
                 // we should not continue
-                log.warn("Cannot get bean attributes " + e.getMessage());
+                log.warn("Cannot get bean attributes or class name: " + e.getMessage());
                 if (e.getMessage() == connection.CLOSED_CLIENT_CAUSE) {
                     throw e;
                 }
                 continue;
             } catch (Exception e) {
-                log.warn("Cannot get bean attributes " + e.getMessage());
-                continue;
-            }
-
-            String className;
-
-            try {
-                className = connection.getClassNameForBean(beanName);
-                log.debug("ClassName: " + className);
-            } catch (Exception e) {
-                log.warn("Cannot get class name " + e.getMessage());
+                log.warn("Cannot get bean attributes or class name: " + e.getMessage());
                 continue;
             }
 

--- a/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
@@ -35,6 +35,7 @@ public abstract class JmxAttribute {
                     "bean_name",
                     "bean",
                     "bean_regex",
+                    "class_name",
                     "attribute",
                     "exclude_tags",
                     "tags");
@@ -48,6 +49,7 @@ public abstract class JmxAttribute {
     private Connection connection;
     private ObjectName beanName;
     private String domain;
+    private String className;
     private String beanStringName;
     private HashMap<String, String> beanParameters;
     private String attributeName;
@@ -61,6 +63,7 @@ public abstract class JmxAttribute {
     JmxAttribute(
             MBeanAttributeInfo attribute,
             ObjectName beanName,
+            String className,
             String instanceName,
             Connection connection,
             Map<String, String> instanceTags,
@@ -68,6 +71,7 @@ public abstract class JmxAttribute {
             boolean emptyDefaultHostname) {
         this.attribute = attribute;
         this.beanName = beanName;
+        this.className = className;
         this.matchingConf = null;
         this.connection = connection;
         this.attributeName = attribute.getName();
@@ -272,13 +276,31 @@ public abstract class JmxAttribute {
         return (includeDomain == null || includeDomain.equals(domain))
                 && (includeDomainRegex == null || includeDomainRegex.matcher(domain).matches());
     }
-
     boolean excludeMatchDomain(Configuration conf) {
         String excludeDomain = conf.getExclude().getDomain();
         Pattern excludeDomainRegex = conf.getExclude().getDomainRegex();
 
         return excludeDomain != null && excludeDomain.equals(domain)
                 || excludeDomainRegex != null && excludeDomainRegex.matcher(domain).matches();
+    }
+
+
+    boolean matchClassName(Configuration conf) {
+        String includeClassName = conf.getInclude().getClassName();
+        Pattern includeClassNameRegex = conf.getInclude().getClassNameRegex();
+        log.debug("matchClassName className: " + className);
+        log.debug("matchClassName includeClassName: " + includeClassName);
+
+        return (includeClassName == null || includeClassName.equals(className))
+                && (includeClassNameRegex == null || includeClassNameRegex.matcher(className).matches());
+    }
+
+    boolean excludeMatchClassName(Configuration conf) {
+        String excludeClassName = conf.getExclude().getClassName();
+        Pattern excludeClassNameRegex = conf.getExclude().getClassNameRegex();
+
+        return excludeClassName != null && excludeClassName.equals(className)
+                || excludeClassNameRegex != null && excludeClassNameRegex.matcher(className).matches();
     }
 
     Object convertMetricValue(Object metricValue, String field) {

--- a/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
@@ -291,8 +291,6 @@ public abstract class JmxAttribute {
     boolean matchClassName(Configuration conf) {
         String includeClassName = conf.getInclude().getClassName();
         Pattern includeClassNameRegex = conf.getInclude().getClassNameRegex();
-        log.debug("matchClassName className: " + className);
-        log.debug("matchClassName includeClassName: " + includeClassName);
 
         return (includeClassName == null || includeClassName.equals(className))
                 && (includeClassNameRegex == null || includeClassNameRegex.matcher(className).matches());

--- a/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
@@ -35,7 +35,8 @@ public abstract class JmxAttribute {
                     "bean_name",
                     "bean",
                     "bean_regex",
-                    "class_name",
+                    "class",
+                    "class_regex",
                     "attribute",
                     "exclude_tags",
                     "tags");
@@ -298,7 +299,6 @@ public abstract class JmxAttribute {
     boolean excludeMatchClassName(Configuration conf) {
         String excludeClassName = conf.getExclude().getClassName();
         Pattern excludeClassNameRegex = conf.getExclude().getClassNameRegex();
-
         return excludeClassName != null && excludeClassName.equals(className)
                 || excludeClassNameRegex != null && excludeClassNameRegex.matcher(className).matches();
     }

--- a/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
@@ -279,6 +279,7 @@ public abstract class JmxAttribute {
         return (includeDomain == null || includeDomain.equals(domain))
                 && (includeDomainRegex == null || includeDomainRegex.matcher(domain).matches());
     }
+
     boolean excludeMatchDomain(Configuration conf) {
         String excludeDomain = conf.getExclude().getDomain();
         Pattern excludeDomainRegex = conf.getExclude().getDomainRegex();
@@ -293,14 +294,16 @@ public abstract class JmxAttribute {
         Pattern includeClassNameRegex = conf.getInclude().getClassNameRegex();
 
         return (includeClassName == null || includeClassName.equals(className))
-                && (includeClassNameRegex == null || includeClassNameRegex.matcher(className).matches());
+                && (includeClassNameRegex == null
+                    || includeClassNameRegex.matcher(className).matches());
     }
 
     boolean excludeMatchClassName(Configuration conf) {
         String excludeClassName = conf.getExclude().getClassName();
         Pattern excludeClassNameRegex = conf.getExclude().getClassNameRegex();
         return excludeClassName != null && excludeClassName.equals(className)
-                || excludeClassNameRegex != null && excludeClassNameRegex.matcher(className).matches();
+                || excludeClassNameRegex != null
+                && excludeClassNameRegex.matcher(className).matches();
     }
 
     Object convertMetricValue(Object metricValue, String field) {

--- a/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
@@ -273,37 +273,39 @@ public abstract class JmxAttribute {
     }
 
     boolean matchDomain(Configuration conf) {
-        String includeDomain = conf.getInclude().getDomain();
-        Pattern includeDomainRegex = conf.getInclude().getDomainRegex();
-
-        return (includeDomain == null || includeDomain.equals(domain))
-                && (includeDomainRegex == null || includeDomainRegex.matcher(domain).matches());
+        return includeMatchName(domain,
+                conf.getInclude().getDomain(),
+                conf.getInclude().getDomainRegex());
     }
 
     boolean excludeMatchDomain(Configuration conf) {
-        String excludeDomain = conf.getExclude().getDomain();
-        Pattern excludeDomainRegex = conf.getExclude().getDomainRegex();
-
-        return excludeDomain != null && excludeDomain.equals(domain)
-                || excludeDomainRegex != null && excludeDomainRegex.matcher(domain).matches();
+        return excludeMatchName(domain,
+                conf.getExclude().getDomain(),
+                conf.getExclude().getDomainRegex());
     }
 
 
     boolean matchClassName(Configuration conf) {
-        String includeClassName = conf.getInclude().getClassName();
-        Pattern includeClassNameRegex = conf.getInclude().getClassNameRegex();
-
-        return (includeClassName == null || includeClassName.equals(className))
-                && (includeClassNameRegex == null
-                    || includeClassNameRegex.matcher(className).matches());
+        return includeMatchName(className,
+                conf.getInclude().getClassName(),
+                conf.getInclude().getClassNameRegex());
     }
 
+
     boolean excludeMatchClassName(Configuration conf) {
-        String excludeClassName = conf.getExclude().getClassName();
-        Pattern excludeClassNameRegex = conf.getExclude().getClassNameRegex();
-        return excludeClassName != null && excludeClassName.equals(className)
-                || excludeClassNameRegex != null
-                && excludeClassNameRegex.matcher(className).matches();
+        return excludeMatchName(className,
+                conf.getExclude().getClassName(),
+                conf.getExclude().getClassNameRegex());
+    }
+
+    private boolean includeMatchName(String name, String includeName, Pattern includeNameRegex) {
+        return (includeName == null || includeName.equals(name))
+                && (includeNameRegex == null || includeNameRegex.matcher(name).matches());
+    }
+
+    private boolean excludeMatchName(String name, String excludeName, Pattern excludeNameRegex) {
+        return (excludeName != null && excludeName.equals(name))
+                || (excludeNameRegex != null && excludeNameRegex.matcher(name).matches());
     }
 
     Object convertMetricValue(Object metricValue, String field) {

--- a/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
@@ -23,6 +23,7 @@ public class JmxComplexAttribute extends JmxAttribute {
     public JmxComplexAttribute(
             MBeanAttributeInfo attribute,
             ObjectName beanName,
+            String className,
             String instanceName,
             Connection connection,
             Map<String, String> instanceTags,
@@ -30,6 +31,7 @@ public class JmxComplexAttribute extends JmxAttribute {
         super(
                 attribute,
                 beanName,
+                className,
                 instanceName,
                 connection,
                 instanceTags,
@@ -125,8 +127,10 @@ public class JmxComplexAttribute extends JmxAttribute {
     @Override
     public boolean match(Configuration configuration) {
         if (!matchDomain(configuration)
+                || !matchClassName(configuration)
                 || !matchBean(configuration)
                 || excludeMatchDomain(configuration)
+                || excludeMatchClassName(configuration)
                 || excludeMatchBean(configuration)) {
             return false;
         }

--- a/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
@@ -20,6 +20,7 @@ public class JmxSimpleAttribute extends JmxAttribute {
     public JmxSimpleAttribute(
             MBeanAttributeInfo attribute,
             ObjectName beanName,
+            String className,
             String instanceName,
             Connection connection,
             Map<String, String> instanceTags,
@@ -28,6 +29,7 @@ public class JmxSimpleAttribute extends JmxAttribute {
         super(
                 attribute,
                 beanName,
+                className,
                 instanceName,
                 connection,
                 instanceTags,
@@ -53,9 +55,11 @@ public class JmxSimpleAttribute extends JmxAttribute {
     /** Returns whether an attribute matches in a configuration spec. */
     public boolean match(Configuration configuration) {
         return matchDomain(configuration)
+                && matchClassName(configuration)
                 && matchBean(configuration)
                 && matchAttribute(configuration)
                 && !(excludeMatchDomain(configuration)
+                        || excludeMatchClassName(configuration)
                         || excludeMatchBean(configuration)
                         || excludeMatchAttribute(configuration));
     }

--- a/src/main/java/org/datadog/jmxfetch/JmxSubAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxSubAttribute.java
@@ -8,9 +8,10 @@ import javax.management.ObjectName;
 abstract class JmxSubAttribute extends JmxAttribute {
     private Map<String, Metric> cachedMetrics = new HashMap<String, Metric>();
 
-    public JmxSubAttribute(MBeanAttributeInfo attribute, ObjectName beanName, String className, String instanceName,
-            String checkName, Connection connection, Map<String, String> instanceTags,
-            boolean cassandraAliasing, boolean emptyDefaultHostname) {
+    public JmxSubAttribute(MBeanAttributeInfo attribute, ObjectName beanName, String className,
+            String instanceName, String checkName, Connection connection,
+            Map<String, String> instanceTags, boolean cassandraAliasing,
+            boolean emptyDefaultHostname) {
         super(attribute, beanName, className, instanceName, checkName, connection, instanceTags,
                 cassandraAliasing, emptyDefaultHostname);
     }

--- a/src/main/java/org/datadog/jmxfetch/JmxSubAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxSubAttribute.java
@@ -8,10 +8,10 @@ import javax.management.ObjectName;
 abstract class JmxSubAttribute extends JmxAttribute {
     private Map<String, Metric> cachedMetrics = new HashMap<String, Metric>();
 
-    public JmxSubAttribute(MBeanAttributeInfo attribute, ObjectName beanName, String instanceName,
+    public JmxSubAttribute(MBeanAttributeInfo attribute, ObjectName beanName, String className, String instanceName,
             String checkName, Connection connection, Map<String, String> instanceTags,
             boolean cassandraAliasing, boolean emptyDefaultHostname) {
-        super(attribute, beanName, instanceName, checkName, connection, instanceTags,
+        super(attribute, beanName, className, instanceName, checkName, connection, instanceTags,
                 cassandraAliasing, emptyDefaultHostname);
     }
 

--- a/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
@@ -32,6 +32,7 @@ public class JmxTabularAttribute extends JmxAttribute {
     public JmxTabularAttribute(
             MBeanAttributeInfo attribute,
             ObjectName beanName,
+            String className,
             String instanceName,
             Connection connection,
             Map<String, String> instanceTags,
@@ -39,6 +40,7 @@ public class JmxTabularAttribute extends JmxAttribute {
         super(
                 attribute,
                 beanName,
+                className,
                 instanceName,
                 connection,
                 instanceTags,
@@ -266,8 +268,10 @@ public class JmxTabularAttribute extends JmxAttribute {
     @Override
     public boolean match(Configuration configuration) {
         if (!matchDomain(configuration)
+                || !matchClassName(configuration)
                 || !matchBean(configuration)
                 || excludeMatchDomain(configuration)
+                || excludeMatchClassName(configuration)
                 || excludeMatchBean(configuration)) {
             return false;
         }

--- a/src/test/java/org/datadog/jmxfetch/SimpleTestJavaApp2.java
+++ b/src/test/java/org/datadog/jmxfetch/SimpleTestJavaApp2.java
@@ -1,5 +1,0 @@
-package org.datadog.jmxfetch;
-
-public class SimpleTestJavaApp2 extends SimpleTestJavaApp {
-
-}

--- a/src/test/java/org/datadog/jmxfetch/SimpleTestJavaApp2.java
+++ b/src/test/java/org/datadog/jmxfetch/SimpleTestJavaApp2.java
@@ -1,0 +1,5 @@
+package org.datadog.jmxfetch;
+
+public class SimpleTestJavaApp2 extends SimpleTestJavaApp {
+
+}

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -270,6 +270,47 @@ public class TestApp extends TestCommon {
     }
 
     @Test
+    public void testClassExclude() throws Exception {
+        // We expose a few metrics through JMX
+        registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.includeme:type=AType");
+        registerMBean(new SimpleTestJavaApp2(), "org.datadog.jmxfetch.includeme2:type=AnotherType");
+
+        // Initializing application
+        initApplication("jmx_class_exclude.yaml");
+
+        // Collecting metrics
+        run();
+        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+
+        // First filter 14 = 13 metrics from java.lang + 2 metrics explicitly define- 1 implicitly
+        // defined in the exclude section
+        assertEquals(14, metrics.size());
+    }
+
+    @Test
+    public void testClassRegex() throws Exception {
+        class SimpleTestJavaAppIncludeMe extends SimpleTestJavaApp { }
+        class SimpleTestJavaAppIncludeMeToo extends SimpleTestJavaApp { }
+        class SimpleTestJavaAppIncludeMeNotMeX extends SimpleTestJavaApp { }
+
+        // We expose a few metrics through JMX
+        registerMBean(new SimpleTestJavaAppIncludeMe(), "org.datadog.jmxfetch.includeme:type=AType");
+        registerMBean(new SimpleTestJavaAppIncludeMeToo(), "org.datadog.jmxfetch.includeme.too:type=AType");
+        registerMBean(new SimpleTestJavaAppIncludeMeNotMeX(), "org.datadog.jmxfetch.includeme.not.me:type=AType");
+
+        // Initializing application
+        initApplication("jmx_class_regex.yaml");
+
+        // Collecting metrics
+        run();
+        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+
+        // First filter 15 = 13 metrics from java.lang + 3 metrics explicitly defined - 1 implicitly
+        // defined in exclude section
+        assertEquals(15, metrics.size());
+    }
+
+    @Test
     public void testParameterMatch() throws Exception {
         // Do not match beans which do not contain types specified in the conf
         registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:param=AParameter");

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -272,9 +272,13 @@ public class TestApp extends TestCommon {
 
     @Test
     public void testClassExclude() throws Exception {
+        class SimpleTestJavaAnotherApp extends SimpleTestJavaApp {
+
+        }
+
         // We expose a few metrics through JMX
         registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.includeme:type=AType");
-        registerMBean(new SimpleTestJavaApp2(), "org.datadog.jmxfetch.includeme2:type=AnotherType");
+        registerMBean(new SimpleTestJavaAnotherApp(), "org.datadog.jmxfetch.includeme2:type=AnotherType");
 
         // Initializing application
         initApplication("jmx_class_exclude.yaml");

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -256,6 +256,20 @@ public class TestApp extends TestCommon {
     }
 
     @Test
+    public void testClassInclude() throws Exception {
+        // We expose a few metrics through JMX
+        registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.includeme:type=AType");
+        initApplication("jmx_class_include.yaml");
+
+        // Collecting metrics
+        run();
+        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+
+        // First filter 29 = 13 metrics from java.lang + 16 metrics implicitly defined
+        assertEquals(29, metrics.size());
+    }
+
+    @Test
     public void testParameterMatch() throws Exception {
         // Do not match beans which do not contain types specified in the conf
         registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:param=AParameter");

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -264,7 +264,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<Map<String, Object>> metrics = getMetrics();
 
         // First filter 29 = 13 metrics from java.lang + 16 metrics implicitly defined
         assertEquals(29, metrics.size());
@@ -281,7 +281,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<Map<String, Object>> metrics = getMetrics();
 
         // First filter 14 = 13 metrics from java.lang + 2 metrics explicitly define- 1 implicitly
         // defined in the exclude section
@@ -304,7 +304,7 @@ public class TestApp extends TestCommon {
 
         // Collecting metrics
         run();
-        LinkedList<HashMap<String, Object>> metrics = getMetrics();
+        List<Map<String, Object>> metrics = getMetrics();
 
         // First filter 15 = 13 metrics from java.lang + 3 metrics explicitly defined - 1 implicitly
         // defined in exclude section

--- a/src/test/resources/jmx_class_exclude.yaml
+++ b/src/test/resources/jmx_class_exclude.yaml
@@ -1,0 +1,13 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        conf:
+            - include:
+                  attribute:
+                      ShouldBe100:
+                          metric_type: gauge
+                          alias: this.is.100
+              exclude:
+                  class: org.datadog.jmxfetch.SimpleTestJavaApp2

--- a/src/test/resources/jmx_class_exclude.yaml
+++ b/src/test/resources/jmx_class_exclude.yaml
@@ -10,4 +10,4 @@ instances:
                           metric_type: gauge
                           alias: this.is.100
               exclude:
-                  class: org.datadog.jmxfetch.SimpleTestJavaApp2
+                  class: org.datadog.jmxfetch.TestApp$1SimpleTestJavaAnotherApp

--- a/src/test/resources/jmx_class_include.yaml
+++ b/src/test/resources/jmx_class_include.yaml
@@ -1,0 +1,11 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        conf:
+            - include:
+                class: org.datadog.jmxfetch.SimpleTestJavaApp
+#                domain: org.datadog.jmxfetch.includeme
+
+

--- a/src/test/resources/jmx_class_include.yaml
+++ b/src/test/resources/jmx_class_include.yaml
@@ -6,6 +6,3 @@ instances:
         conf:
             - include:
                 class: org.datadog.jmxfetch.SimpleTestJavaApp
-#                domain: org.datadog.jmxfetch.includeme
-
-

--- a/src/test/resources/jmx_class_regex.yaml
+++ b/src/test/resources/jmx_class_regex.yaml
@@ -1,0 +1,14 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        conf:
+            - include:
+                class_regex: .*IncludeMe.*
+                attribute:
+                    ShouldBe100:
+                        metric_type: gauge
+                        alias: this.is.100
+              exclude:
+                class_regex: .*Me$


### PR DESCRIPTION
## What this PR does

Add class name and class regex filters

## Motivation

Allow creating rules based on class name filters.

For example Kafka / Confluent Platform uses yammer metrics that provide different MBean classes like `Gauge`, `Histogram`, `Timer`, `Meter`. Since each class have different attributes and require specific rules, a filter by class can be helpful in targeting all metrics from a specific MBean class.

The classes are like follow:

```
- com.yammer.metrics.reporting.JmxReporter$Gauge
- com.yammer.metrics.reporting.JmxReporter$Histogram
- com.yammer.metrics.reporting.JmxReporter$Timer
- com.yammer.metrics.reporting.JmxReporter$Meter
```

That will allow creating rules tailored to each class:

```yaml
jmx_metrics:
  - include:
      domain_regex: kafka\..*
      class_regex: .*$Gauge
      attribute:
        Value:
          alias: $domain.$type.$name
          metric_type: gauge
  - include:
      domain_regex: kafka\..*
      class_regex: .*$Histogram
      attribute:
        Count:
          alias: $domain.$type.$name.count
          metric_type: count
        Mean:
          alias: $domain.$type.$name.avg
          metric_type: gauge
        99thPercentile:
          alias: $domain.$type.$name.99percentile
          metric_type: gauge

```

