### PR TITLE
Only log about broken instances when they exist

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -556,9 +556,7 @@ public class App {
         }
 
         // Attempt to fix broken instances
-        log.debug("Trying to recover broken instances...");
         fixBrokenInstances(reporter);
-        log.debug("Done trying to recover broken instances.");
 
         try {
             appConfig.getStatus().flush();
@@ -568,6 +566,11 @@ public class App {
     }
 
     private void fixBrokenInstances(Reporter reporter) {
+        if (brokenInstanceMap.isEmpty()) {
+            return;
+        }
+
+        log.debug("Trying to recover broken instances...");
         List<InstanceTask<Void>> fixInstanceTasks =
                 new ArrayList<InstanceTask<Void>>(brokenInstanceMap.values().size());
 
@@ -628,6 +631,8 @@ public class App {
         } catch (Exception e) {
             // NADA
         }
+
+        log.debug("Done trying to recover broken instances.");
     }
 
     /**


### PR DESCRIPTION
The previous behavior logged something similar to:

```
[dd.trace 2020-03-03 18:32:28:591 -0500] [dd-jmx-collector] DEBUG org.datadog.jmxfetch.App - Trying to recover broken instances...
[dd.trace 2020-03-03 18:32:28:591 -0500] [dd-jmx-collector] DEBUG org.datadog.jmxfetch.App - Done trying to recover broken instances.
```

_every iteration_.  This is noisy even at the debug level.  It also lead to confusion as to whether this was an error.

This pull request only prints the above log messages when there are broken traces.

I made sure the calls outside of the main for loop don't do anything if `brokenInstanceMap` (and therefore `fixInstanceTasks`) are empty.