### PR TITLE
Fix service check name for Console and Json Reporters

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
@@ -45,16 +45,16 @@ public class ConsoleReporter extends Reporter {
     }
 
     /** Adds service check to report on. */
-    public void doSendServiceCheck(String checkName, String status, String message, String[] tags) {
+    public void doSendServiceCheck(String serviceCheckName, String status, String message, String[] tags) {
         String tagString = "";
         if (tags != null && tags.length > 0) {
             tagString = "[" + Joiner.on(",").join(tags) + "]";
         }
         log.info(
-                checkName + tagString + " - " + System.currentTimeMillis() / 1000 + " = " + status);
+                serviceCheckName + tagString + " - " + System.currentTimeMillis() / 1000 + " = " + status);
 
         Map<String, Object> sc = new HashMap<String, Object>();
-        sc.put("name", checkName);
+        sc.put("name", serviceCheckName);
         sc.put("status", status);
         sc.put("message", message);
         sc.put("tags", tags);

--- a/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
@@ -45,13 +45,14 @@ public class ConsoleReporter extends Reporter {
     }
 
     /** Adds service check to report on. */
-    public void doSendServiceCheck(String serviceCheckName, String status, String message, String[] tags) {
+    public void doSendServiceCheck(
+            String serviceCheckName, String status, String message, String[] tags) {
         String tagString = "";
         if (tags != null && tags.length > 0) {
             tagString = "[" + Joiner.on(",").join(tags) + "]";
         }
-        log.info(
-                serviceCheckName + tagString + " - " + System.currentTimeMillis() / 1000 + " = " + status);
+        log.info(serviceCheckName + tagString + " - "
+                 + System.currentTimeMillis() / 1000 + " = " + status);
 
         Map<String, Object> sc = new HashMap<String, Object>();
         sc.put("name", serviceCheckName);

--- a/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
@@ -39,7 +39,8 @@ public class JsonReporter extends Reporter {
     }
 
     /** Use the service check callback to display the JSON. */
-    public void doSendServiceCheck(String serviceCheckName, String status, String message, String[] tags) {
+    public void doSendServiceCheck(
+            String serviceCheckName, String status, String message, String[] tags) {
         log.debug("Displaying JSON output");
         Map<String, Object> sc = new HashMap<String, Object>();
         sc.put("check", serviceCheckName);

--- a/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
@@ -39,10 +39,10 @@ public class JsonReporter extends Reporter {
     }
 
     /** Use the service check callback to display the JSON. */
-    public void doSendServiceCheck(String checkName, String status, String message, String[] tags) {
+    public void doSendServiceCheck(String serviceCheckName, String status, String message, String[] tags) {
         log.debug("Displaying JSON output");
         Map<String, Object> sc = new HashMap<String, Object>();
-        sc.put("check", checkName);
+        sc.put("check", serviceCheckName);
         sc.put("host_name", "default");
         sc.put("timestamp", System.currentTimeMillis() / 1000);
         sc.put("status", status);

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -157,9 +157,9 @@ public abstract class Reporter {
     /** Submits service check. */
     public void sendServiceCheck(String checkName, String status, String message, String[] tags) {
         this.incrementServiceCheckCount(checkName);
-        String dataName = Reporter.formatServiceCheckPrefix(checkName);
+        String serviceCheckName = String.format("%s.can_connect", Reporter.formatServiceCheckPrefix(checkName));
 
-        this.doSendServiceCheck(dataName, status, message, tags);
+        this.doSendServiceCheck(serviceCheckName, status, message, tags);
     }
 
     /** Increments the service check count - for book-keeping purposes. */

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -155,9 +155,11 @@ public abstract class Reporter {
     }
 
     /** Submits service check. */
-    public void sendServiceCheck(String checkName, String status, String message, String[] tags) {
+    public void sendServiceCheck(
+            String checkName, String status, String message, String[] tags) {
         this.incrementServiceCheckCount(checkName);
-        String serviceCheckName = String.format("%s.can_connect", Reporter.formatServiceCheckPrefix(checkName));
+        String serviceCheckName = String.format(
+                "%s.can_connect", Reporter.formatServiceCheckPrefix(checkName));
 
         this.doSendServiceCheck(serviceCheckName, status, message, tags);
     }

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -80,7 +80,8 @@ public class StatsdReporter extends Reporter {
     }
 
     /** Submits service check. */
-    public void doSendServiceCheck(String serviceCheckName, String status, String message, String[] tags) {
+    public void doSendServiceCheck(
+            String serviceCheckName, String status, String message, String[] tags) {
         if (System.currentTimeMillis() - this.initializationTime > 300 * 1000) {
             this.statsDClient.stop();
             init();

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -80,14 +80,14 @@ public class StatsdReporter extends Reporter {
     }
 
     /** Submits service check. */
-    public void doSendServiceCheck(String checkName, String status, String message, String[] tags) {
+    public void doSendServiceCheck(String serviceCheckName, String status, String message, String[] tags) {
         if (System.currentTimeMillis() - this.initializationTime > 300 * 1000) {
             this.statsDClient.stop();
             init();
         }
 
         ServiceCheck sc = ServiceCheck.builder()
-                .withName(String.format("%s.can_connect", checkName))
+                .withName(serviceCheckName)
                 .withStatus(this.statusToServiceCheckStatus(status))
                 .withMessage(message)
                 .withTags(tags)

--- a/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
+++ b/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
@@ -42,7 +42,7 @@ public class TestServiceChecks extends TestCommon {
         String scStatus = (String) (sc.get("status"));
         String[] scTags = (String[]) (sc.get("tags"));
 
-        assertEquals(Reporter.formatServiceCheckPrefix("jmx"), scName);
+        assertEquals(Reporter.formatServiceCheckPrefix("jmx") + ".can_connect", scName);
         assertEquals(Status.STATUS_OK, scStatus);
         assertEquals(scTags.length, 3);
         assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
@@ -83,7 +83,7 @@ public class TestServiceChecks extends TestCommon {
         String scStatus = (String) (sc.get("status"));
         String[] scTags = (String[]) (sc.get("tags"));
 
-        assertEquals(Reporter.formatServiceCheckPrefix("too_many_metrics"), scName);
+        assertEquals(Reporter.formatServiceCheckPrefix("too_many_metrics") + ".can_connect", scName);
         // We should have an OK service check status when too many metrics are getting sent
         assertEquals(Status.STATUS_OK, scStatus);
         assertEquals(scTags.length, 3);
@@ -115,7 +115,7 @@ public class TestServiceChecks extends TestCommon {
         String scMessage = (String) (sc.get("message"));
         String[] scTags = (String[]) (sc.get("tags"));
 
-        assertEquals(Reporter.formatServiceCheckPrefix("non_running_process"), scName);
+        assertEquals(Reporter.formatServiceCheckPrefix("non_running_process") + ".can_connect", scName);
         assertEquals(Status.STATUS_ERROR, scStatus);
         assertEquals(
                 "Unable to instantiate or initialize instance process_regex: `.*non_running_process_test.*`. "
@@ -142,7 +142,7 @@ public class TestServiceChecks extends TestCommon {
         scMessage = (String) (sc.get("message"));
         scTags = (String[]) (sc.get("tags"));
 
-        assertEquals(Reporter.formatServiceCheckPrefix("non_running_process"), scName);
+        assertEquals(Reporter.formatServiceCheckPrefix("non_running_process") + ".can_connect", scName);
         assertEquals(Status.STATUS_ERROR, scStatus);
         assertEquals(
                 "Unable to instantiate or initialize instance process_regex: `.*non_running_process_test.*`. "


### PR DESCRIPTION
## What this PR does

Build service check name earlier so all reporters will have the right service check name.

## Motiviation

Currently, reporters other than `StatsdReporter.java` will report a wrong service check name (Service check name without `.can_connect` suffix).

```
    "service_checks" : [ {
      "check" : "activemq",
      "message" : null,
      "host_name" : "default",
      "timestamp" : 1583840340,
      "status" : "OK",
      "tags" : [ "jmx_server:localhost", "instance:activemq-localhost-1616" ]
    } ]
```

should be


```
    "service_checks" : [ {
      "check" : "activemq.can_connect",
      "message" : null,
      "host_name" : "default",
      "timestamp" : 1583840340,
      "status" : "OK",
      "tags" : [ "jmx_server:localhost", "instance:activemq-localhost-1616" ]
    } ]
```

