### PR TITLE
Refactor of the RMI Socket timeout fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ target/*
 
 # jenv
 .java_version
+.factorypath

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -10,6 +10,7 @@ import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXServiceURL;
 import javax.management.remote.rmi.RMIConnectorServer;
 import javax.rmi.ssl.SslRMIClientSocketFactory;
+import java.rmi.server.RMISocketFactory;
 
 @Slf4j
 public class RemoteConnection extends Connection {
@@ -88,6 +89,8 @@ public class RemoteConnection extends Connection {
 
         // Set an RMI timeout so we don't get stuck waiting for a bean to report a value
         System.setProperty("sun.rmi.transport.tcp.responseTimeout", rmiTimeout);
+
+        RMISocketFactory.setSocketFactory(new SocketFactory(Integer.parseInt(rmiTimeout)));
 
         createConnection();
     }

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -4,13 +4,13 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.rmi.server.RMISocketFactory;
 import java.util.HashMap;
 import java.util.Map;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXServiceURL;
 import javax.management.remote.rmi.RMIConnectorServer;
 import javax.rmi.ssl.SslRMIClientSocketFactory;
-import java.rmi.server.RMISocketFactory;
 
 @Slf4j
 public class RemoteConnection extends Connection {

--- a/src/main/java/org/datadog/jmxfetch/SocketFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/SocketFactory.java
@@ -1,0 +1,27 @@
+package org.datadog.jmxfetch;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.rmi.server.RMISocketFactory;
+
+public class SocketFactory extends RMISocketFactory {
+    private final int timeout;
+
+    SocketFactory(final int timeout) {
+        this.timeout = timeout;
+    }
+
+    @Override
+    public Socket createSocket(final String host, final int port) throws IOException {
+        final Socket socket = new Socket();
+        socket.connect(new InetSocketAddress(host, port), timeout);
+        return socket;
+    }
+
+    @Override
+    public ServerSocket createServerSocket(final int port) throws IOException {
+        return new ServerSocket(port);
+    }
+}


### PR DESCRIPTION
This is to refactor the PR submitted by a client: 
https://github.com/DataDog/jmxfetch/pull/282 

In an attempt to fix #279

Isolated the SocketFactory Class and added VS code files to .gitignore
