### PR TITLE
Add check prefix config

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -820,13 +820,13 @@ public class App {
     }
 
     private String getServiceCheckName(Instance instance) {
-        String checkPrefix;
-        if (instance.getCheckPrefix() != null) {
-            checkPrefix = instance.getCheckPrefix();
+        String serviceCheckPrefix;
+        if (instance.getServiceCheckPrefix() != null) {
+            serviceCheckPrefix = instance.getServiceCheckPrefix();
         } else {
-            checkPrefix = ServiceCheckHelper.formatServiceCheckPrefix(instance.getCheckName());
+            serviceCheckPrefix = ServiceCheckHelper.formatServiceCheckPrefix(instance.getCheckName());
         }
-        return String.format("%s.can_connect", checkPrefix);
+        return String.format("%s.can_connect", serviceCheckPrefix);
     }
 
     private Instance instantiate(

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -814,7 +814,8 @@ public class App {
         String checkName = instance.getCheckName();
         String serviceCheckName = getServiceCheckName(instance);
 
-        reporter.sendServiceCheck(checkName, serviceCheckName, status, message, instance.getServiceCheckTags());
+        reporter.sendServiceCheck(
+                checkName, serviceCheckName, status, message, instance.getServiceCheckTags());
         reporter.resetServiceCheckCount(checkName);
     }
 

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -19,6 +19,7 @@ import org.datadog.jmxfetch.tasks.TaskProcessor;
 import org.datadog.jmxfetch.tasks.TaskStatusHandler;
 import org.datadog.jmxfetch.util.CustomLogger;
 import org.datadog.jmxfetch.util.FileHelper;
+import org.datadog.jmxfetch.util.ServiceCheckHelper;
 import org.slf4j.Marker;
 import org.slf4j.MarkerFactory;
 
@@ -811,9 +812,20 @@ public class App {
     private void sendServiceCheck(
             Reporter reporter, Instance instance, String message, String status) {
         String checkName = instance.getCheckName();
+        String serviceCheckName = getServiceCheckName(instance);
 
-        reporter.sendServiceCheck(checkName, status, message, instance.getServiceCheckTags());
+        reporter.sendServiceCheck(checkName, serviceCheckName, status, message, instance.getServiceCheckTags());
         reporter.resetServiceCheckCount(checkName);
+    }
+
+    private String getServiceCheckName(Instance instance) {
+        String checkPrefix;
+        if (instance.getCheckPrefix() != null) {
+            checkPrefix = instance.getCheckPrefix();
+        } else {
+            checkPrefix = ServiceCheckHelper.formatServiceCheckPrefix(instance.getCheckName());
+        }
+        return String.format("%s.can_connect", checkPrefix);
     }
 
     private Instance instantiate(

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -90,6 +90,7 @@ public class Instance {
     private String service;
     private Map<String, String> tags;
     private String checkName;
+    private String checkPrefix;
     private int maxReturnedMetrics;
     private boolean limitReached;
     private Connection connection;
@@ -184,6 +185,10 @@ public class Instance {
                                 + "Please define a name in your instance configuration");
                 this.instanceName = this.checkName;
             }
+        }
+
+        if (initConfig != null) {
+            this.checkPrefix = (String) initConfig.get("check_prefix");
         }
 
         // Alternative aliasing for CASSANDRA-4009 metrics
@@ -704,6 +709,11 @@ public class Instance {
     /** Returns the check name. */
     public String getCheckName() {
         return this.checkName;
+    }
+
+    /** Returns the check prefix. */
+    public String getCheckPrefix() {
+        return this.checkPrefix;
     }
 
     /** Returns the maximum number of metrics an instance may collect. */

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -90,7 +90,7 @@ public class Instance {
     private String service;
     private Map<String, String> tags;
     private String checkName;
-    private String checkPrefix;
+    private String serviceCheckPrefix;
     private int maxReturnedMetrics;
     private boolean limitReached;
     private Connection connection;
@@ -188,7 +188,7 @@ public class Instance {
         }
 
         if (initConfig != null) {
-            this.checkPrefix = (String) initConfig.get("check_prefix");
+            this.serviceCheckPrefix = (String) initConfig.get("service_check_prefix");
         }
 
         // Alternative aliasing for CASSANDRA-4009 metrics
@@ -712,8 +712,8 @@ public class Instance {
     }
 
     /** Returns the check prefix. */
-    public String getCheckPrefix() {
-        return this.checkPrefix;
+    public String getServiceCheckPrefix() {
+        return this.serviceCheckPrefix;
     }
 
     /** Returns the maximum number of metrics an instance may collect. */

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -156,7 +156,8 @@ public abstract class Reporter {
     }
 
     /** Submits service check. */
-    public void sendServiceCheck(String checkName, String serviceCheckName, String status, String message, String[] tags) {
+    public void sendServiceCheck(String checkName, String serviceCheckName,
+                                 String status, String message, String[] tags) {
         this.incrementServiceCheckCount(checkName);
         this.doSendServiceCheck(serviceCheckName, status, message, tags);
     }

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -2,7 +2,6 @@ package org.datadog.jmxfetch.reporter;
 
 import com.timgroup.statsd.ServiceCheck;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.commons.lang.StringUtils;
 
 import org.datadog.jmxfetch.App;
 import org.datadog.jmxfetch.Instance;
@@ -157,11 +156,8 @@ public abstract class Reporter {
     }
 
     /** Submits service check. */
-    public void sendServiceCheck(String checkName, String status, String message, String[] tags) {
+    public void sendServiceCheck(String checkName, String serviceCheckName, String status, String message, String[] tags) {
         this.incrementServiceCheckCount(checkName);
-        String serviceCheckName = String.format(
-            "%s.can_connect", Reporter.formatServiceCheckPrefix(checkName));
-
         this.doSendServiceCheck(serviceCheckName, status, message, tags);
     }
 
@@ -182,13 +178,6 @@ public abstract class Reporter {
 
     protected Map<String, Integer> getServiceCheckCountMap() {
         return this.serviceCheckCount;
-    }
-
-    /** Formats the service check prefix. */
-    public static String formatServiceCheckPrefix(String fullname) {
-        String[] chunks = fullname.split("\\.");
-        chunks[0] = chunks[0].replaceAll("[A-Z0-9:_\\-]", "");
-        return StringUtils.join(chunks, ".");
     }
 
     protected ServiceCheck.Status statusToServiceCheckStatus(String status) {

--- a/src/main/java/org/datadog/jmxfetch/util/ServiceCheckHelper.java
+++ b/src/main/java/org/datadog/jmxfetch/util/ServiceCheckHelper.java
@@ -3,7 +3,10 @@ package org.datadog.jmxfetch.util;
 import org.apache.commons.lang.StringUtils;
 
 public class ServiceCheckHelper {
-    /** Formats the service check prefix. */
+    /**
+     * Formats the service check prefix.
+     * First implemented here: https://github.com/DataDog/jmxfetch/commit/0428c41ebf7a14404ae50928e3ecfc229701c042
+     * */
     public static String formatServiceCheckPrefix(String fullname) {
         String[] chunks = fullname.split("\\.");
         chunks[0] = chunks[0].replaceAll("[A-Z0-9:_\\-]", "");

--- a/src/main/java/org/datadog/jmxfetch/util/ServiceCheckHelper.java
+++ b/src/main/java/org/datadog/jmxfetch/util/ServiceCheckHelper.java
@@ -1,0 +1,12 @@
+package org.datadog.jmxfetch.util;
+
+import org.apache.commons.lang.StringUtils;
+
+public class ServiceCheckHelper {
+    /** Formats the service check prefix. */
+    public static String formatServiceCheckPrefix(String fullname) {
+        String[] chunks = fullname.split("\\.");
+        chunks[0] = chunks[0].replaceAll("[A-Z0-9:_\\-]", "");
+        return StringUtils.join(chunks, ".");
+    }
+}

--- a/src/main/java/org/datadog/jmxfetch/util/ServiceCheckHelper.java
+++ b/src/main/java/org/datadog/jmxfetch/util/ServiceCheckHelper.java
@@ -5,7 +5,14 @@ import org.apache.commons.lang.StringUtils;
 public class ServiceCheckHelper {
     /**
      * Formats the service check prefix.
-     * First implemented here: https://github.com/DataDog/jmxfetch/commit/0428c41ebf7a14404ae50928e3ecfc229701c042
+     * First implemented here:
+     * https://github.com/DataDog/jmxfetch/commit/0428c41ebf7a14404ae50928e3ecfc229701c042
+     *
+     * <p>The formatted service check name is kept for backward compatibility only.
+     * Previously there were 2 JMXFetch integrations for activemq: one called activemq
+     * for older versions of activemq, the other called activemq_58 for v5.8+ of activemq,
+     * see https://github.com/DataDog/dd-agent/tree/5.10.x/conf.d
+     * And we still wanted both integrations to send the service check with the activemq prefix.
      * */
     public static String formatServiceCheckPrefix(String fullname) {
         String[] chunks = fullname.split("\\.");

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -72,7 +72,7 @@ public class TestInstance extends TestCommon {
         }
 
         List<Map<String, Object>> serviceChecks = getServiceChecks();
-        assertEquals(2, serviceChecks.size());
+        assertEquals(4, serviceChecks.size());
         for (Map<String, Object> sc : serviceChecks) {
             String[] tags = (String[]) sc.get("tags");
             this.assertHostnameTags(Arrays.asList(tags));
@@ -98,7 +98,7 @@ public class TestInstance extends TestCommon {
         }
 
         List<Map<String, Object>> serviceChecks = getServiceChecks();
-        assertEquals(2, serviceChecks.size());
+        assertEquals(4, serviceChecks.size());
         for (Map<String, Object> sc : serviceChecks) {
             String[] tags = (String[]) sc.get("tags");
             this.assertServiceTag(Arrays.asList(tags), "global");
@@ -119,7 +119,7 @@ public class TestInstance extends TestCommon {
         }
 
         List<Map<String, Object>> serviceChecks = getServiceChecks();
-        assertEquals(2, serviceChecks.size());
+        assertEquals(4, serviceChecks.size());
         for (Map<String, Object> sc : serviceChecks) {
             String[] tags = (String[]) sc.get("tags");
             this.assertServiceTag(Arrays.asList(tags), "override");

--- a/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
+++ b/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
@@ -11,7 +11,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.datadog.jmxfetch.reporter.Reporter;
-import org.datadog.jmxfetch.util.ServiceCheckHelper;
 import org.junit.Test;
 
 public class TestServiceChecks extends TestCommon {
@@ -42,7 +41,7 @@ public class TestServiceChecks extends TestCommon {
         String scStatus = (String) (sc.get("status"));
         String[] scTags = (String[]) (sc.get("tags"));
 
-        assertEquals(ServiceCheckHelper.formatServiceCheckPrefix("jmx") + ".can_connect", scName);
+        assertEquals("jmx.can_connect", scName);
         assertEquals(Status.STATUS_OK, scStatus);
         assertEquals(scTags.length, 3);
         assertTrue(Arrays.asList(scTags).contains("instance:jmx_test_instance"));
@@ -70,7 +69,7 @@ public class TestServiceChecks extends TestCommon {
         List<Map<String, Object>> metrics = getMetrics();
         assertTrue(metrics.size() >= 350);
 
-        assertEquals(1, serviceChecks.size());
+        assertEquals(2, serviceChecks.size());
         Map<String, Object> sc = serviceChecks.get(0);
         assertNotNull(sc.get("name"));
         assertNotNull(sc.get("status"));
@@ -83,7 +82,7 @@ public class TestServiceChecks extends TestCommon {
         String scStatus = (String) (sc.get("status"));
         String[] scTags = (String[]) (sc.get("tags"));
 
-        assertEquals(ServiceCheckHelper.formatServiceCheckPrefix("too_many_metrics") + ".can_connect", scName);
+        assertEquals("too_many_metrics.can_connect", scName);
         // We should have an OK service check status when too many metrics are getting sent
         assertEquals(Status.STATUS_OK, scStatus);
         assertEquals(scTags.length, 3);
@@ -102,7 +101,7 @@ public class TestServiceChecks extends TestCommon {
 
         // Test that a CRITICAL service check status is sent on initialization
         List<Map<String, Object>> serviceChecks = getServiceChecks();
-        assertEquals(1, serviceChecks.size());
+        assertEquals(2, serviceChecks.size());
 
         Map<String, Object> sc = serviceChecks.get(0);
         assertNotNull(sc.get("name"));
@@ -115,7 +114,7 @@ public class TestServiceChecks extends TestCommon {
         String scMessage = (String) (sc.get("message"));
         String[] scTags = (String[]) (sc.get("tags"));
 
-        assertEquals(ServiceCheckHelper.formatServiceCheckPrefix("non_running_process") + ".can_connect", scName);
+        assertEquals("non_running_process.can_connect", scName);
         assertEquals(Status.STATUS_ERROR, scStatus);
         assertEquals(
                 "Unable to instantiate or initialize instance process_regex: `.*non_running_process_test.*`. "
@@ -129,7 +128,7 @@ public class TestServiceChecks extends TestCommon {
         run();
 
         serviceChecks = getServiceChecks();
-        assertEquals(1, serviceChecks.size());
+        assertEquals(2, serviceChecks.size());
 
         sc = serviceChecks.get(0);
         assertNotNull(sc.get("name"));
@@ -142,7 +141,7 @@ public class TestServiceChecks extends TestCommon {
         scMessage = (String) (sc.get("message"));
         scTags = (String[]) (sc.get("tags"));
 
-        assertEquals(ServiceCheckHelper.formatServiceCheckPrefix("non_running_process") + ".can_connect", scName);
+        assertEquals("non_running_process.can_connect", scName);
         assertEquals(Status.STATUS_ERROR, scStatus);
         assertEquals(
                 "Unable to instantiate or initialize instance process_regex: `.*non_running_process_test.*`. "
@@ -180,21 +179,6 @@ public class TestServiceChecks extends TestCommon {
     }
 
     @Test
-    public void testPrefixFormatter() throws Exception {
-        // Let's get a list of Strings to test (add real versionned check names
-        // here when you add  new versionned check)
-        String[][] data = {
-            {"activemq_58.foo.bar12", "activemq.foo.bar12"},
-            {"test_package-X86_64-VER1:0.weird.metric_name", "testpackage.weird.metric_name"}
-        };
-
-        // Let's test them all
-        for (int i = 0; i < data.length; ++i)
-            assertEquals(data[i][1], ServiceCheckHelper.formatServiceCheckPrefix(data[i][0]));
-    }
-
-
-    @Test
     public void testServiceCheckPrefix() throws Exception {
         // We expose a few metrics through JMX
         registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:type=ServiceCheckTest");
@@ -220,4 +204,63 @@ public class TestServiceChecks extends TestCommon {
 
         assertEquals( "myprefix.can_connect", scName);
     }
+
+    @Test
+    public void testServiceCheckNoPrefix() throws Exception {
+        // We expose a few metrics through JMX
+        registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:type=ServiceCheckTest");
+
+        // We do a first collection
+        when(appConfig.isTargetDirectInstances()).thenReturn(true);
+        initApplication("jmx_check_no_prefix.yaml");
+
+        run();
+        List<Map<String, Object>> metrics = getMetrics();
+
+        // Test that the check prefix is used
+        List<Map<String, Object>> serviceChecks = getServiceChecks();
+
+        assertEquals(2, serviceChecks.size());
+        Map<String, Object> sc = serviceChecks.get(0);
+        assertNotNull(sc.get("name"));
+        assertNotNull(sc.get("status"));
+        assertNull(sc.get("message"));
+        assertNotNull(sc.get("tags"));
+
+        String scName = (String) (sc.get("name"));
+        assertEquals( "jmx_check_no_prefix.can_connect", scName);
+
+        Map<String, Object> sc2 = serviceChecks.get(1);
+        assertNotNull(sc2.get("name"));
+        assertNotNull(sc2.get("status"));
+        assertNull(sc2.get("message"));
+        assertNotNull(sc2.get("tags"));
+
+        String sc2Name = (String) (sc2.get("name"));
+        assertEquals( "jmxchecknoprefix.can_connect", sc2Name);
+    }
+
+    @Test
+    public void testServiceCheckOnceNoFormattingNeeded() throws Exception {
+        // We expose a few metrics through JMX
+        registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:type=ServiceCheckTest");
+
+        // We do a first collection
+        when(appConfig.isTargetDirectInstances()).thenReturn(true);
+        initApplication("jmx.yaml");
+
+        run();
+
+        List<Map<String, Object>> serviceChecks = getServiceChecks();
+
+        // Only 1 service check is expected if the formatted service check prefix (`jmx`)
+        // is same as the unformatted one (`jmx`).
+        assertEquals(1, serviceChecks.size());
+
+        Map<String, Object> sc = serviceChecks.get(0);
+        String scName = (String) (sc.get("name"));
+
+        assertEquals("jmx.can_connect", scName);
+    }
+
 }

--- a/src/test/java/org/datadog/jmxfetch/util/ServiceCheckHelperTest.java
+++ b/src/test/java/org/datadog/jmxfetch/util/ServiceCheckHelperTest.java
@@ -1,0 +1,19 @@
+package org.datadog.jmxfetch.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class ServiceCheckHelperTest {
+
+    @Test
+    public void testFormatServiceCheckPrefix() {
+        assertEquals("foo.my_check_name",
+                ServiceCheckHelper.formatServiceCheckPrefix("foo.my_check_name"));
+        assertEquals("foobar.my_check_name",
+                ServiceCheckHelper.formatServiceCheckPrefix("foo_bar.my_check_name"));
+        assertEquals("foobaz.my_check_name123ABC",
+                ServiceCheckHelper.formatServiceCheckPrefix("foo_123bazABC.my_check_name123ABC"));
+    }
+
+}

--- a/src/test/java/org/datadog/jmxfetch/util/ServiceCheckHelperTest.java
+++ b/src/test/java/org/datadog/jmxfetch/util/ServiceCheckHelperTest.java
@@ -8,12 +8,16 @@ public class ServiceCheckHelperTest {
 
     @Test
     public void testFormatServiceCheckPrefix() {
-        assertEquals("foo.my_check_name",
-                ServiceCheckHelper.formatServiceCheckPrefix("foo.my_check_name"));
-        assertEquals("foobar.my_check_name",
-                ServiceCheckHelper.formatServiceCheckPrefix("foo_bar.my_check_name"));
-        assertEquals("foobaz.my_check_name123ABC",
-                ServiceCheckHelper.formatServiceCheckPrefix("foo_123bazABC.my_check_name123ABC"));
-    }
+        // Let's get a list of Strings to test (add real versionned check names
+        // here when you add  new versionned check)
+        String[][] data = {
+                {"activemq_58.foo.bar12", "activemq.foo.bar12"},
+                {"test_package-X86_64-VER1:0.weird.metric_name", "testpackage.weird.metric_name"}
+        };
 
+        // Let's test them all
+        for (String[] datum : data) {
+            assertEquals(datum[1], ServiceCheckHelper.formatServiceCheckPrefix(datum[0]));
+        }
+    }
 }

--- a/src/test/resources/jmx_check_no_prefix.yaml
+++ b/src/test/resources/jmx_check_no_prefix.yaml
@@ -1,0 +1,9 @@
+init_config:
+  service_check_prefix: null
+
+instances:
+  -   jvm_direct: true
+      name: jmx_test_instance
+      conf:
+        - include:
+            domain: org.datadog.jmxfetch.test

--- a/src/test/resources/jmx_check_prefix.yaml
+++ b/src/test/resources/jmx_check_prefix.yaml
@@ -1,5 +1,5 @@
 init_config:
-  check_prefix: myprefix
+  service_check_prefix: myprefix
 
 instances:
   -   jvm_direct: true

--- a/src/test/resources/jmx_check_prefix.yaml
+++ b/src/test/resources/jmx_check_prefix.yaml
@@ -1,0 +1,9 @@
+init_config:
+  check_prefix: myprefix
+
+instances:
+  -   jvm_direct: true
+      name: jmx_test_instance
+      conf:
+        - include:
+            domain: org.datadog.jmxfetch.test


### PR DESCRIPTION
#### Add option to configure the prefix used for service checks.

This solves two issues:

- Some integration use prefix that doesn't necessarily correspond to the integration name.
  - Confluent Platform use `confluent.` as prefix. https://github.com/DataDog/integrations-core/pull/5733/files#diff-9d75daf4238a279ff75c4a0c591b3d54R6
- When integration is a multi word e.g. `my_integration`, the `_` is currently is stripped out. Which is usually not wanted.
  - example of issue https://github.com/DataDog/integrations-core/pull/5999