### PR TITLE
Fix rmi socket connection timeout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ target/*
 
 # jenv
 .java_version
+.factorypath

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -10,6 +10,7 @@ import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXServiceURL;
 import javax.management.remote.rmi.RMIConnectorServer;
 import javax.rmi.ssl.SslRMIClientSocketFactory;
+import java.rmi.server.RMISocketFactory;
 
 @Slf4j
 public class RemoteConnection extends Connection {
@@ -88,6 +89,8 @@ public class RemoteConnection extends Connection {
 
         // Set an RMI timeout so we don't get stuck waiting for a bean to report a value
         System.setProperty("sun.rmi.transport.tcp.responseTimeout", rmiTimeout);
+
+        RMISocketFactory.setSocketFactory(new SocketFactory(Integer.parseInt(rmiTimeout)));
 
         createConnection();
     }

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -97,7 +97,8 @@ public class RemoteConnection extends Connection {
         try {
             rmiConnectionTimeout = (Integer) connectionParams.get("rmi_connection_timeout");
         } catch (final ClassCastException e) {
-            rmiConnectionTimeout = Integer.parseInt((String) connectionParams.get("rmi_connection_timeout"));
+            rmiConnectionTimeout = 
+                Integer.parseInt((String) connectionParams.get("rmi_connection_timeout"));
         }
         if (rmiConnectionTimeout == null) {
             rmiConnectionTimeout = DEFAULT_RMI_CONNECTION_TIMEOUT;

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -4,13 +4,13 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.rmi.server.RMISocketFactory;
 import java.util.HashMap;
 import java.util.Map;
 import javax.management.remote.JMXConnector;
 import javax.management.remote.JMXServiceURL;
 import javax.management.remote.rmi.RMIConnectorServer;
 import javax.rmi.ssl.SslRMIClientSocketFactory;
-import java.rmi.server.RMISocketFactory;
 
 @Slf4j
 public class RemoteConnection extends Connection {

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -29,8 +29,8 @@ public class RemoteConnection extends Connection {
     private static final String KEY_STORE_PASSWORD_KEY = "key_store_password";
     private static final String DEFAULT_RMI_RESPONSE_TIMEOUT =
             "15000"; // Match the collection period default
-    // Match the default RMI connection timeout value
-    private static final Integer DEFAULT_RMI_CONNECTION_TIMEOUT = Integer.valueOf(0);
+    // The default behaviour is to wait indefinitely, we change that and only wait for 15sec.
+    private static final Integer DEFAULT_RMI_CONNECTION_TIMEOUT = Integer.valueOf(15000);
 
     /** RemoteConnection constructor for specified remote connection parameters. */
     public RemoteConnection(Map<String, Object> connectionParams) throws IOException {

--- a/src/main/java/org/datadog/jmxfetch/SocketFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/SocketFactory.java
@@ -1,0 +1,27 @@
+package org.datadog.jmxfetch;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.rmi.server.RMISocketFactory;
+
+public class SocketFactory extends RMISocketFactory {
+    private final int timeout;
+
+    SocketFactory(final int timeout) {
+        this.timeout = timeout;
+    }
+
+    @Override
+    public Socket createSocket(final String host, final int port) throws IOException {
+        final Socket socket = new Socket();
+        socket.connect(new InetSocketAddress(host, port), timeout);
+        return socket;
+    }
+
+    @Override
+    public ServerSocket createServerSocket(final int port) throws IOException {
+        return new ServerSocket(port);
+    }
+}


### PR DESCRIPTION
Based on #283 & #282 

It aims to provide piece of resolution for https://github.com/DataDog/jmxfetch/issues/279 
It allows to set a RMI connection timeout on a per-instance basis, using the configuration parameter `rmi_connection_timeout` (in milliseconds).