### PR TITLE
[snakeyaml] Bump to 1.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <log4j.version>2.12.1</log4j.version>
         <slf4j.version>1.7.26</slf4j.version>
         <jackson.version>2.10.0</jackson.version>
-        <snakeyaml.version>1.13</snakeyaml.version>
+        <snakeyaml.version>1.26</snakeyaml.version>
         <!-- Note: using project checkstyle with AOSP style
         find the default google java checkstyle config here -
 		<checkstyle.config.location>google_checks.xml</checkstyle.config.location>


### PR DESCRIPTION
See changelog: https://bitbucket.org/asomov/snakeyaml/wiki/Changes

Nothing that should break anything on our end. Worth noting: Java 6 support is dropped (only Java 7+ is supported), which is fine (JMXFetch doesn't support Java 6 anymore).

Testing done: checked locally that the Agent 6 still runs fine with a build of jmxfetch that includes this, and that JMXFetch-collected metrics show up.