### PR TITLE
Add JMX/RMI socket factory with timeout

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/util/JmxfetchRmiClientSocketFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/util/JmxfetchRmiClientSocketFactory.java
@@ -1,0 +1,133 @@
+package org.datadog.jmxfetch.util;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.net.Socket;
+import java.rmi.server.RMIClientSocketFactory;
+import java.rmi.server.RMISocketFactory;
+import javax.rmi.ssl.SslRMIClientSocketFactory;
+
+public class JmxfetchRmiClientSocketFactory implements RMIClientSocketFactory {
+    private final int timeoutMs;
+    private final int connectionTimeoutMs;
+    private final RMIClientSocketFactory factory;
+
+    /**
+     * JmxfetchRmiClientSocketFactory constructor with socket timeout (milliseconds), a socket
+     * connection timeout (millisecondes) and a flag to enable/disable SSL.
+     */
+    public JmxfetchRmiClientSocketFactory(
+            final int timeoutMs, final int connectionTimeoutMs,final boolean ssl) {
+        this.timeoutMs = timeoutMs;
+        this.connectionTimeoutMs = connectionTimeoutMs;
+        this.factory = 
+            ssl ? new SslRMIClientSocketFactory() : RMISocketFactory.getDefaultSocketFactory();
+    }
+
+    @Override
+    public Socket createSocket(final String host, final int port) throws IOException {
+        Socket socket = null;
+        final AsyncSocketFactory f = new AsyncSocketFactory(factory, host, port);
+        final Thread t = new Thread(f);
+        try {
+            synchronized (f) {
+                t.start();
+                try {
+                    long now = System.currentTimeMillis();
+                    final long until = now + connectionTimeoutMs;
+                    do {
+                        f.wait(until - now);
+                        socket = getSocketFromFactory(f);
+                        if (socket != null) {
+                            break;
+                        }
+                        now = System.currentTimeMillis();
+                    } while (now < until);
+                } catch (final InterruptedException e) {
+                    throw new InterruptedIOException(
+                        "interrupted during socket connection attempt");
+                }
+            }
+        } catch (IOException e) {
+            /* will close socket if it ever connects */
+            f.clean();
+            throw e;
+        }
+        if (socket == null) {
+            throw new IOException("connect timed out: " + host + ":" + port);
+        }
+        socket.setSoTimeout(timeoutMs);
+        socket.setSoLinger(false, 0);
+        return socket;
+    }
+
+    Socket getSocketFromFactory(final AsyncSocketFactory factory) throws IOException {
+        final Exception e = factory.getException();
+        if (e != null) {
+            e.fillInStackTrace();
+            if (e instanceof RuntimeException) {
+                throw (RuntimeException) e;
+            } else if (e instanceof IOException) {
+                throw (IOException) e;
+            } else {
+                throw new Error("unforeseen checked exception" + e.toString());
+            }
+        }
+        return factory.getSocket();
+    }
+
+    private class AsyncSocketFactory implements Runnable {
+        private final RMIClientSocketFactory factory;
+        private final String host;
+        private final int port;
+        private Exception exception = null;
+        private Socket socket = null;
+        private boolean shouldClose = false;
+        
+        AsyncSocketFactory(
+                final RMIClientSocketFactory factory,final String host, final int port) {
+            this.factory = factory;
+            this.host = host;
+            this.port = port;
+        }
+
+        public void run() {
+            try {
+                final Socket s = factory.createSocket(host, port);
+                synchronized (this) {
+                    socket = s;
+                    notify();
+                }
+                synchronized (this) {
+                    if (shouldClose) {
+                        try {
+                            s.close();
+                        } catch (final IOException e) { /* empty on purpose */ }
+                    }
+                }
+            } catch (final Exception e) {
+                synchronized (this) {
+                    exception = e;
+                    notify();
+                }
+            }
+        }
+
+        synchronized void clean() {
+            if (socket != null) {
+                try {
+                    socket.close();
+                } catch (final IOException e) { /* empty on purpose */ }
+            }
+            shouldClose = true;
+        }
+
+        private synchronized Exception getException() {
+            return exception;
+        }
+
+        private synchronized Socket getSocket() {
+            return socket;
+        }
+    }
+}


### PR DESCRIPTION
Proper RMI/JMX socket factory with timeout for both SSL and non-SSL.
Should be a drop in replacement for actual code. I also suggest to remove `Connection.connectWithTimeout` because timeouts are enforced within the socket factory. I also tested the attach API and it seems that infinite freeze can not happen in that case.

`rmi_connection_timeout` & `rmi_client_timeout` have been retained to configure timeouts in the socket factory.

See code comment for a question about the mysterious `attribute.remote.x.request.waiting.timeout` property...

A piece of the code path that may block because of network timeout is located [here](http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/jdk8u232-ga/src/share/classes/sun/rmi/transport/tcp/TCPChannel.java#l210) it plays with different configurable timeout during the TCP connection sequence, it even overrides for certain steps the `SO_TIMEOUT` from the the socket factory in at least one [place](http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/jdk8u232-ga/src/share/classes/sun/rmi/transport/tcp/TCPChannel.java#l279) (Can be set with through the following property `sun.rmi.transport.tcp.handshakeTimeout`). But having the `SO_TIMEOUT` always set at the socket level ensure always having a configurable timeout on socket operation. The the initial connection timeout is managed differently to keep the ability to get a socket from any factory (used for SSL support at the moment). It shall be noticed that the connection timeout can be shortened but there is an upper bound for enforceable value. The upper bound depends on the OS settings (~1 min on average).

Timeout will then be logged as shown below :

```
2020-06-04 11:51:42,501 | INFO  | App | Could not initialize instance: jmx-10.121.132.56-7198: java.util.concurrent.ExecutionException: java.io.IOException: Failed to retrieve RMIServer stub: javax.naming.CommunicationException [Root exception is java.rmi.ConnectIOException: Exception creating connection to: 10.121.132.56; nested exception is:
        java.io.IOException: connect timed out: 10.121.132.56:7198]
```
For information the call stack while connecting, providing information about involved classes : 

```
PlainSocketImpl.socketConnect(InetAddress,int,int)[native method] (/rt.jar/java.net/PlainSocketImpl.class:-1)
AbstractPlainSocketImpl.doConnect(InetAddress,int,int) (/rt.jar/java.net/AbstractPlainSocketImpl.class:350)
AbstractPlainSocketImpl.connectToAddress(InetAddress,int,int) (/rt.jar/java.net/AbstractPlainSocketImpl.class:206)
AbstractPlainSocketImpl.connect(SocketAddress,int) (/rt.jar/java.net/AbstractPlainSocketImpl.class:188)
SocksSocketImpl.connect(SocketAddress,int) (/rt.jar/java.net/SocksSocketImpl.class:392)
Socket.connect(SocketAddress,int) (/rt.jar/java.net/Socket.class:607)
Socket.connect(SocketAddress) (/rt.jar/java.net/Socket.class:556)
Socket.<init>(SocketAddress,SocketAddress,boolean) (/rt.jar/java.net/Socket.class:452)
Socket.<init>(String,int) (/rt.jar/java.net/Socket.class:229)
RMIDirectSocketFactory.createSocket(String,int) (/rt.jar/sun.rmi.transport.proxy/RMIDirectSocketFactory.class:40)
RMIMasterSocketFactory.createSocket(String,int) (/rt.jar/sun.rmi.transport.proxy/RMIMasterSocketFactory.class:148)
JmxfetchRmiClientSocketFactory.createSocket(String,int) (/Users/pierre.rognant/git/jmxfetch/src/main/java/org/datadog/jmxfetch/util/JmxfetchRmiClientSocketFactory.java:29)
TCPEndpoint.newSocket() (/rt.jar/sun.rmi.transport.tcp/TCPEndpoint.class:617)
TCPChannel.createConnection() (/rt.jar/sun.rmi.transport.tcp/TCPChannel.class:216)
TCPChannel.newConnection() (/rt.jar/sun.rmi.transport.tcp/TCPChannel.class:202)
UnicastRef.newCall(RemoteObject,Operation[],int,long) (/rt.jar/sun.rmi.server/UnicastRef.class:343)
RegistryImpl_Stub.lookup(String) (/rt.jar/sun.rmi.registry/RegistryImpl_Stub.class:116)
RegistryContext.lookup(Name) (/rt.jar/com.sun.jndi.rmi.registry/RegistryContext.class:132)
GenericURLContext.lookup(String) (/rt.jar/com.sun.jndi.toolkit.url/GenericURLContext.class:205)
InitialContext.lookup(String) (/rt.jar/javax.naming/InitialContext.class:417)
RMIConnector.findRMIServerJNDI(String,Map,boolean) (/rt.jar/javax.management.remote.rmi/RMIConnector.class:1955)
RMIConnector.findRMIServer(JMXServiceURL,Map) (/rt.jar/javax.management.remote.rmi/RMIConnector.class:1922)
RMIConnector.connect(Map) (/rt.jar/javax.management.remote.rmi/RMIConnector.class:287)
JMXConnectorFactory.connect(JMXServiceURL,Map) (/rt.jar/javax.management.remote/JMXConnectorFactory.class:270)
Connection.createConnection() (/Users/pierre.rognant/git/jmxfetch/src/main/java/org/datadog/jmxfetch/Connection.java:63)
RemoteConnection.<init>(Map) (/Users/pierre.rognant/git/jmxfetch/src/main/java/org/datadog/jmxfetch/RemoteConnection.java:126)
ConnectionFactory.createConnection(Map) (/Users/pierre.rognant/git/jmxfetch/src/main/java/org/datadog/jmxfetch/ConnectionFactory.java:38)
Instance.getConnection(Map,boolean) (/Users/pierre.rognant/git/jmxfetch/src/main/java/org/datadog/jmxfetch/Instance.java:371)
Instance.init(boolean) (/Users/pierre.rognant/git/jmxfetch/src/main/java/org/datadog/jmxfetch/Instance.java:384)
InstanceInitializingTask.call() (/Users/pierre.rognant/git/jmxfetch/src/main/java/org/datadog/jmxfetch/InstanceInitializingTask.java:15)
InstanceInitializingTask.call() (/Users/pierre.rognant/git/jmxfetch/src/main/java/org/datadog/jmxfetch/InstanceInitializingTask.java:3)
FutureTask.run() (/rt.jar/java.util.concurrent/FutureTask.class:266)
ThreadPoolExecutor.runWorker(ThreadPoolExecutor$Worker) (/rt.jar/java.util.concurrent/ThreadPoolExecutor.class:1149)
ThreadPoolExecutor$Worker.run() (/rt.jar/java.util.concurrent/ThreadPoolExecutor.class:624)
Thread.run() (/rt.jar/java.lang/Thread.class:748)
```