### PR TITLE
Adjust log format

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/util/CustomLogger.java
+++ b/src/main/java/org/datadog/jmxfetch/util/CustomLogger.java
@@ -21,7 +21,8 @@ import org.apache.logging.log4j.core.layout.PatternLayout;
 @Slf4j
 public class CustomLogger {
     private static final Multiset<String> messageCount = HashMultiset.create();
-    private static final String LOGGER_LAYOUT = "%d{yyyy-MM-dd HH:mm:ss z} | JMX | %-5p | %c{1} | %m%n";
+    private static final String layout = "%d{yyyy-MM-dd HH:mm:ss z} | JMX | %-5p | %c{1} | %m%n";
+    private static final String LOGGER_LAYOUT = layout;
     // log4j2 uses SYSTEM_OUT and SYSTEM_ERR - support both
     private static final String SYSTEM_OUT_ALT = "STDOUT";
     private static final String SYSTEM_ERR_ALT = "STDERR";

--- a/src/main/java/org/datadog/jmxfetch/util/CustomLogger.java
+++ b/src/main/java/org/datadog/jmxfetch/util/CustomLogger.java
@@ -21,7 +21,7 @@ import org.apache.logging.log4j.core.layout.PatternLayout;
 @Slf4j
 public class CustomLogger {
     private static final Multiset<String> messageCount = HashMultiset.create();
-    private static final String LOGGER_LAYOUT = "%d | %-5p| %c{1} | %m%n";
+    private static final String LOGGER_LAYOUT = "%d{yyyy-MM-dd HH:mm:ss z} | JMX | %-5p | %c{1} | %m%n";
     // log4j2 uses SYSTEM_OUT and SYSTEM_ERR - support both
     private static final String SYSTEM_OUT_ALT = "STDOUT";
     private static final String SYSTEM_ERR_ALT = "STDERR";

--- a/src/main/java/org/datadog/jmxfetch/util/CustomLogger.java
+++ b/src/main/java/org/datadog/jmxfetch/util/CustomLogger.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.core.layout.PatternLayout;
 @Slf4j
 public class CustomLogger {
     private static final Multiset<String> messageCount = HashMultiset.create();
+    //Saving to another variable due to check style
     private static final String layout = "%d{yyyy-MM-dd HH:mm:ss z} | JMX | %-5p | %c{1} | %m%n";
     private static final String LOGGER_LAYOUT = layout;
     // log4j2 uses SYSTEM_OUT and SYSTEM_ERR - support both

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -5,6 +5,6 @@ appender.console.type = Console
 appender.console.name = CONSOLE
 appender.console.target = SYSTEM_OUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d | %-5p | %c{1} | %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss z} | JMX | %-5p | %c{1} | %m%n
 appender.console.filter.threshold.type = ThresholdFilter
 appender.console.filter.threshold.level = all


### PR DESCRIPTION
Adjusting log format of jmx fetch so they have the exact format as the agent:

New format: 

`
2020-06-02 12:48:47 CEST | JMX | INFO  | Reporter | Instance cassandra-localhost-7199 is sending 229 metrics to the metrics reporter during collection #3
`

