### PR TITLE
Initial ZGC support

### DIFF
--- a/src/main/resources/org/datadog/jmxfetch/default-jmx-metrics.yaml
+++ b/src/main/resources/org/datadog/jmxfetch/default-jmx-metrics.yaml
@@ -186,3 +186,11 @@
       Usage.used:
         alias: jvm.gc.old_gen_size
         metric_type: gauge
+- include:
+    domain: java.lang
+    type: MemoryPool
+    name: Metaspace
+    attribute:
+      Usage.used:
+        alias: jvm.gc.metaspace_size
+        metric_type: gauge

--- a/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
+++ b/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
@@ -101,3 +101,14 @@
       CollectionTime:
         alias: jvm.gc.major_collection_time
         metric_type: counter
+- include:
+    domain: java.lang
+    type: GarbageCollector
+    name: ZGC
+    attribute:
+      CollectionCount:
+        alias: jvm.gc.major_collection_count
+        metric_type: counter
+      CollectionTime:
+        alias: jvm.gc.major_collection_time
+        metric_type: counter


### PR DESCRIPTION
Initial support for [ZGC](https://wiki.openjdk.java.net/display/zgc/Main) metrics.