### PR TITLE
Add Shenandoah metrics

### DIFF
--- a/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
+++ b/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
@@ -101,3 +101,14 @@
       CollectionTime:
         alias: jvm.gc.major_collection_time
         metric_type: counter
+- include:
+    domain: java.lang
+    type: GarbageCollector
+    name: Shenandoah Cycles
+    attribute:
+      CollectionCount:
+        alias: jvm.gc.major_collection_count
+        metric_type: counter
+      CollectionTime:
+        alias: jvm.gc.major_collection_time
+        metric_type: counter


### PR DESCRIPTION
Use Cycles bean for CollectionCount & CollectionTime.
This includes concurrent time and pauses for the full cycle
Following #303
