### PR TITLE
Revert "[pom] log4j: bump to 2.13.2."

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <guava.version>27.1-android</guava.version> <!-- From the docs: If you need support for JDK 1.7 or Android, use the Android flavor. -->
         <java-dogstatsd-client.version>2.9.0</java-dogstatsd-client.version>
         <jcommander.version>1.35</jcommander.version>
+        <!-- log4j 2.13+ drops support for Java 7, so stick to 2.12 -->
         <log4j.version>2.12.1</log4j.version>
         <slf4j.version>1.7.26</slf4j.version>
         <jackson.version>2.10.0</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <guava.version>27.1-android</guava.version> <!-- From the docs: If you need support for JDK 1.7 or Android, use the Android flavor. -->
         <java-dogstatsd-client.version>2.9.0</java-dogstatsd-client.version>
         <jcommander.version>1.35</jcommander.version>
-        <log4j.version>2.13.2</log4j.version>
+        <log4j.version>2.12.1</log4j.version>
         <slf4j.version>1.7.26</slf4j.version>
         <jackson.version>2.10.0</jackson.version>
         <snakeyaml.version>1.26</snakeyaml.version>


### PR DESCRIPTION
Reverts DataDog/jmxfetch#309

`log4j` only supports Java 1.8 and up since `2.13`. We want to still support 1.7 for now, so we should go back to `2.12.1`.

(fwiw, this is mentioned in `log4j`'s [main docs page](https://logging.apache.org/log4j/2.x/) but not in its [changelog](https://logging.apache.org/log4j/2.x/changelog.html)...)

We do have java 1.7 tests on Travis, not sure why they didn't catch this.

I confirmed this PR makes JMXFetch work again with Java 1.7.