### PR TITLE
Issue debug message for invalid types

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -95,9 +95,9 @@ public abstract class Reporter {
 
             // StatsD doesn't support rate metrics so we need to have our own aggregator to compute
             // rates
-            if ("gauge".equals(metricType) || "histogram".equals(metricType)) {
+            if (metricType.equals("gauge") || metricType.equals("histogram")) {
                 sendMetricPoint(metricType, metricName, currentValue, tags);
-            } else if ("monotonic_count".equals(metricType)) {
+            } else if (metricType.equals("monotonic_count")) {
                 String key = generateId(metric);
                 if (!instanceCountersAggregator.containsKey(key)) {
                     instanceCountersAggregator.put(key,  currentValue.longValue());
@@ -121,8 +121,8 @@ public abstract class Reporter {
 
             } else {
                 // `counter` and `rate` are equivalent and both accepted as valid.
-                // We continue accepting other cases for backward compatibility.
-                if (!"counter".equals(metricType) && !"rate".equals(metricType)) {
+                // Other types, deprecated or wrong, will default to a counter/rate type and a warning will be logged.
+                if (!metricType.equals("counter") && !metricType.equals("rate")) {
                     log.warn("Invalid metric type " + metricType + " for metric " + metricName
                             + ". The metric will be processed as rate"
                             + " (this is a DEPRECATED behaviour, use a valid type instead).");

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -124,7 +124,7 @@ public abstract class Reporter {
                 // Other types, deprecated or wrong, will default to a counter/rate
                 // type and a warning will be logged.
                 if (!metricType.equals("counter") && !metricType.equals("rate")) {
-                    log.warn("Invalid metric type " + metricType + " for metric " + metricName
+                    log.debug("Invalid metric type " + metricType + " for metric " + metricName
                             + ". The metric will be processed as rate"
                             + " (this is a DEPRECATED behaviour, use a valid type instead).");
                 }

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -119,7 +119,15 @@ public abstract class Reporter {
                 }
                 sendMetricPoint(metricType, metricName, delta, tags);
 
-            } else { // The metric should be 'counter'
+            } else {
+                // `counter` and `rate` are equivalent and both accepted as valid.
+                // We continue accepting other cases for backward compatibility.
+                if (!"counter".equals(metricType) && !"rate".equals(metricType)) {
+                    log.warn("Invalid metric type " + metricType + " for metric " + metricName
+                            + ". The metric will be processed as rate"
+                            + " (this is a DEPRECATED behaviour, use a valid type instead).");
+                }
+
                 String key = generateId(metric);
                 if (!instanceRatesAggregator.containsKey(key)) {
                     Map<String, Object> rateInfo = new HashMap<String, Object>();

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -121,7 +121,8 @@ public abstract class Reporter {
 
             } else {
                 // `counter` and `rate` are equivalent and both accepted as valid.
-                // Other types, deprecated or wrong, will default to a counter/rate type and a warning will be logged.
+                // Other types, deprecated or wrong, will default to a counter/rate
+                // type and a warning will be logged.
                 if (!metricType.equals("counter") && !metricType.equals("rate")) {
                     log.warn("Invalid metric type " + metricType + " for metric " + metricName
                             + ". The metric will be processed as rate"

--- a/src/test/resources/jmx_counter_rate.yaml
+++ b/src/test/resources/jmx_counter_rate.yaml
@@ -1,0 +1,23 @@
+init_config:
+
+instances:
+  -   process_name_regex: .*surefire.*
+      refresh_beans: 4
+      name: jmx_test_instance
+      conf:
+        - include:
+            domain: org.datadog.jmxfetch.test
+            attribute:
+              ShouldBeCounter:
+                metric_type: counter
+                alias: test.counter
+  -   process_name_regex: .*surefire.*
+      refresh_beans: 4
+      name: jmx_test_instance
+      conf:
+        - include:
+            domain: org.datadog.jmxfetch.test
+            attribute:
+              ShouldBeCounter:
+                metric_type: rate
+                alias: test.rate


### PR DESCRIPTION
When using metric_type in  jmxfetch metrics definition, if the value is anything other than `gauge`, `histogram`, `monotonic_count` it will default to “counter” (aka rate).  https://github.com/DataDog/jmxfetch/blob/f39e75a8a3d5c83890d01f6752cea4dc0aef679c/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java#L122

This seems not ideal since multiple values for `metric_type` can lead this same `counter/rate` behaviour including typos like `gauuge`.

The fix: issue warning/deprecation for anything other than `counter` and `rate`.

We keep both counter and rate as valid since they are already in use and documented here: https://docs.datadoghq.com/integrations/java/?tab=host#the-attribute-filter