### PR TITLE
[config] Harmonize timeouts

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -55,7 +55,7 @@ public class AppConfig {
 
     private static final int DEFAULT_THREAD_POOL_SIZE = 3;
     private static final int DEFAULT_COLLECTION_TO_S = 60;
-    private static final int DEFAULT_RECONNECTION_TO_S = 15;
+    private static final int DEFAULT_RECONNECTION_TO_S = 60;
 
     @Parameter(
             names = {"--help", "-h"},


### PR DESCRIPTION
Harmonize timeouts for connection & reconnection events : 
* Initial connection asks are triggered here with the collection timeout : https://github.com/DataDog/jmxfetch/blob/0.38.2/src/main/java/org/datadog/jmxfetch/App.java#L970-L980 
* Reconnection task are triggered here with the reconnection timeout: https://github.com/DataDog/jmxfetch/blob/0.38.2/src/main/java/org/datadog/jmxfetch/App.java#L617-L627

In both cases tasks classes (`InstanceInitializingTask` ) are the same, so we can end up with timeout happening in one case and not the other, leading to inconsistent behaviour between the initial connection and the subsequent ones (if any).

Note: the reconnection timeout is also used when `InstanceCleanupTask` are triggered, that why I suggest not to remove it (for the moment).
