### PR TITLE
replace guava functionality with equivalent JDK or custom features

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <apache-commons-lang3.version>3.5</apache-commons-lang3.version>
-        <guava.version>27.1-android</guava.version> <!-- From the docs: If you need support for JDK 1.7 or Android, use the Android flavor. -->
         <java-dogstatsd-client.version>2.9.0</java-dogstatsd-client.version>
         <jcommander.version>1.35</jcommander.version>
         <!-- log4j 2.13+ drops support for Java 7, so stick to 2.12 -->
@@ -84,11 +83,6 @@
             <version>1.4.2</version>
             <scope>system</scope>
             <systemPath>${java.home}/../lib/tools.jar</systemPath>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -2,8 +2,6 @@ package org.datadog.jmxfetch;
 
 import static org.datadog.jmxfetch.Instance.isDirectInstance;
 
-import com.google.common.primitives.Bytes;
-
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -17,6 +15,7 @@ import org.datadog.jmxfetch.tasks.TaskMethod;
 import org.datadog.jmxfetch.tasks.TaskProcessException;
 import org.datadog.jmxfetch.tasks.TaskProcessor;
 import org.datadog.jmxfetch.tasks.TaskStatusHandler;
+import org.datadog.jmxfetch.util.ByteArraySearcher;
 import org.datadog.jmxfetch.util.CustomLogger;
 import org.datadog.jmxfetch.util.FileHelper;
 import org.datadog.jmxfetch.util.ServiceCheckHelper;
@@ -427,6 +426,10 @@ public class App {
                 if (adPipe != null && adPipe.available() > 0) {
                     byte[] buffer = new byte[0];
                     boolean terminated = false;
+                    ByteArraySearcher configTermSearcher
+                            = new ByteArraySearcher(App.AD_CONFIG_TERM.getBytes());
+                    ByteArraySearcher legacyConfigTermSearcher
+                            = new ByteArraySearcher(App.AD_LEGACY_CONFIG_TERM.getBytes());
                     while (!terminated) {
                         int len = adPipe.available();
                         if (len > 0) {
@@ -436,9 +439,8 @@ public class App {
                             // The separator always comes in its own atomic write() from the agent
                             // side -
                             // so it will never be chopped.
-                            if (Bytes.indexOf(minibuff, App.AD_LEGACY_CONFIG_TERM.getBytes()) > -1
-                                    || Bytes.indexOf(minibuff, App.AD_CONFIG_TERM.getBytes())
-                                            > -1) {
+                            if (configTermSearcher.matches(minibuff)
+                                    || legacyConfigTermSearcher.matches(minibuff)) {
                                 terminated = true;
                             }
 

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -1,7 +1,5 @@
 package org.datadog.jmxfetch;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import lombok.extern.slf4j.Slf4j;
 import org.datadog.jmxfetch.reporter.Reporter;
 import org.yaml.snakeyaml.Yaml;
@@ -244,7 +242,10 @@ public class Instance {
         }
     }
 
-    @VisibleForTesting
+    /**
+     * Note that this method is only visible for testing and should not be used
+     * from outside of this class.
+     */
     static void loadMetricConfigFiles(
             AppConfig appConfig, List<Configuration> configurationList) {
         List<String> metricConfigFiles = appConfig.getMetricConfigFiles();
@@ -280,7 +281,10 @@ public class Instance {
         }
     }
 
-    @VisibleForTesting
+    /**
+     * Note that this method is only visible for testing and should not be used
+     * from outside of this class.
+     */
     static void loadMetricConfigResources(
             AppConfig config, List<Configuration> configurationList) {
         List<String> resourceConfigList = config.getMetricConfigResources();

--- a/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
@@ -1,11 +1,10 @@
 package org.datadog.jmxfetch.reporter;
 
-import com.google.common.base.Joiner;
-
 import lombok.extern.slf4j.Slf4j;
 
 import org.datadog.jmxfetch.Instance;
 import org.datadog.jmxfetch.JmxAttribute;
+import org.datadog.jmxfetch.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -21,7 +20,7 @@ public class ConsoleReporter extends Reporter {
     @Override
     protected void sendMetricPoint(
             String metricType, String metricName, double value, String[] tags) {
-        String tagString = "[" + Joiner.on(",").join(tags) + "]";
+        String tagString = "[" + StringUtils.join(",", tags) + "]";
         log.info(
                 metricName + tagString + " - " + System.currentTimeMillis() / 1000 + " = " + value);
 
@@ -49,7 +48,7 @@ public class ConsoleReporter extends Reporter {
             String serviceCheckName, String status, String message, String[] tags) {
         String tagString = "";
         if (tags != null && tags.length > 0) {
-            tagString = "[" + Joiner.on(",").join(tags) + "]";
+            tagString = "[" + StringUtils.join(",", tags) + "]";
         }
         log.info(serviceCheckName + tagString + " - " + System.currentTimeMillis() / 1000
                  + " = " + status);

--- a/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
@@ -1,6 +1,6 @@
 package org.datadog.jmxfetch.reporter;
 
-import com.google.common.base.Joiner;
+import org.datadog.jmxfetch.util.StringUtils;
 
 import java.util.Arrays;
 
@@ -20,9 +20,8 @@ public class ReporterFactory {
             String host = "localhost";
             Integer port = Integer.valueOf(typeElements[typeElements.length - 1]);
             if (typeElements.length > 2) {
-                host =
-                        Joiner.on(":")
-                                .join(Arrays.copyOfRange(typeElements, 1, typeElements.length - 1));
+                host = StringUtils.join(":",
+                        Arrays.copyOfRange(typeElements, 1, typeElements.length - 1));
             }
             return new StatsdReporter(host, port);
         } else {

--- a/src/main/java/org/datadog/jmxfetch/util/ByteArraySearcher.java
+++ b/src/main/java/org/datadog/jmxfetch/util/ByteArraySearcher.java
@@ -1,0 +1,47 @@
+package org.datadog.jmxfetch.util;
+
+public final class ByteArraySearcher {
+
+    private final long[] high;
+    private final long[] low;
+    private final long termination;
+
+    /**
+     * Constructs a simple literal matcher from the input term.
+     * @param term the input term, must be shorter than 64 bytes.
+     */
+    public ByteArraySearcher(byte[] term) {
+        if (term.length > 64) {
+            throw new IllegalArgumentException("term must be shorter than 64 characters");
+        }
+        this.high = new long[16];
+        this.low = new long[16];
+        int mask = 1;
+        for (byte b : term) {
+            low[b & 0xF] |= mask;
+            high[b >>> 4] |= mask;
+            mask <<= 1;
+        }
+        this.termination = 1 << (term.length - 1);
+    }
+
+
+    /**
+     * Returns true if the array contains a literal match of this searcher's term.
+     * @param array the input array
+     * @return whether the array matches or not
+     */
+    public boolean matches(byte[] array) {
+        long state = 0;
+        for (int i = 0; i < array.length; ++i) {
+            byte symbol = array[i];
+            long highMask = high[symbol >>> 4];
+            long lowMask = low[symbol & 0xF];
+            state = ((state << 1) | 1) & highMask & lowMask;
+            if ((state & termination) == termination) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/datadog/jmxfetch/util/StringUtils.java
+++ b/src/main/java/org/datadog/jmxfetch/util/StringUtils.java
@@ -1,0 +1,46 @@
+package org.datadog.jmxfetch.util;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+public class StringUtils {
+
+    /**
+     * Joins the parts together delimitd by the delimiter.
+     * @param delimiter the delimiter
+     * @param parts the parts to join
+     * @return a new string composed of the parts delimited by the delimiter
+     */
+    public static String join(String delimiter, Collection<String> parts) {
+        StringBuilder sb = new StringBuilder();
+        Iterator<String> it = parts.iterator();
+        if (it.hasNext()) {
+            sb.append(it.next());
+        }
+        while (it.hasNext()) {
+            sb.append(delimiter).append(it.next());
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Joins the parts together delimitd by the delimiter.
+     * @param delimiter the delimiter
+     * @param parts the parts to join
+     * @return a new string composed of the parts delimited by the delimiter
+     */
+    public static String join(String delimiter, String... parts) {
+        if (parts.length > 1) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(parts[0]);
+            for (int i = 1; i < parts.length; ++i) {
+                sb.append(delimiter).append(parts[i]);
+            }
+            return sb.toString();
+        }
+        if (parts.length == 1) {
+            return parts[0];
+        }
+        return "";
+    }
+}

--- a/src/main/java/org/datadog/jmxfetch/validator/Log4JLevelValidator.java
+++ b/src/main/java/org/datadog/jmxfetch/validator/Log4JLevelValidator.java
@@ -1,9 +1,9 @@
 package org.datadog.jmxfetch.validator;
 
-import com.google.common.base.Joiner;
 
 import com.beust.jcommander.IParameterValidator;
 import com.beust.jcommander.ParameterException;
+import org.datadog.jmxfetch.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
@@ -21,7 +21,7 @@ public class Log4JLevelValidator implements IParameterValidator {
                     "Parameter "
                             + name
                             + " should be in ("
-                            + Joiner.on(",").join(LOG4J_LEVELS)
+                            + StringUtils.join(",", LOG4J_LEVELS)
                             + ")";
             throw new ParameterException(message);
         }

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -7,13 +7,8 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.Lists;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.LogManager;
@@ -130,7 +125,7 @@ public class TestInstance extends TestCommon {
     public void testLoadMetricConfigFiles() throws Exception {
         URL defaultConfig = Instance.class.getResource("default-jmx-metrics.yaml");
         AppConfig config = mock(AppConfig.class);
-        when(config.getMetricConfigFiles()).thenReturn(Lists.newArrayList(defaultConfig.getPath()));
+        when(config.getMetricConfigFiles()).thenReturn(Collections.singletonList(defaultConfig.getPath()));
         List<Configuration> configurationList = new ArrayList<Configuration>();
         Instance.loadMetricConfigFiles(config, configurationList);
 
@@ -142,7 +137,7 @@ public class TestInstance extends TestCommon {
         URL defaultConfig = Instance.class.getResource("sample-metrics.yaml");
         String configResource = defaultConfig.getPath().split("test-classes/")[1];
         AppConfig config = mock(AppConfig.class);
-        when(config.getMetricConfigResources()).thenReturn(Lists.newArrayList(configResource));
+        when(config.getMetricConfigResources()).thenReturn(Collections.singletonList(configResource));
         List<Configuration> configurationList = new ArrayList<Configuration>();
         Instance.loadMetricConfigResources(config, configurationList);
 

--- a/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
+++ b/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
@@ -7,11 +7,11 @@ import static org.junit.Assert.assertTrue;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
-import com.google.common.base.Joiner;
 import java.util.Arrays;
 import java.util.List;
 import org.datadog.jmxfetch.reporter.ConsoleReporter;
 import org.datadog.jmxfetch.reporter.StatsdReporter;
+import org.datadog.jmxfetch.util.StringUtils;
 import org.datadog.jmxfetch.validator.Log4JLevelValidator;
 import org.junit.Test;
 
@@ -256,7 +256,7 @@ public class TestParsingJCommander {
                     "--reporter",
                     REPORTER_CONSOLE,
                     "-c",
-                    Joiner.on(",").join(MULTI_CHECK),
+                    StringUtils.join(",", MULTI_CHECK),
                     "--conf_directory",
                     CONF_DIR,
                     AppConfig.ACTION_COLLECT

--- a/src/test/java/org/datadog/jmxfetch/util/ByteArraySearcherTest.java
+++ b/src/test/java/org/datadog/jmxfetch/util/ByteArraySearcherTest.java
@@ -1,0 +1,49 @@
+package org.datadog.jmxfetch.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import sun.nio.cs.StandardCharsets;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class ByteArraySearcherTest {
+
+    private final byte[] term;
+    private final byte[] content;
+    private final boolean matches;
+
+    public ByteArraySearcherTest(String content, String term, boolean matches) {
+        this.content = content.getBytes(Charset.forName("UTF-8"));
+        this.term = term.getBytes(Charset.forName("UTF-8"));
+        this.matches = matches;
+    }
+
+    @Parameterized.Parameters
+    public static Iterable<Object[]> testCases() {
+        return Arrays.asList(
+                new Object[][] {
+                        {"foobar", "foo", true},
+                        {"foofoo", "foo", true},
+                        {"", "foo", false},
+                        {"bar", "foo", false},
+                        {"barbarfoo", "foo", true},
+                        {"barbarfoobar", "foo", true},
+                        {"fofofofofo", "foo", false},
+                        {UUID.randomUUID().toString(), "pqrst", false},
+                }
+        );
+    }
+
+
+    @Test
+    public void testFindTermInContent() {
+        assertEquals(matches, new ByteArraySearcher(term).matches(content));
+    }
+}

--- a/src/test/java/org/datadog/jmxfetch/util/StringUtilsTest.java
+++ b/src/test/java/org/datadog/jmxfetch/util/StringUtilsTest.java
@@ -1,0 +1,49 @@
+package org.datadog.jmxfetch.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class StringUtilsTest {
+
+
+    @Parameterized.Parameters
+    public static Iterable<Object[]> testCases() {
+        return Arrays.asList(new Object[][] {
+                {Collections.emptyList(), ":", ""},
+                {Collections.singletonList("foo"), ":", "foo"},
+                {Arrays.asList("foo", "bar"), ":", "foo:bar"},
+                {Arrays.asList("foo", "bar"), "::", "foo::bar"},
+                {Arrays.asList("foo", "bar", "qux"), ":", "foo:bar:qux"},
+                {Arrays.asList("foo", "bar", "qux"), "::", "foo::bar::qux"}
+        });
+    }
+
+    private final Collection<String> parts;
+    private final String delimiter;
+    private final String expected;
+
+    public StringUtilsTest(Collection<String> parts, String delimiter, String expected) {
+        this.parts = parts;
+        this.delimiter = delimiter;
+        this.expected = expected;
+    }
+
+    @Test
+    public void testJoinCollection() {
+        assertEquals(expected, StringUtils.join(delimiter, parts));
+    }
+
+    @Test
+    public void testJoinArray() {
+        assertEquals(expected, StringUtils.join(delimiter, parts.toArray(new String[0])));
+    }
+
+}


### PR DESCRIPTION
The motivation here is to reduce the deployment size by shedding a 2.7MB dependency which isn't extensively used.