### PR TITLE
Corrects collection loop period

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -485,8 +485,8 @@ public class App {
             try {
                 long loopPeriod = appConfig.getCheckPeriod();
                 long sleepPeriod = (duration > loopPeriod) ? loopPeriod : loopPeriod - duration;
-                log.debug("Sleeping for " + loopPeriod + " ms.");
-                Thread.sleep(loopPeriod);
+                log.debug("Sleeping for " + sleepPeriod + " ms.");
+                Thread.sleep(sleepPeriod);
             } catch (InterruptedException e) {
                 log.warn(e.getMessage(), e);
             }

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -486,9 +486,10 @@ public class App {
                 long loopPeriod = appConfig.getCheckPeriod();
                 long sleepPeriod = loopPeriod - duration;
                 if (sleepPeriod <= 0) {
-                    log.debug("The collection cycle took longer that the configured check period, the next cycle will start immediatly");
-                }
-                else {
+                    log.debug(
+                        "The collection cycle took longer that the configured check period,"
+                        + " the next cycle will start immediatly");
+                } else {
                     log.debug("Sleeping for " + sleepPeriod + " ms.");
                     Thread.sleep(sleepPeriod);    
                 }

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -484,9 +484,14 @@ public class App {
             // Sleep until next collection
             try {
                 long loopPeriod = appConfig.getCheckPeriod();
-                long sleepPeriod = (duration > loopPeriod) ? loopPeriod : loopPeriod - duration;
-                log.debug("Sleeping for " + sleepPeriod + " ms.");
-                Thread.sleep(sleepPeriod);
+                long sleepPeriod = loopPeriod - duration;
+                if (sleepPeriod <= 0) {
+                    log.debug("The collection cycle took longer that the configured check period, the next cycle will start immediatly");
+                }
+                else {
+                    log.debug("Sleeping for " + sleepPeriod + " ms.");
+                    Thread.sleep(sleepPeriod);    
+                }
             } catch (InterruptedException e) {
                 log.warn(e.getMessage(), e);
             }


### PR DESCRIPTION
It seems that we computed a `sleepPeriod` that was never used.

If the collection took less that the `loopPeriod I agree with the calculation.
However if the collection exceeds the `loopPeriod` on one hand I find it confusing to still wait the `loopPeriod` on the other hand I'm not sure that not doing a pause is a good idea.