### PR TITLE
replace guava functionality with equivalent JDK or custom features 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
         <apache-commons-lang3.version>3.5</apache-commons-lang3.version>
-        <guava.version>27.1-android</guava.version> <!-- From the docs: If you need support for JDK 1.7 or Android, use the Android flavor. -->
         <java-dogstatsd-client.version>2.1.0</java-dogstatsd-client.version>
         <jcommander.version>1.35</jcommander.version>
         <log4j.version>1.2.17</log4j.version>
@@ -82,11 +81,6 @@
             <version>1.4.2</version>
             <scope>system</scope>
             <systemPath>${java.home}/../lib/tools.jar</systemPath>
-        </dependency>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>${guava.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -1,6 +1,5 @@
 package org.datadog.jmxfetch;
 
-import com.google.common.primitives.Bytes;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
@@ -15,6 +14,7 @@ import org.datadog.jmxfetch.tasks.TaskMethod;
 import org.datadog.jmxfetch.tasks.TaskProcessException;
 import org.datadog.jmxfetch.tasks.TaskProcessor;
 import org.datadog.jmxfetch.tasks.TaskStatusHandler;
+import org.datadog.jmxfetch.util.ByteArraySearcher;
 import org.datadog.jmxfetch.util.CustomLogger;
 import org.datadog.jmxfetch.util.FileHelper;
 
@@ -360,6 +360,10 @@ public class App {
                 if (adPipe != null && adPipe.available() > 0) {
                     byte[] buffer = new byte[0];
                     boolean terminated = false;
+                    ByteArraySearcher configTermSearcher
+                            = new ByteArraySearcher(App.AD_CONFIG_TERM.getBytes());
+                    ByteArraySearcher legacyConfigTermSearcher
+                            = new ByteArraySearcher(App.AD_LEGACY_CONFIG_TERM.getBytes());
                     while (!terminated) {
                         int len = adPipe.available();
                         if (len > 0) {
@@ -369,9 +373,8 @@ public class App {
                             // The separator always comes in its own atomic write() from the agent
                             // side -
                             // so it will never be chopped.
-                            if (Bytes.indexOf(minibuff, App.AD_LEGACY_CONFIG_TERM.getBytes()) > -1
-                                    || Bytes.indexOf(minibuff, App.AD_CONFIG_TERM.getBytes())
-                                            > -1) {
+                            if (configTermSearcher.matches(minibuff)
+                                    || legacyConfigTermSearcher.matches(minibuff)) {
                                 terminated = true;
                             }
 

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -1,8 +1,5 @@
 package org.datadog.jmxfetch;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
-
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
 
@@ -15,10 +12,13 @@ import org.datadog.jmxfetch.validator.Log4JLevelValidator;
 import org.datadog.jmxfetch.validator.PositiveIntegerValidator;
 import org.datadog.jmxfetch.validator.ReporterValidator;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Collections;
 
 @Parameters(separators = "=")
 public class AppConfig {
@@ -340,15 +340,20 @@ public class AppConfig {
             String logLocation,
             String logLevel) {
         AppConfig config = new AppConfig();
-        config.action = ImmutableList.of(ACTION_COLLECT);
-        config.instanceConfigResources = ImmutableList.copyOf(instanceConfigResources);
-        config.metricConfigResources = ImmutableList.copyOf(metricConfigResources);
-        config.metricConfigFiles = ImmutableList.copyOf(metricConfigFiles);
+        config.action = Collections.unmodifiableList(Arrays.asList(ACTION_COLLECT));
+        config.instanceConfigResources = Collections.unmodifiableList(new ArrayList<String>(instanceConfigResources));
+        config.metricConfigResources = Collections.unmodifiableList(new ArrayList<String>(metricConfigResources));
+        config.metricConfigFiles = Collections.unmodifiableList(new ArrayList<String>(metricConfigFiles));
         if (checkPeriod != null) {
             config.checkPeriod = checkPeriod;
         }
         config.refreshBeansPeriod = refreshBeansPeriod;
-        config.globalTags = ImmutableMap.copyOf(globalTags);
+        // deep copy globalTags
+        Map<String, String> globalTagsCopy = new HashMap<String, String>();
+        for(Map.Entry<String, String> entry : globalTags.entrySet()) {
+            globalTagsCopy.put(entry.getKey(), new String(entry.getValue()));
+        }
+        config.globalTags = Collections.unmodifiableMap(globalTagsCopy);
         config.reporter = ReporterFactory.getReporter(reporter);
         config.logLocation = logLocation;
         config.logLevel = logLevel;

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -14,11 +14,11 @@ import org.datadog.jmxfetch.validator.ReporterValidator;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Collections;
 
 @Parameters(separators = "=")
 public class AppConfig {
@@ -341,16 +341,19 @@ public class AppConfig {
             String logLevel) {
         AppConfig config = new AppConfig();
         config.action = Collections.unmodifiableList(Arrays.asList(ACTION_COLLECT));
-        config.instanceConfigResources = Collections.unmodifiableList(new ArrayList<String>(instanceConfigResources));
-        config.metricConfigResources = Collections.unmodifiableList(new ArrayList<String>(metricConfigResources));
-        config.metricConfigFiles = Collections.unmodifiableList(new ArrayList<String>(metricConfigFiles));
+        config.instanceConfigResources = Collections.unmodifiableList(
+                new ArrayList<String>(instanceConfigResources));
+        config.metricConfigResources = Collections.unmodifiableList(
+                new ArrayList<String>(metricConfigResources));
+        config.metricConfigFiles = Collections.unmodifiableList(
+                new ArrayList<String>(metricConfigFiles));
         if (checkPeriod != null) {
             config.checkPeriod = checkPeriod;
         }
         config.refreshBeansPeriod = refreshBeansPeriod;
         // deep copy globalTags
         Map<String, String> globalTagsCopy = new HashMap<String, String>();
-        for(Map.Entry<String, String> entry : globalTags.entrySet()) {
+        for (Map.Entry<String, String> entry : globalTags.entrySet()) {
             globalTagsCopy.put(entry.getKey(), new String(entry.getValue()));
         }
         config.globalTags = Collections.unmodifiableMap(globalTagsCopy);

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -221,7 +221,7 @@ public class Instance {
      * from outside of this class.
      */
     static void loadMetricConfigFiles(
-            AppConfig appConfig, LinkedList<Configuration> configurationList) {
+            AppConfig appConfig, List<Configuration> configurationList) {
         if (appConfig.getMetricConfigFiles() != null) {
             for (String fileName : appConfig.getMetricConfigFiles()) {
                 String yamlPath = new File(fileName).getAbsolutePath();
@@ -257,7 +257,7 @@ public class Instance {
      * from outside of this class.
      */
     static void loadMetricConfigResources(
-            AppConfig config, LinkedList<Configuration> configurationList) {
+            AppConfig config, List<Configuration> configurationList) {
         List<String> resourceConfigList = config.getMetricConfigResources();
         if (resourceConfigList != null) {
             ClassLoader classLoader = Thread.currentThread().getContextClassLoader();

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -1,7 +1,5 @@
 package org.datadog.jmxfetch;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import org.apache.log4j.Logger;
 
 import org.datadog.jmxfetch.reporter.Reporter;
@@ -218,7 +216,10 @@ public class Instance {
         }
     }
 
-    @VisibleForTesting
+    /**
+     * Note that this method is only visible for testing and should not be used
+     * from outside of this class.
+     */
     static void loadMetricConfigFiles(
             AppConfig appConfig, LinkedList<Configuration> configurationList) {
         if (appConfig.getMetricConfigFiles() != null) {
@@ -251,7 +252,10 @@ public class Instance {
         }
     }
 
-    @VisibleForTesting
+    /**
+     * Note that this method is only visible for testing and should not be used
+     * from outside of this class.
+     */
     static void loadMetricConfigResources(
             AppConfig config, LinkedList<Configuration> configurationList) {
         List<String> resourceConfigList = config.getMetricConfigResources();

--- a/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ConsoleReporter.java
@@ -1,11 +1,10 @@
 package org.datadog.jmxfetch.reporter;
 
-import com.google.common.base.Joiner;
-
 import org.apache.log4j.Logger;
 
 import org.datadog.jmxfetch.Instance;
 import org.datadog.jmxfetch.JmxAttribute;
+import org.datadog.jmxfetch.util.StringUtils;
 
 import java.util.HashMap;
 import java.util.LinkedList;
@@ -21,7 +20,7 @@ public class ConsoleReporter extends Reporter {
     @Override
     protected void sendMetricPoint(
             String metricType, String metricName, double value, String[] tags) {
-        String tagString = "[" + Joiner.on(",").join(tags) + "]";
+        String tagString = "[" + StringUtils.join(",", tags) + "]";
         LOGGER.info(
                 metricName + tagString + " - " + System.currentTimeMillis() / 1000 + " = " + value);
 
@@ -48,7 +47,7 @@ public class ConsoleReporter extends Reporter {
     public void doSendServiceCheck(String checkName, String status, String message, String[] tags) {
         String tagString = "";
         if (tags != null && tags.length > 0) {
-            tagString = "[" + Joiner.on(",").join(tags) + "]";
+            tagString = "[" + StringUtils.join(",", tags) + "]";
         }
         LOGGER.info(
                 checkName + tagString + " - " + System.currentTimeMillis() / 1000 + " = " + status);

--- a/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
@@ -1,6 +1,6 @@
 package org.datadog.jmxfetch.reporter;
 
-import com.google.common.base.Joiner;
+import org.datadog.jmxfetch.util.StringUtils;
 
 import java.util.Arrays;
 
@@ -18,9 +18,8 @@ public class ReporterFactory {
             String host = "localhost";
             Integer port = Integer.valueOf(typeElements[typeElements.length - 1]);
             if (typeElements.length > 2) {
-                host =
-                        Joiner.on(":")
-                                .join(Arrays.copyOfRange(typeElements, 1, typeElements.length - 1));
+                host = StringUtils.join(":",
+                        Arrays.copyOfRange(typeElements, 1, typeElements.length - 1));
             }
             return new StatsdReporter(host, port);
         } else {

--- a/src/main/java/org/datadog/jmxfetch/util/ByteArraySearcher.java
+++ b/src/main/java/org/datadog/jmxfetch/util/ByteArraySearcher.java
@@ -1,0 +1,47 @@
+package org.datadog.jmxfetch.util;
+
+public final class ByteArraySearcher {
+
+    private final long[] high;
+    private final long[] low;
+    private final long termination;
+
+    /**
+     * Constructs a simple literal matcher from the input term.
+     * @param term the input term, must be shorter than 64 bytes.
+     */
+    public ByteArraySearcher(byte[] term) {
+        if (term.length > 64) {
+            throw new IllegalArgumentException("term must be shorter than 64 characters");
+        }
+        this.high = new long[16];
+        this.low = new long[16];
+        int mask = 1;
+        for (byte b : term) {
+            low[b & 0xF] |= mask;
+            high[b >>> 4] |= mask;
+            mask <<= 1;
+        }
+        this.termination = 1 << (term.length - 1);
+    }
+
+
+    /**
+     * Returns true if the array contains a literal match of this searcher's term.
+     * @param array the input array
+     * @return whether the array matches or not
+     */
+    public boolean matches(byte[] array) {
+        long state = 0;
+        for (int i = 0; i < array.length; ++i) {
+            byte symbol = array[i];
+            long highMask = high[symbol >>> 4];
+            long lowMask = low[symbol & 0xF];
+            state = ((state << 1) | 1) & highMask & lowMask;
+            if ((state & termination) == termination) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/org/datadog/jmxfetch/util/CustomLogger.java
+++ b/src/main/java/org/datadog/jmxfetch/util/CustomLogger.java
@@ -1,17 +1,19 @@
 package org.datadog.jmxfetch.util;
 
-import com.google.common.collect.HashMultiset;
-import com.google.common.collect.Multiset;
-
+<<<<<<< HEAD
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
 import org.apache.log4j.RollingFileAppender;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
 public class CustomLogger {
     private static final Logger LOGGER = Logger.getLogger(CustomLogger.class.getName());
-    private static final Multiset<String> messageCount = HashMultiset.create();
+    private static final ConcurrentHashMap<String, AtomicInteger> messageCount
+            = new ConcurrentHashMap<String, AtomicInteger>();
     private static final String LOGGER_LAYOUT = "%d | %-5p| %c{1} | %m%n";
 
     /** Sets up the custom logger to the specified level and location. */
@@ -42,10 +44,23 @@ public class CustomLogger {
 
     /** Laconic logging for reduced verbosity. */
     public static void laconic(Logger logger, Level level, String message, int max) {
+        int messageCount = getAndIncrementMessageCount(message);
         if (messageCount.count(message) <= max) {
             logger.log(level, message);
             messageCount.add(message);
         }
+    }
+
+    private static int getAndIncrementMessageCount(String message) {
+        AtomicInteger count = messageCount.get(message);
+        if (null == count) {
+            count = new AtomicInteger();
+            AtomicInteger winner = messageCount.putIfAbsent(message, count);
+            if (winner != null) {
+                count = winner;
+            }
+        }
+        return count.getAndIncrement();
     }
 
     private CustomLogger() {}

--- a/src/main/java/org/datadog/jmxfetch/util/CustomLogger.java
+++ b/src/main/java/org/datadog/jmxfetch/util/CustomLogger.java
@@ -1,6 +1,5 @@
 package org.datadog.jmxfetch.util;
 
-<<<<<<< HEAD
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -44,10 +43,9 @@ public class CustomLogger {
 
     /** Laconic logging for reduced verbosity. */
     public static void laconic(Logger logger, Level level, String message, int max) {
-        int messageCount = getAndIncrementMessageCount(message);
-        if (messageCount.count(message) <= max) {
+        int count = getAndIncrementMessageCount(message);
+        if (count <= max) {
             logger.log(level, message);
-            messageCount.add(message);
         }
     }
 

--- a/src/main/java/org/datadog/jmxfetch/util/StringUtils.java
+++ b/src/main/java/org/datadog/jmxfetch/util/StringUtils.java
@@ -1,0 +1,46 @@
+package org.datadog.jmxfetch.util;
+
+import java.util.Collection;
+import java.util.Iterator;
+
+public class StringUtils {
+
+    /**
+     * Joins the parts together delimitd by the delimiter.
+     * @param delimiter the delimiter
+     * @param parts the parts to join
+     * @return a new string composed of the parts delimited by the delimiter
+     */
+    public static String join(String delimiter, Collection<String> parts) {
+        StringBuilder sb = new StringBuilder();
+        Iterator<String> it = parts.iterator();
+        if (it.hasNext()) {
+            sb.append(it.next());
+        }
+        while (it.hasNext()) {
+            sb.append(delimiter).append(it.next());
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Joins the parts together delimitd by the delimiter.
+     * @param delimiter the delimiter
+     * @param parts the parts to join
+     * @return a new string composed of the parts delimited by the delimiter
+     */
+    public static String join(String delimiter, String... parts) {
+        if (parts.length > 1) {
+            StringBuilder sb = new StringBuilder();
+            sb.append(parts[0]);
+            for (int i = 1; i < parts.length; ++i) {
+                sb.append(delimiter).append(parts[i]);
+            }
+            return sb.toString();
+        }
+        if (parts.length == 1) {
+            return parts[0];
+        }
+        return "";
+    }
+}

--- a/src/main/java/org/datadog/jmxfetch/validator/Log4JLevelValidator.java
+++ b/src/main/java/org/datadog/jmxfetch/validator/Log4JLevelValidator.java
@@ -1,9 +1,9 @@
 package org.datadog.jmxfetch.validator;
 
-import com.google.common.base.Joiner;
 
 import com.beust.jcommander.IParameterValidator;
 import com.beust.jcommander.ParameterException;
+import org.datadog.jmxfetch.util.StringUtils;
 
 import java.util.Arrays;
 import java.util.List;
@@ -21,7 +21,7 @@ public class Log4JLevelValidator implements IParameterValidator {
                     "Parameter "
                             + name
                             + " should be in ("
-                            + Joiner.on(",").join(LOG4J_LEVELS)
+                            + StringUtils.join(",", LOG4J_LEVELS)
                             + ")";
             throw new ParameterException(message);
         }

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -7,12 +7,9 @@ import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.Lists;
 import java.net.URL;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
+
 import org.apache.log4j.Logger;
 import org.junit.Test;
 
@@ -80,8 +77,8 @@ public class TestInstance extends TestCommon {
     public void testLoadMetricConfigFiles() throws Exception {
         URL defaultConfig = Instance.class.getResource("default-jmx-metrics.yaml");
         AppConfig config = mock(AppConfig.class);
-        when(config.getMetricConfigFiles()).thenReturn(Lists.newArrayList(defaultConfig.getPath()));
-        LinkedList<Configuration> configurationList = new LinkedList<Configuration>();
+        when(config.getMetricConfigFiles()).thenReturn(Collections.singletonList(defaultConfig.getPath()));
+        List<Configuration> configurationList = new ArrayList<Configuration>();
         Instance.loadMetricConfigFiles(config, configurationList);
 
         assertEquals(2, configurationList.size());
@@ -92,8 +89,8 @@ public class TestInstance extends TestCommon {
         URL defaultConfig = Instance.class.getResource("sample-metrics.yaml");
         String configResource = defaultConfig.getPath().split("test-classes/")[1];
         AppConfig config = mock(AppConfig.class);
-        when(config.getMetricConfigResources()).thenReturn(Lists.newArrayList(configResource));
-        LinkedList<Configuration> configurationList = new LinkedList<Configuration>();
+        when(config.getMetricConfigResources()).thenReturn(Collections.singletonList(configResource));
+        List<Configuration> configurationList = new ArrayList<Configuration>();
         Instance.loadMetricConfigResources(config, configurationList);
 
         assertEquals(2, configurationList.size());

--- a/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
+++ b/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
@@ -7,11 +7,11 @@ import static org.junit.Assert.assertTrue;
 
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.ParameterException;
-import com.google.common.base.Joiner;
 import java.util.Arrays;
 import java.util.List;
 import org.datadog.jmxfetch.reporter.ConsoleReporter;
 import org.datadog.jmxfetch.reporter.StatsdReporter;
+import org.datadog.jmxfetch.util.StringUtils;
 import org.datadog.jmxfetch.validator.Log4JLevelValidator;
 import org.junit.Test;
 
@@ -256,7 +256,7 @@ public class TestParsingJCommander {
                     "--reporter",
                     REPORTER_CONSOLE,
                     "-c",
-                    Joiner.on(",").join(MULTI_CHECK),
+                    StringUtils.join(",", MULTI_CHECK),
                     "--conf_directory",
                     CONF_DIR,
                     AppConfig.ACTION_COLLECT

--- a/src/test/java/org/datadog/jmxfetch/util/ByteArraySearcherTest.java
+++ b/src/test/java/org/datadog/jmxfetch/util/ByteArraySearcherTest.java
@@ -1,0 +1,49 @@
+package org.datadog.jmxfetch.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import sun.nio.cs.StandardCharsets;
+
+import java.nio.charset.Charset;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class ByteArraySearcherTest {
+
+    private final byte[] term;
+    private final byte[] content;
+    private final boolean matches;
+
+    public ByteArraySearcherTest(String content, String term, boolean matches) {
+        this.content = content.getBytes(Charset.forName("UTF-8"));
+        this.term = term.getBytes(Charset.forName("UTF-8"));
+        this.matches = matches;
+    }
+
+    @Parameterized.Parameters
+    public static Iterable<Object[]> testCases() {
+        return Arrays.asList(
+                new Object[][] {
+                        {"foobar", "foo", true},
+                        {"foofoo", "foo", true},
+                        {"", "foo", false},
+                        {"bar", "foo", false},
+                        {"barbarfoo", "foo", true},
+                        {"barbarfoobar", "foo", true},
+                        {"fofofofofo", "foo", false},
+                        {UUID.randomUUID().toString(), "pqrst", false},
+                }
+        );
+    }
+
+
+    @Test
+    public void testFindTermInContent() {
+        assertEquals(matches, new ByteArraySearcher(term).matches(content));
+    }
+}

--- a/src/test/java/org/datadog/jmxfetch/util/StringUtilsTest.java
+++ b/src/test/java/org/datadog/jmxfetch/util/StringUtilsTest.java
@@ -1,0 +1,49 @@
+package org.datadog.jmxfetch.util;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class StringUtilsTest {
+
+
+    @Parameterized.Parameters
+    public static Iterable<Object[]> testCases() {
+        return Arrays.asList(new Object[][] {
+                {Collections.emptyList(), ":", ""},
+                {Collections.singletonList("foo"), ":", "foo"},
+                {Arrays.asList("foo", "bar"), ":", "foo:bar"},
+                {Arrays.asList("foo", "bar"), "::", "foo::bar"},
+                {Arrays.asList("foo", "bar", "qux"), ":", "foo:bar:qux"},
+                {Arrays.asList("foo", "bar", "qux"), "::", "foo::bar::qux"}
+        });
+    }
+
+    private final Collection<String> parts;
+    private final String delimiter;
+    private final String expected;
+
+    public StringUtilsTest(Collection<String> parts, String delimiter, String expected) {
+        this.parts = parts;
+        this.delimiter = delimiter;
+        this.expected = expected;
+    }
+
+    @Test
+    public void testJoinCollection() {
+        assertEquals(expected, StringUtils.join(delimiter, parts));
+    }
+
+    @Test
+    public void testJoinArray() {
+        assertEquals(expected, StringUtils.join(delimiter, parts.toArray(new String[0])));
+    }
+
+}


### PR DESCRIPTION
This allows a large (2.7MB) dependency to be dropped from size-sensitive deployments.
Fixes legacy java 1.6 support which broke with previous guava version bump.