### PR TITLE
[travis] adding Java6 testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ dist: precise
 
 language: java
 
+install: echo "do nada"
+
 addons:
   hostname: dd-jmxfetch-testhost
   apt:
@@ -39,11 +41,11 @@ matrix:
        - DESC="OpenJDK6 testing"
        # TLSv1.2 fails
        #
-       - BUILDCMD="mvn install -Dhttps.protocols=TLSv1,TLSv1.1 -DskipTests=true -Dmaven.javadoc.skip=true -B -V"
+       # - BUILDCMD="mvn install -Dhttps.protocols=TLSv1,TLSv1.1 -DskipTests=true -Dmaven.javadoc.skip=true -B -V"
        - TESTCMD="mvn test -B -Dhttps.protocols=TLSv1,TLSv1.1 -Dcheckstyle.skip=true -Dlog4j.configuration=log4j.travis.properties"
 
 script:
   - echo "Running $DESC..."
-  - if [[ -z "${BUILDCMD}" ]]; then (eval $BUILDCMD); fi
-  - if [[ -z "${TESTCMD}" ]]; then (eval $TESTCMD); fi
+  - if [[ ! -z "${BUILDCMD}" ]]; then (eval $BUILDCMD); fi
+  - if [[ ! -z "${TESTCMD}" ]]; then (eval $TESTCMD); fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ dist: precise
 
 language: java
 
-install: mvn install -Dhttps.protocols=TLSv1.2 -DskipTests=true -Dmaven.javadoc.skip=true -B -V
-
 addons:
   hostname: dd-jmxfetch-testhost
   apt:
@@ -16,28 +14,36 @@ matrix:
     - jdk: oraclejdk8
       env:
        - DESC="Oracle JDK8 linting"
-       - CMD="mvn verify -B -Dhttps.protocols=TLSv1.2 -DskipTests -Dlog4j.configuration=log4j.travis.properties"
+       - TESTCMD="mvn verify -B -Dhttps.protocols=TLSv1.2 -DskipTests -Dlog4j.configuration=log4j.travis.properties"
 
     - jdk: oraclejdk8
       env:
        - DESC="Oracle JDK8 testing"
-       - CMD="mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configuration=log4j.travis.properties"
+       - BUILDCMD="mvn install -Dhttps.protocols=TLSv1.2 -DskipTests=true -Dmaven.javadoc.skip=true -B -V"
+       - TESTCMD="mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configuration=log4j.travis.properties"
 
     - jdk: oraclejdk7
       env:
        - DESC="Oracle JDK7 testing"
-       - CMD="mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configuration=log4j.travis.properties"
+       - BUILDCMD="mvn install -Dhttps.protocols=TLSv1.2 -DskipTests=true -Dmaven.javadoc.skip=true -B -V"
+       - TESTCMD="mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configuration=log4j.travis.properties"
 
     - jdk: openjdk7
       env:
        - DESC="OpenJDK7 testing"
-       - CMD="mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configuration=log4j.travis.properties"
+       - BUILDCMD="mvn install -Dhttps.protocols=TLSv1.2 -DskipTests=true -Dmaven.javadoc.skip=true -B -V"
+       - TESTCMD="mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configuration=log4j.travis.properties"
 
     - jdk: openjdk6
       env:
        - DESC="OpenJDK6 testing"
        # TLSv1.2 fails
-       - CMD="mvn test -B -Dhttps.protocols=TLSv1,TLSv1.1 -Dcheckstyle.skip=true -Dlog4j.configuration=log4j.travis.properties"
+       #
+       - BUILDCMD="mvn install -Dhttps.protocols=TLSv1,TLSv1.1 -DskipTests=true -Dmaven.javadoc.skip=true -B -V"
+       - TESTCMD="mvn test -B -Dhttps.protocols=TLSv1,TLSv1.1 -Dcheckstyle.skip=true -Dlog4j.configuration=log4j.travis.properties"
 
-script: echo "Running $DESC..." && (eval $CMD)
+script:
+  - echo "Running $DESC..."
+  - if [[ -z "${BUILDCMD}" ]]; then (eval $BUILDCMD); fi
+  - if [[ -z "${TESTCMD}" ]]; then (eval $TESTCMD); fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ matrix:
     - jdk: openjdk6
       env:
        - DESC="OpenJDK6 testing"
-       - CMD="mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configuration=log4j.travis.properties"
+       # TLSv1.2 fails
+       - CMD="mvn test -B -Dhttps.protocols=TLSv1,TLSv1.1 -Dcheckstyle.skip=true -Dlog4j.configuration=log4j.travis.properties"
 
 script: echo "Running $DESC..." && (eval $CMD)
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,29 +6,37 @@ install: mvn install -Dhttps.protocols=TLSv1.2 -DskipTests=true -Dmaven.javadoc.
 
 addons:
   hostname: dd-jmxfetch-testhost
+  apt:
+    packages:
+      - openjdk-6-jdk
 
 matrix:
   fast_finish: true
   include:
     - jdk: oraclejdk8
-      env: 
+      env:
        - DESC="Oracle JDK8 linting"
        - CMD="mvn verify -B -Dhttps.protocols=TLSv1.2 -DskipTests -Dlog4j.configuration=log4j.travis.properties"
 
     - jdk: oraclejdk8
-      env: 
+      env:
        - DESC="Oracle JDK8 testing"
        - CMD="mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configuration=log4j.travis.properties"
 
     - jdk: oraclejdk7
-      env: 
+      env:
        - DESC="Oracle JDK7 testing"
        - CMD="mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configuration=log4j.travis.properties"
 
     - jdk: openjdk7
-      env: 
+      env:
        - DESC="OpenJDK7 testing"
        - CMD="mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configuration=log4j.travis.properties"
 
-script: echo "Running $DESC..." && (eval $CMD) 
+    - jdk: openjdk6
+      env:
+       - DESC="OpenJDK6 testing"
+       - CMD="mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configuration=log4j.travis.properties"
+
+script: echo "Running $DESC..." && (eval $CMD)
 


### PR DESCRIPTION
This PR is similar to #326, but less aggressive in that it will not remove offending deps/bytecode because the codepath is not susceptible of execution. 

We still Java6 in the CI, so the failing test (which does execute the bad code) will be removed.