### PR TITLE
[release] preparing for 0.26.8: pom, changelog, readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 Changes
 =======
 
-# 0.26.6 / 2020-09-01
+# 0.26.8 / 2020-09-15
+
+### Changes
+
+* [BUGFIX] Fix another Java 6 incompatibility; removal of guava with equivalent JDK or custom functionalities. [#325][]
+
+# 0.26.7 / 2020-09-01
 
 ### Changes
 
@@ -390,6 +396,7 @@ Changes
 [#311]: https://github.com/DataDog/jmxfetch/issues/311
 [#312]: https://github.com/DataDog/jmxfetch/issues/312
 [#315]: https://github.com/DataDog/jmxfetch/issues/315
+[#325]: https://github.com/DataDog/jmxfetch/issues/325
 [@alz]: https://github.com/alz
 [@aoking]: https://github.com/aoking
 [@arrawatia]: https://github.com/arrawatia

--- a/README.md
+++ b/README.md
@@ -51,5 +51,5 @@ mvn test
 # To run:
 ```
 Get help on usage:
-java -jar jmxfetch-0.26.7-jar-with-dependencies.jar --help
+java -jar jmxfetch-0.26.8-jar-with-dependencies.jar --help
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.datadoghq</groupId>
     <artifactId>jmxfetch</artifactId>
-    <version>0.26.7</version>
+    <version>0.26.8</version>
     <packaging>jar</packaging>
 
     <name>jmxfetch</name>


### PR DESCRIPTION
Updating pom.xml, changelog and readme as we prepare to release `0.26.8`.

Unfortunately, `0.26.7` should've never been released as not all Java6 issues had been resolved. Apologies.