### PR TITLE
[json status and reporter] Include null fields in serialized JSON

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Status.java
+++ b/src/main/java/org/datadog/jmxfetch/Status.java
@@ -126,7 +126,7 @@ public class Status {
         Map<String, Object> status = new HashMap<String, Object>();
         status.put("timestamp", System.currentTimeMillis());
         status.put("checks", this.instanceStats);
-        return JSON.std.asString(status);
+        return JSON.std.with(JSON.Feature.WRITE_NULL_PROPERTIES).asString(status);
     }
 
     /** Flushes current status. */

--- a/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
@@ -60,7 +60,12 @@ public class JsonReporter extends Reporter {
 
         System.out.println("=== JSON ===");
         try {
-            System.out.println(JSON.std.with(JSON.Feature.PRETTY_PRINT_OUTPUT, JSON.Feature.WRITE_NULL_PROPERTIES).asString(series));
+            System.out.println(
+                JSON.std.with(
+                    JSON.Feature.PRETTY_PRINT_OUTPUT,
+                    JSON.Feature.WRITE_NULL_PROPERTIES
+                ).asString(series)
+            );
         } catch (IOException e) {
             log.error("Couln't produce JSON output");
         }

--- a/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/JsonReporter.java
@@ -47,7 +47,7 @@ public class JsonReporter extends Reporter {
         sc.put("status", this.statusToServiceCheckStatusValue(status));
         sc.put("message", message);
         sc.put("tags", tags);
-      
+
         Map<String, Object> aggregator = new HashMap<String, Object>();
         aggregator.put("metrics", metrics);
         List<Object> serviceChecks = new ArrayList<Object>();
@@ -60,7 +60,7 @@ public class JsonReporter extends Reporter {
 
         System.out.println("=== JSON ===");
         try {
-            System.out.println(JSON.std.with(JSON.Feature.PRETTY_PRINT_OUTPUT).asString(series));
+            System.out.println(JSON.std.with(JSON.Feature.PRETTY_PRINT_OUTPUT, JSON.Feature.WRITE_NULL_PROPERTIES).asString(series));
         } catch (IOException e) {
             log.error("Couln't produce JSON output");
         }


### PR DESCRIPTION
To keep pre-existing behavior that changed with https://github.com/DataDog/jmxfetch/pull/321.

Apparently `com.fasterxml.jackson.databind.ObjectMapper` used to serialize null fields, whereas `com.fasterxml.jackson.jr.ob.JSON ` doesn't anymore by default (need to enable this property: http://fasterxml.github.io/jackson-jr/javadoc/2.5/com/fasterxml/jackson/jr/ob/JSON.Feature.html#WRITE_NULL_PROPERTIES).

* The change didn't break the agent's parsing of the status, but I still changed back to pre-existing behavior.
* The change did break [e2e integrations-core tooling](https://github.com/DataDog/integrations-core/blob/38076dcc545bcfd74c0f5af53aadb8934a84d6f3/datadog_checks_dev/datadog_checks/dev/_env.py#L123), which is parsing the output of the `JSONReporter`.

Testing: I tested the resulting jar with a local agent, JMXFetch's status still reports fine in the agent's status page.