### PR TITLE
[pom] bumping junit to 4.13.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
          -->
 		<checkstyle.config.location>style.xml</checkstyle.config.location>
 
-        <junit.version>4.11</junit.version>
+        <junit.version>4.13.1</junit.version>
         <mockito.version>2.2.27</mockito.version>
 
         <maven-surefire-plugin.version>2.9</maven-surefire-plugin.version>


### PR DESCRIPTION
Simply bumps JUnit to `4.13.1`, doesn't affect compiled JAR, only testing.