### PR TITLE
Throttle bean attribute refresh + Configuration

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -402,10 +402,12 @@ public class Instance {
 
         if (throttleUpdateAttributesTime != null) {
             if (this.updateAttributesTask.isRunning) {
-                log.warn("Cannot start updateMatchingAttributes task because it is already running");
+                log.warn("Cannot start updateMatchingAttributes"
+                        + " task because it is already running");
             } else {
                 this.updateAttributesTask.runAsync(beans);
-                log.info("Updating attributes async - Done initializing JMX Server at " + this.toString());
+                log.info("Updating attributes async - Done initializing JMX Server at "
+                        + this.toString());
             }
         } else {
             this.updateMatchingAttributes(beans);
@@ -442,7 +444,8 @@ public class Instance {
 
             if (throttleUpdateAttributesTime != null) {
                 if (this.updateAttributesTask.isRunning) {
-                    log.warn("Cannot start updateMatchingAttributes task because it is already running");
+                    log.warn("Cannot start updateMatchingAttributes"
+                            + " task because it is already running");
                 } else {
                     this.updateAttributesTask.runAsync(beans);
                 }

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -516,11 +516,13 @@ public class Instance {
                 ? 0
                 : 1000 * throttleUpdateAttributesTime / beans.size();
 
-        for (ObjectName beanName : beans) {
+        if (sleepTime > 0) {
+            log.debug("throttleUpdateAttributesTime is set - Sleeping for " + sleepTime + "ms between updates");
+        }
 
+        for (ObjectName beanName : beans) {
             if (throttleUpdateAttributesTime != null) {
                 try {
-                    log.debug("throttleUpdateAttributesTime is set - Sleeping for " + sleepTime);
                     Thread.sleep(sleepTime);
                 } catch (InterruptedException e) {
                     log.warn(e.getMessage(), e);

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -147,4 +147,19 @@ public class TestInstance extends TestCommon {
 
         assertEquals(2, configurationList.size());
     }
+
+    @Test
+    public void testThrottleUpdateBeanAttributes() throws Exception {
+        registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:foo=Bar,qux=Baz");
+        initApplication("jmx_instance_throttle_bean_refresh.yaml");
+
+        run();
+        // Since attributes are refreshed async - expect 0 the first time
+        assertEquals(0, getMetrics().size());
+
+        Thread.sleep(2500);
+        run();
+        // BG task should have finished by now
+        assertEquals(15, getMetrics().size());
+    }
 }

--- a/src/test/resources/jmx_instance_throttle_bean_refresh.yaml
+++ b/src/test/resources/jmx_instance_throttle_bean_refresh.yaml
@@ -1,0 +1,16 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        throttle_bean_refresh_interval: 2
+        conf:
+            - include:
+                  domain: org.datadog.jmxfetch.test
+                  attribute:
+                      ShouldBe100:
+                          metric_type: gauge
+                          alias: this.is.100.$foo.$qux
+                      Hashmap.thisis0:
+                          metric_type: gauge
+                          alias: $domain.$qux.$attribute


### PR DESCRIPTION
A new config option to allow bean attribute refresh to be throttled over a time interval, non blocking on a background thread. 