### PR TITLE
Statsd reporter to require host name and optional port to support UDS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
         <commons-io.version>2.4</commons-io.version>
         <apache-commons-lang3.version>3.5</apache-commons-lang3.version>
-        <java-dogstatsd-client.version>2.9.0</java-dogstatsd-client.version>
+        <java-dogstatsd-client.version>2.10.3</java-dogstatsd-client.version>
         <jcommander.version>1.35</jcommander.version>
         <!-- log4j 2.13+ drops support for Java 7, so stick to 2.12 -->
         <log4j.version>2.12.1</log4j.version>

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -106,7 +106,8 @@ public class AppConfig {
     @Parameter(
             names = {"--reporter", "-r"},
             description =
-                    "Reporter to use: should be either \"statsd:[STATSD_PORT]\", "
+                    "Reporter to use: should be either \"statsd:[STATSD_HOST][STATSD_PORT]\", "
+                     + "\"statsd:[STATSD_SOCKET_PATH]\", "
                      + "\"console\" or \"json\"",
             validateWith = ReporterValidator.class,
             converter = ReporterConverter.class,

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -107,7 +107,7 @@ public class AppConfig {
             names = {"--reporter", "-r"},
             description =
                     "Reporter to use: should be either \"statsd:[STATSD_HOST][STATSD_PORT]\", "
-                     + "\"statsd:[STATSD_UNIX_SOCKET_PATH]\", "
+                     + "\"statsd:unix://[STATSD_UNIX_SOCKET_PATH]\", "
                      + "\"console\" or \"json\"",
             validateWith = ReporterValidator.class,
             converter = ReporterConverter.class,

--- a/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
@@ -19,16 +19,16 @@ public class ReporterFactory {
             return new JsonReporter();
         } else if (type.startsWith("statsd:")) {
 
-            Matcher m = Pattern.compile("^statsd:(.*):(\\d+)$").matcher(type);
-            if (m.find() && m.groupCount() == 2) {
-                String host = m.group(1);
-                Integer port = Integer.valueOf(m.group(2));
+            Matcher matcher = Pattern.compile("^statsd:(.*):(\\d+)$").matcher(type);
+            if (matcher.find() && matcher.groupCount() == 2) {
+                String host = matcher.group(1);
+                Integer port = Integer.valueOf(matcher.group(2));
                 return new StatsdReporter(host, port);
             }
 
-            m = Pattern.compile("^statsd:(.*)$").matcher(type);
-            if (m.find() && m.groupCount() == 1) {
-                String socketPath = m.group(1);
+            matcher = Pattern.compile("^statsd:(.*)$").matcher(type);
+            if (matcher.find() && matcher.groupCount() == 1) {
+                String socketPath = matcher.group(1);
                 return new StatsdReporter(socketPath, 0);
             }
         }

--- a/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
@@ -28,8 +28,8 @@ public class ReporterFactory {
 
             m = Pattern.compile("^statsd:(.*)$").matcher(type);
             if (m.find() && m.groupCount() == 1) {
-                String host = m.group(1);
-                return new StatsdReporter(host, 0);
+                String socketPath = m.group(1);
+                return new StatsdReporter(socketPath, 0);
             }
         }
         throw new IllegalArgumentException("Invalid reporter type: " + type);

--- a/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
@@ -26,7 +26,7 @@ public class ReporterFactory {
                 return new StatsdReporter(host, port);
             }
 
-            matcher = Pattern.compile("^statsd:(.*)$").matcher(type);
+            matcher = Pattern.compile("^statsd:unix://(.*)$").matcher(type);
             if (matcher.find() && matcher.groupCount() == 1) {
                 String socketPath = matcher.group(1);
                 return new StatsdReporter(socketPath, 0);

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -41,14 +41,19 @@ public class StatsdReporter extends Reporter {
         /* Create the StatsDClient with "entity-id" set to "none" to avoid
            having dogstatsd server adding origin tags, when the connection is
            done with UDS. */
-        statsDClient = new NonBlockingStatsDClientBuilder()
+        NonBlockingStatsDClientBuilder builder = new NonBlockingStatsDClientBuilder()
                 .enableTelemetry(false)
                 .hostname(this.statsdHost)
                 .port(this.statsdPort)
                 .queueSize(Integer.MAX_VALUE)
                 .errorHandler(new LoggingErrorHandler())
-                .entityID(entityId)
-                .build();
+                .entityID(entityId);
+
+        // When using UDS set the datagram size to 8k
+        if (this.statsdPort == 0) {
+            builder.maxPacketSizeBytes(8192);
+        }
+        statsDClient = builder.build();
     }
 
     protected void sendMetricPoint(

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -45,7 +45,6 @@ public class StatsdReporter extends Reporter {
                 .enableTelemetry(false)
                 .hostname(this.statsdHost)
                 .port(this.statsdPort)
-                .queueSize(Integer.MAX_VALUE)
                 .errorHandler(new LoggingErrorHandler())
                 .entityID(entityId);
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -1,9 +1,6 @@
 package org.datadog.jmxfetch.reporter;
 
-import com.timgroup.statsd.NonBlockingStatsDClient;
-import com.timgroup.statsd.ServiceCheck;
-import com.timgroup.statsd.StatsDClient;
-import com.timgroup.statsd.StatsDClientErrorHandler;
+import com.timgroup.statsd.*;
 import lombok.extern.slf4j.Slf4j;
 import org.datadog.jmxfetch.Instance;
 import org.datadog.jmxfetch.JmxAttribute;
@@ -41,15 +38,14 @@ public class StatsdReporter extends Reporter {
         /* Create the StatsDClient with "entity-id" set to "none" to avoid
            having dogstatsd server adding origin tags, when the connection is
            done with UDS. */
-        statsDClient =
-                new NonBlockingStatsDClient(
-                        null,
-                        this.statsdHost,
-                        this.statsdPort,
-                        Integer.MAX_VALUE,
-                        new String[] {},
-                        new LoggingErrorHandler(),
-                        entityId);
+        statsDClient = new NonBlockingStatsDClientBuilder()
+                .enableTelemetry(false)
+                .hostname(this.statsdHost)
+                .port(this.statsdPort)
+                .queueSize(Integer.MAX_VALUE)
+                .errorHandler(new LoggingErrorHandler())
+                .entityID(entityId)
+                .build();
     }
 
     protected void sendMetricPoint(

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -1,6 +1,9 @@
 package org.datadog.jmxfetch.reporter;
 
-import com.timgroup.statsd.*;
+import com.timgroup.statsd.NonBlockingStatsDClientBuilder;
+import com.timgroup.statsd.ServiceCheck;
+import com.timgroup.statsd.StatsDClient;
+import com.timgroup.statsd.StatsDClientErrorHandler;
 import lombok.extern.slf4j.Slf4j;
 import org.datadog.jmxfetch.Instance;
 import org.datadog.jmxfetch.JmxAttribute;

--- a/src/main/java/org/datadog/jmxfetch/validator/ReporterValidator.java
+++ b/src/main/java/org/datadog/jmxfetch/validator/ReporterValidator.java
@@ -11,17 +11,8 @@ public class ReporterValidator implements IParameterValidator {
 
     /** Validates a reporter configurations (console, statsd). */
     public void validate(String name, String value) throws ParameterException {
-        if (value.startsWith(STATSD_PREFIX) && value.length() > STATSD_PREFIX.length()) {
-            String[] splitValue = value.split(":");
-            String port = splitValue[splitValue.length - 1];
-            try {
-                positiveIntegerValidator.validate(name, port);
-            } catch (ParameterException pe) {
-                throw new ParameterException(
-                        "Statsd Port should be a positive integer (found " + port + ")");
-            }
-            return;
-        }
+        if (value.startsWith(STATSD_PREFIX) && value.length() > STATSD_PREFIX.length()) return;
+
         if (!value.equals("console") && !value.equals("json")) {
             throw new ParameterException(
                     "Parameter "

--- a/src/main/java/org/datadog/jmxfetch/validator/ReporterValidator.java
+++ b/src/main/java/org/datadog/jmxfetch/validator/ReporterValidator.java
@@ -13,7 +13,7 @@ public class ReporterValidator implements IParameterValidator {
                             + name
                             + " should be either 'console', 'json',"
                             + " 'statsd:[STATSD_HOST]:[STATSD_PORT]'"
-                            + " or 'statsd:[STATSD_SOCKET_PATH]'");
+                            + " or 'statsd:unix://[STATSD_UNIX_SOCKET_PATH]'");
         }
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/validator/ReporterValidator.java
+++ b/src/main/java/org/datadog/jmxfetch/validator/ReporterValidator.java
@@ -5,22 +5,14 @@ import com.beust.jcommander.ParameterException;
 
 public class ReporterValidator implements IParameterValidator {
 
-    private static final String STATSD_PREFIX = "statsd:";
-    private final PositiveIntegerValidator positiveIntegerValidator =
-            new PositiveIntegerValidator();
-
     /** Validates a reporter configurations (console, statsd). */
     public void validate(String name, String value) throws ParameterException {
-        if (value.startsWith(STATSD_PREFIX) && value.length() > STATSD_PREFIX.length()) {
-            return;
-        }
-
-        if (!value.equals("console") && !value.equals("json")) {
+        if (!value.matches("^statsd:.+$") && !value.equals("console") && !value.equals("json")) {
             throw new ParameterException(
                     "Parameter "
                             + name
-                            + " should be either 'console', 'json', 'statsd:[STATSD_PORT]' "
-                            + "or 'statsd:[STATSD_HOST]:[STATSD_PORT]'");
+                            + " should be either 'console', 'json', 'statsd:[STATSD_HOST]:[STATSD_PORT]'"
+                            + " or 'statsd:[STATSD_SOCKET_PATH]'");
         }
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/validator/ReporterValidator.java
+++ b/src/main/java/org/datadog/jmxfetch/validator/ReporterValidator.java
@@ -11,7 +11,9 @@ public class ReporterValidator implements IParameterValidator {
 
     /** Validates a reporter configurations (console, statsd). */
     public void validate(String name, String value) throws ParameterException {
-        if (value.startsWith(STATSD_PREFIX) && value.length() > STATSD_PREFIX.length()) return;
+        if (value.startsWith(STATSD_PREFIX) && value.length() > STATSD_PREFIX.length()) {
+            return;
+        }
 
         if (!value.equals("console") && !value.equals("json")) {
             throw new ParameterException(

--- a/src/main/java/org/datadog/jmxfetch/validator/ReporterValidator.java
+++ b/src/main/java/org/datadog/jmxfetch/validator/ReporterValidator.java
@@ -11,7 +11,8 @@ public class ReporterValidator implements IParameterValidator {
             throw new ParameterException(
                     "Parameter "
                             + name
-                            + " should be either 'console', 'json', 'statsd:[STATSD_HOST]:[STATSD_PORT]'"
+                            + " should be either 'console', 'json',"
+                            + " 'statsd:[STATSD_HOST]:[STATSD_PORT]'"
                             + " or 'statsd:[STATSD_SOCKET_PATH]'");
         }
     }

--- a/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
+++ b/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
@@ -149,7 +149,7 @@ public class TestParsingJCommander {
         params =
                 new String[] {
                     "--reporter",
-                    "statsd:10",
+                    "statsd:localhost:10",
                     "--check",
                     SINGLE_CHECK,
                     "--conf_directory",
@@ -216,23 +216,22 @@ public class TestParsingJCommander {
                     pe.getMessage());
         }
 
-        // invalid port
+        // UDS
         params =
                 new String[] {
                     "-r",
-                    "statsd:-1",
+                    "statsd:/path/to/dsd.socket",
                     "--check",
                     SINGLE_CHECK,
                     "--conf_directory",
                     CONF_DIR,
                     AppConfig.ACTION_COLLECT
                 };
-        try {
-            testCommand(params);
-            fail("Should have failed because statsd reporter port is invalid");
-        } catch (ParameterException pe) {
-            assertEquals("Statsd Port should be a positive integer (found -1)", pe.getMessage());
-        }
+        appConfig = testCommand(params);
+        assertNotNull(appConfig.getReporter());
+        assertTrue(appConfig.getReporter() instanceof StatsdReporter);
+        assertEquals("/path/to/dsd.socket", ((StatsdReporter) appConfig.getReporter()).getStatsdHost());
+        assertEquals(0, ((StatsdReporter) appConfig.getReporter()).getStatsdPort());
     }
 
     @Test

--- a/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
+++ b/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
@@ -212,7 +212,7 @@ public class TestParsingJCommander {
             fail("Should have failed because reporter is invalid");
         } catch (ParameterException pe) {
             assertEquals(
-                    "Parameter --reporter should be either 'console', 'json', 'statsd:[STATSD_HOST]:[STATSD_PORT]' or 'statsd:[STATSD_UNIX_SOCKET_PATH]'",
+                    "Parameter --reporter should be either 'console', 'json', 'statsd:[STATSD_HOST]:[STATSD_PORT]' or 'statsd:unix://[STATSD_UNIX_SOCKET_PATH]'",
                     pe.getMessage());
         }
 
@@ -220,7 +220,7 @@ public class TestParsingJCommander {
         params =
                 new String[] {
                     "-r",
-                    "statsd:/path/to/dsd.socket",
+                    "statsd:unix:///path/to/dsd.socket",
                     "--check",
                     SINGLE_CHECK,
                     "--conf_directory",

--- a/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
+++ b/src/test/java/org/datadog/jmxfetch/TestParsingJCommander.java
@@ -212,7 +212,7 @@ public class TestParsingJCommander {
             fail("Should have failed because reporter is invalid");
         } catch (ParameterException pe) {
             assertEquals(
-                    "Parameter --reporter should be either 'console', 'json', 'statsd:[STATSD_PORT]' or 'statsd:[STATSD_HOST]:[STATSD_PORT]'",
+                    "Parameter --reporter should be either 'console', 'json', 'statsd:[STATSD_HOST]:[STATSD_PORT]' or 'statsd:[STATSD_SOCKET_PATH]'",
                     pe.getMessage());
         }
 


### PR DESCRIPTION
This change enables JMXFetch to use UDS as well as UDP connections for statsd. 
I am introducing a breaking change to the statsd connection string. Now it will require a hostname whereas before the host was optional and it only required a port. Now the host is require and the port is optional. If no port number is found, JMXFetch assumes UDS. 

I also rev'd the java-dogstatsd-client version