### PR TITLE
[status] track dogstatsd client errors

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -809,7 +809,7 @@ public class App {
                 metricCount, reporter.getServiceCheckCount(checkName),
                 message, status);
         if (reporter.getHandler() != null) {
-           stats.addErrorStats(reporter.getHandler().getErrors());
+            stats.addErrorStats(reporter.getHandler().getErrors());
         }
     }
 

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -803,12 +803,14 @@ public class App {
             String status) {
         String checkName = instance.getCheckName();
 
-        appConfig
-                .getStatus()
-                .addInstanceStats(
-                        checkName, instance.getName(),
-                        metricCount, reporter.getServiceCheckCount(checkName),
-                        message, status);
+        Status stats = appConfig.getStatus();
+        stats.addInstanceStats(
+                checkName, instance.getName(),
+                metricCount, reporter.getServiceCheckCount(checkName),
+                message, status);
+        if (reporter.getHandler() != null) {
+           stats.addErrorStats(reporter.getHandler().getErrors());
+        }
     }
 
     private void sendServiceCheck(

--- a/src/main/java/org/datadog/jmxfetch/Status.java
+++ b/src/main/java/org/datadog/jmxfetch/Status.java
@@ -26,6 +26,7 @@ public class Status {
     private static final String API_STATUS_PATH = "agent/jmx/status";
     private Map<String, Object> instanceStats;
     private Map<String, Object> info;
+    private int errors;
     private String statusFileLocation;
     private HttpClient client;
     private boolean isEnabled;
@@ -83,6 +84,10 @@ public class Status {
                 INITIALIZED_CHECKS);
     }
 
+    public void addErrorStats(int errors) {
+        this.errors = errors;
+    }
+
     @SuppressWarnings("unchecked")
     private void addStats(
             String checkName,
@@ -128,6 +133,7 @@ public class Status {
         status.put("info", this.info);
         status.put("timestamp", System.currentTimeMillis());
         status.put("checks", this.instanceStats);
+        status.put("errors", this.errors);
         return new Yaml().dump(status);
     }
 
@@ -136,6 +142,7 @@ public class Status {
         status.put("info", this.info);
         status.put("timestamp", System.currentTimeMillis());
         status.put("checks", this.instanceStats);
+        status.put("errors", this.errors);
         return JSON.std.with(JSON.Feature.WRITE_NULL_PROPERTIES).asString(status);
     }
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/LoggingErrorHandler.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/LoggingErrorHandler.java
@@ -1,0 +1,24 @@
+package org.datadog.jmxfetch.reporter;
+
+import com.timgroup.statsd.StatsDClientErrorHandler;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+/** An error handler class to track errors as required. */
+@Slf4j
+public class LoggingErrorHandler implements StatsDClientErrorHandler {
+    private AtomicInteger errors = new AtomicInteger();
+
+    @Override
+    public void handle(Exception exception) {
+        errors.incrementAndGet();
+        log.error("statsd client error:", exception);
+    }
+
+    public int getErrors() {
+        return errors.get();
+    }
+}
+

--- a/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/Reporter.java
@@ -23,6 +23,7 @@ public abstract class Reporter {
             new HashMap<String, Map<String, Map<String, Object>>>();
     private Map<String, Map<String, Long>> countersAggregator =
             new HashMap<String, Map<String, Long>>();
+    protected LoggingErrorHandler handler;
 
     /** Reporter constructor. */
     public Reporter() {
@@ -188,6 +189,10 @@ public abstract class Reporter {
 
     protected Map<String, Integer> getServiceCheckCountMap() {
         return this.serviceCheckCount;
+    }
+
+    public LoggingErrorHandler getHandler() {
+        return this.handler;
     }
 
     protected ServiceCheck.Status statusToServiceCheckStatus(String status) {

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -7,8 +7,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.datadog.jmxfetch.Instance;
 import org.datadog.jmxfetch.JmxAttribute;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
 
 /** A reporter class to submit metrics via statsd. */
 @Slf4j


### PR DESCRIPTION
The goal of this PR is to allow us to tap into potential errors happening in the java dogstatsd client that we might otherwise not have good visibility into. This isn't particularly rich, but at least it'll allow support, and us, to quickly identify potential issues on socket operations. This is particularly interesting in the case of UDS, where we could have drops happening at the socket level - this would result in gaps in our customers timeseries - but not be able to prove otherwise.  