### PR TITLE
[MetadataHelper] Close stream opened to read app properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,8 +32,8 @@
     </developers>
 
     <properties>
-        <maven.compiler.source>1.6</maven.compiler.source>
-        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
 
         <commons-io.version>2.4</commons-io.version>
         <apache-commons-lang3.version>3.5</apache-commons-lang3.version>

--- a/src/main/java/org/datadog/jmxfetch/util/MetadataHelper.java
+++ b/src/main/java/org/datadog/jmxfetch/util/MetadataHelper.java
@@ -1,17 +1,25 @@
 package org.datadog.jmxfetch.util;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
 public class MetadataHelper {
     /**  Returns our own version number. */
     public static String getVersion() {
+        final Properties properties = new Properties();
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        InputStream stream = classLoader.getResourceAsStream("project.properties");
         try {
-            final Properties properties = new Properties();
-            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-            properties.load(classLoader.getResourceAsStream("project.properties"));
+            properties.load(stream);
+            stream.close();
             return properties.getProperty("version");
         } catch (IOException e) {
+            try {
+                stream.close();
+            } catch (IOException ex) {
+                ex.printStackTrace();
+            }
             e.printStackTrace();
             return "?.?.?";
         }

--- a/src/main/java/org/datadog/jmxfetch/util/MetadataHelper.java
+++ b/src/main/java/org/datadog/jmxfetch/util/MetadataHelper.java
@@ -9,17 +9,10 @@ public class MetadataHelper {
     public static String getVersion() {
         final Properties properties = new Properties();
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        InputStream stream = classLoader.getResourceAsStream("project.properties");
-        try {
+        try (InputStream stream = classLoader.getResourceAsStream("project.properties")) {
             properties.load(stream);
-            stream.close();
             return properties.getProperty("version");
         } catch (IOException e) {
-            try {
-                stream.close();
-            } catch (IOException ex) {
-                ex.printStackTrace();
-            }
             e.printStackTrace();
             return "?.?.?";
         }


### PR DESCRIPTION
In order to fix a memory leak.

The memory leak only started to be visible with the changes in https://github.com/DataDog/jmxfetch/pull/330 because it started calling this version logic regularly to report JMXFetch's version to the Agent, whereas this logic was previously only called once in a JMXFetch's process lifecycle (either for the `version` command, or to log the version once at startup)