### PR TITLE
[reporter] statsd: no need to reinit the statsd client every 5m

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -50,10 +50,6 @@ public class StatsdReporter extends Reporter {
 
     protected void sendMetricPoint(
             String metricType, String metricName, double value, String[] tags) {
-        if (System.currentTimeMillis() - this.initializationTime > 300 * 1000) {
-            this.statsDClient.stop();
-            init();
-        }
         if (metricType.equals("monotonic_count")) {
             statsDClient.count(metricName, (long) value, tags);
         } else if (metricType.equals("histogram")) {
@@ -66,10 +62,6 @@ public class StatsdReporter extends Reporter {
     /** Submits service check. */
     public void doSendServiceCheck(
             String serviceCheckName, String status, String message, String[] tags) {
-        if (System.currentTimeMillis() - this.initializationTime > 300 * 1000) {
-            this.statsDClient.stop();
-            init();
-        }
 
         ServiceCheck sc = ServiceCheck.builder()
                 .withName(serviceCheckName)


### PR DESCRIPTION
This was introduced to fix #19 a long way back, since then plenty of changes on the java dogstatsd client should've addressed this issue, rendering that change unnecessary.