### PR TITLE
[pom] bumping java-dogstatsd-client to 2.10.5 to fix thread leak.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
         <commons-io.version>2.4</commons-io.version>
         <apache-commons-lang3.version>3.5</apache-commons-lang3.version>
-        <java-dogstatsd-client.version>2.10.4</java-dogstatsd-client.version>
+        <java-dogstatsd-client.version>2.10.5</java-dogstatsd-client.version>
         <jcommander.version>1.35</jcommander.version>
         <!-- log4j 2.13+ drops support for Java 7, so stick to 2.12 -->
         <log4j.version>2.12.1</log4j.version>


### PR DESCRIPTION
java-dogstatsd-client `v2.10.4` did not fix the issue due to a problem with the cherry-pick see: https://github.com/DataDog/java-dogstatsd-client/pull/128. This bumps the client to the latests version that addresses the inheritance override issue. 