### PR TITLE
Revert "[reporter] statsd: no need to reinit the statsd client every 5m"

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -50,6 +50,10 @@ public class StatsdReporter extends Reporter {
 
     protected void sendMetricPoint(
             String metricType, String metricName, double value, String[] tags) {
+        if (System.currentTimeMillis() - this.initializationTime > 300 * 1000) {
+            this.statsDClient.stop();
+            init();
+        }
         if (metricType.equals("monotonic_count")) {
             statsDClient.count(metricName, (long) value, tags);
         } else if (metricType.equals("histogram")) {
@@ -62,6 +66,10 @@ public class StatsdReporter extends Reporter {
     /** Submits service check. */
     public void doSendServiceCheck(
             String serviceCheckName, String status, String message, String[] tags) {
+        if (System.currentTimeMillis() - this.initializationTime > 300 * 1000) {
+            this.statsDClient.stop();
+            init();
+        }
 
         ServiceCheck sc = ServiceCheck.builder()
                 .withName(serviceCheckName)


### PR DESCRIPTION
Reverts DataDog/jmxfetch#339

Let's revert this for `0.40.3`, we can put it back for `0.40.4+` - easier than branching off.