### PR TITLE
Added config to not collect default JVM metrics

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -224,8 +224,12 @@ public class Instance {
             }
         }
 
-        loadDefaultConfig("default-jmx-metrics.yaml");
-        loadDefaultConfig(gcMetricConfig);
+        Boolean collectDefaultJvmMetrics = (Boolean) instanceMap.get("collect_default_jvm_metrics");
+        if (collectDefaultJvmMetrics == null || collectDefaultJvmMetrics) {
+            log.info("collect_default_jvm_metrics is true - not collecting default JVM metrics");
+            loadDefaultConfig("default-jmx-metrics.yaml");
+            loadDefaultConfig(gcMetricConfig);
+        }
     }
 
     public static boolean isDirectInstance(Map<String, Object> configInstance) {

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -226,9 +226,10 @@ public class Instance {
 
         Boolean collectDefaultJvmMetrics = (Boolean) instanceMap.get("collect_default_jvm_metrics");
         if (collectDefaultJvmMetrics == null || collectDefaultJvmMetrics) {
-            log.info("collect_default_jvm_metrics is true - not collecting default JVM metrics");
             loadDefaultConfig("default-jmx-metrics.yaml");
             loadDefaultConfig(gcMetricConfig);
+        } else {
+            log.info("collect_default_jvm_metrics is false - not collecting default JVM metrics");
         }
     }
 


### PR DESCRIPTION
There are instances where users may not want to collect default JVM metrics. 
This PR adds a new flag to disable this behavior. 

When the flag is not present it defaults to the existing behavior (enabled) 