### PR TITLE
Default cassandra_aliasing to true for cassandra checks

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -192,8 +192,12 @@ public class Instance {
         // Alternative aliasing for CASSANDRA-4009 metrics
         // More information: https://issues.apache.org/jira/browse/CASSANDRA-4009
         this.cassandraAliasing = (Boolean) instanceMap.get("cassandra_aliasing");
-        if (this.cassandraAliasing == null) {
-            this.cassandraAliasing = false;
+        if ( this.cassandraAliasing == null) {
+            if ( this.checkName == "cassandra") {
+                this.cassandraAliasing = true;
+            } else {
+                this.cassandraAliasing = false;
+            }
         }
 
         // In case the configuration to match beans is not specified in the "instance" parameter but

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -192,8 +192,8 @@ public class Instance {
         // Alternative aliasing for CASSANDRA-4009 metrics
         // More information: https://issues.apache.org/jira/browse/CASSANDRA-4009
         this.cassandraAliasing = (Boolean) instanceMap.get("cassandra_aliasing");
-        if ( this.cassandraAliasing == null) {
-            if ( this.checkName == "cassandra") {
+        if (this.cassandraAliasing == null) {
+            if (this.checkName.startsWith("cassandra")) {
                 this.cassandraAliasing = true;
             } else {
                 this.cassandraAliasing = false;


### PR DESCRIPTION
**Description**

- Sets `cassandra_aliasing` to `true` by default for cassandra integration.

**Motivation**

- the config can be easily overlooked if being set via annotations/autodiscovery