### PR TITLE
Fix empty include in configuration

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Configuration.java
+++ b/src/main/java/org/datadog/jmxfetch/Configuration.java
@@ -43,7 +43,7 @@ public class Configuration {
     }
 
     private Boolean hasInclude() {
-        return getInclude() != null;
+        return getInclude() != null && !getInclude().isEmptyFilter();
     }
 
     /**

--- a/src/main/java/org/datadog/jmxfetch/Filter.java
+++ b/src/main/java/org/datadog/jmxfetch/Filter.java
@@ -188,4 +188,8 @@ class Filter {
     public boolean isEmptyBeanName() {
         return (filter.get("bean") == null && filter.get("bean_name") == null);
     }
+
+    public boolean isEmptyFilter() {
+        return filter.isEmpty();
+    }
 }

--- a/src/test/java/org/datadog/jmxfetch/TestConfiguration.java
+++ b/src/test/java/org/datadog/jmxfetch/TestConfiguration.java
@@ -84,11 +84,46 @@ public class TestConfiguration {
     }
 
     /**
+     * Check that an empty include doesn't return a '*:*' filters
+     *
+     * @throws FileNotFoundException
+     * @throws SecurityException
+     * @throws NoSuchMethodException
+     * @throws InvocationTargetException
+     * @throws IllegalArgumentException
+     * @throws IllegalAccessException
+     */
+    @Test
+    public void testEmptyInclude()
+            throws FileNotFoundException, NoSuchMethodException, SecurityException, IllegalAccessException,
+                    IllegalArgumentException, InvocationTargetException {
+        File f = new File("src/test/resources/", "jmx_empty_filters.yaml");
+        String yamlPath = f.getAbsolutePath();
+        FileInputStream yamlInputStream = new FileInputStream(yamlPath);
+        YamlParser fileConfig = new YamlParser(yamlInputStream);
+        List<Map<String, Object>> configInstances =
+                ((List<Map<String, Object>>) fileConfig.getYamlInstances());
+
+        List<Configuration> confs = new ArrayList<Configuration>();
+        for (Map<String, Object> config : configInstances) {
+            Object yamlConf = config.get("conf");
+            for (Map<String, Object> conf :
+                    (List<Map<String, Object>>) (yamlConf)) {
+                confs.add(new Configuration(conf));
+            }
+        }
+
+        assertEquals(confs.size(), 1);
+        List<String> res = Configuration.getGreatestCommonScopes(confs);
+        assertEquals(res, new ArrayList<String>());
+    }
+
+    /**
      * Extract filters from the configuration list and index by domain name
      *
      * @throws SecurityException
      * @throws NoSuchMethodException
-     * @throws InvocationTargetException
+     * @throws InvocationTargetExceptionConfiguration
      * @throws IllegalArgumentException
      * @throws IllegalAccessException
      */

--- a/src/test/resources/jmx_empty_filters.yaml
+++ b/src/test/resources/jmx_empty_filters.yaml
@@ -1,0 +1,6 @@
+init_config:
+
+instances:
+  - name: jmx_test_default_hostname
+    conf:
+        - include:


### PR DESCRIPTION
An empty 'include' configuration would produce a beanScrope of '*:*' and
would match every bean from the server without applying any of the
default configuration