### PR TITLE
Adds a configurable period for the 1st bean refresh

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -244,7 +244,7 @@ public class AppConfig {
     private List<String> metricConfigResources;
     // This is used by things like APM agent to provide metric configuration from files
     private List<String> metricConfigFiles;
-    // This is used by things like APM agent to provide global override for initial bean refresh period
+    // This is used by things like APM agent to provide global override for 1st bean refresh period
     private Integer initialRefreshBeansPeriod;
     // This is used by things like APM agent to provide global override for bean refresh period
     private Integer refreshBeansPeriod;

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -244,6 +244,8 @@ public class AppConfig {
     private List<String> metricConfigResources;
     // This is used by things like APM agent to provide metric configuration from files
     private List<String> metricConfigFiles;
+    // This is used by things like APM agent to provide global override for initial bean refresh period
+    private Integer initialRefreshBeansPeriod;
     // This is used by things like APM agent to provide global override for bean refresh period
     private Integer refreshBeansPeriod;
     // This is used by things like APM agent to provide tags that should be set with all metrics
@@ -399,6 +401,10 @@ public class AppConfig {
 
     public Integer getRefreshBeansPeriod() {
         return refreshBeansPeriod;
+    }
+
+    public Integer getInitialRefreshBeansPeriod() {
+        return initialRefreshBeansPeriod;
     }
 
     public Map<String, String> getGlobalTags() {

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -491,10 +491,10 @@ public class Instance {
 
     /** Returns whather or not the given period has elapsed since reference time. */
     public boolean isPeriodDue(long refTime, Integer refPeriod) {
-        if ((System.currentTimeMillis() - refTime) / 1000 > refPeriod) {
-            return true;
-        } else {
+        if ((System.currentTimeMillis() - refTime) / 1000 < refPeriod) {
             return false;
+        } else {
+            return true;
         }
     }
 

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -441,8 +441,7 @@ public class Instance {
 
         if (this.initialRefreshBeansPeriod != null
                 && (this.initialRefreshTime != 0)
-                && (System.currentTimeMillis() - this.initialRefreshTime) / 1000
-                        > this.initialRefreshBeansPeriod) {
+                && isPeriodDue(this.initialRefreshTime, this.initialRefreshBeansPeriod)) {
             log.info("Refreshing bean list - Initial");
             // We can force the first bean refresh post initialization earlier than the refreshBeansPeriod
             // To enable this, a "refresh_beans_initial" parameter must be specified in the yaml/json config
@@ -453,8 +452,7 @@ public class Instance {
             // We can force to refresh the bean list every x seconds in case of ephemeral beans
             // To enable this, a "refresh_beans" parameter must be specified in the yaml/json config
             if (this.refreshBeansPeriod != null
-                    && (System.currentTimeMillis() - this.lastRefreshTime) / 1000
-                            > this.refreshBeansPeriod) {
+                    && isPeriodDue(this.lastRefreshTime, this.refreshBeansPeriod)) {
                 log.info("Refreshing bean list");
                 this.refreshBeansList();
                 this.getMatchingAttributes();
@@ -491,15 +489,21 @@ public class Instance {
         return metrics;
     }
 
+    /** Returns whather or not the given period has elapsed since reference time. */
+    public boolean isPeriodDue(long refTime, Integer refPeriod) {
+        if ((System.currentTimeMillis() - refTime) / 1000 > refPeriod) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
     /** Returns whather or not its time to collect metrics for the instance. */
     public boolean timeToCollect() {
         if (this.minCollectionPeriod == null) {
             return true;
-        } else if ((System.currentTimeMillis() - this.lastCollectionTime) / 1000
-                < this.minCollectionPeriod) {
-            return false;
         } else {
-            return true;
+            return isPeriodDue(this.lastCollectionTime, this.minCollectionPeriod);
         }
     }
 

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -60,7 +60,6 @@ public class Instance {
     private static final List<String> MULTI_TYPES =
             Arrays.asList("javax.management.openmbean.TabularData");
     private static final int MAX_RETURNED_METRICS = 350;
-    private static final int DEFAULT_INITIAL_REFRESH_BEANS_PERIOD = 150;
     private static final int DEFAULT_REFRESH_BEANS_PERIOD = 600;
     public static final String PROCESS_NAME_REGEX = "process_name_regex";
     public static final String JVM_DIRECT = "jvm_direct";
@@ -146,7 +145,7 @@ public class Instance {
                 // First bean refresh after initialization. Succeeding refresh controlled by refresh_beans
                 // Useful for Java applications that are lazy loaded and may take some time after
                 // application startup before actually being exposed
-                this.initialRefreshBeansPeriod = DEFAULT_INITIAL_REFRESH_BEANS_PERIOD; 
+                this.initialRefreshBeansPeriod = this.refreshBeansPeriod; 
             }
         } else {
             // Allow global overrides

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -443,8 +443,8 @@ public class Instance {
         // post initialization and every x seconds thereafter.
         // To enable this, a "refresh_beans_initial" and/or "refresh_beans" parameters must be
         // specified in the yaml/json config
-        Integer period = (this.initialRefreshTime==this.lastRefreshTime) ? 
-            this.initialRefreshBeansPeriod : this.refreshBeansPeriod;
+        Integer period = (this.initialRefreshTime == this.lastRefreshTime)
+            ? this.initialRefreshBeansPeriod : this.refreshBeansPeriod;
 
         if (isPeriodDue(this.lastRefreshTime, period)) {
             log.info("Refreshing bean list");

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -443,8 +443,7 @@ public class Instance {
         // post initialization and every x seconds thereafter.
         // To enable this, a "refresh_beans_initial" and/or "refresh_beans" parameters must be
         // specified in the yaml/json config
-        Integer period = (this.initialRefreshTime == this.lastRefreshTime)
-            ? this.initialRefreshBeansPeriod : this.refreshBeansPeriod;
+        Integer period = (this.initialRefreshTime == this.lastRefreshTime) ? this.initialRefreshBeansPeriod : this.refreshBeansPeriod;
 
         if (isPeriodDue(this.lastRefreshTime, period)) {
             log.info("Refreshing bean list");

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -443,7 +443,8 @@ public class Instance {
         // post initialization and every x seconds thereafter.
         // To enable this, a "refresh_beans_initial" and/or "refresh_beans" parameters must be
         // specified in the yaml/json config
-        Integer period = (this.initialRefreshTime == this.lastRefreshTime) ? this.initialRefreshBeansPeriod : this.refreshBeansPeriod;
+        Integer period = (this.initialRefreshTime == this.lastRefreshTime)
+            ? this.initialRefreshBeansPeriod : this.refreshBeansPeriod;
 
         if (isPeriodDue(this.lastRefreshTime, period)) {
             log.info("Refreshing bean list");

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -444,9 +444,8 @@ public class Instance {
                 && (System.currentTimeMillis() - this.initialRefreshTime) / 1000
                         > this.initialRefreshBeansPeriod) {
             log.info("Refreshing bean list - Initial");
-            // We can force the first bean refresh post initialization earlier than the
-            // configured "refresh_beans"
-            // To enable this, a "refresh_beans" parameter must be specified in the yaml/json config
+            // We can force the first bean refresh post initialization earlier than the refreshBeansPeriod
+            // To enable this, a "refresh_beans_initial" parameter must be specified in the yaml/json config
             this.refreshBeansList();
             this.getMatchingAttributes();
             this.initialRefreshTime = 0;


### PR DESCRIPTION
### What this PR does

Adds a configurable period for the 1st bean refresh.

### Additional info

- Configurable via `refresh_beans_initial` - time in seconds for jmxfetch to wait to refresh the beans for the first time.
- Succeeding bean refresh still adheres to `refresh_beans` parameter.
- Setting a value greater than the `refresh_beans` will default to a value equal to `refresh_beans`.

### Motivation

- AC-737
- Useful for Java applications that are lazy loaded and may take some time after application startup before actually being exposed.