### PR TITLE
Add tests for refresh_beans and refresh_beans_initial

### DIFF
--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -164,7 +164,7 @@ public class TestInstance extends TestCommon {
         // We register an additional mbean
         registerMBean(testApp, "org.datadog.jmxfetch.test:iteration=one");
         log.info("sleeping before the next collection");
-        Thread.sleep(5000);
+        Thread.sleep(1500);
 
         // We run a second collection. refresh_beans_initial should be due.
         run();
@@ -176,7 +176,7 @@ public class TestInstance extends TestCommon {
         // We register additional mbean
         registerMBean(testApp, "org.datadog.jmxfetch.test:iteration=two");
         log.info("sleeping before the next collection");
-        Thread.sleep(5000);
+        Thread.sleep(1500);
 
         // We run a third collection. No change expected; refresh_beans not due.
         run();
@@ -186,7 +186,7 @@ public class TestInstance extends TestCommon {
         assertEquals(15, metrics.size());
 
         log.info("sleeping before the next collection");
-        Thread.sleep(5000);
+        Thread.sleep(1500);
 
         // We run the last collection. refresh_beans should be due.
         run();

--- a/src/test/resources/jmx_refresh_beans.yaml
+++ b/src/test/resources/jmx_refresh_beans.yaml
@@ -1,0 +1,14 @@
+init_config:
+
+instances:
+  -   process_name_regex: .*surefire.*
+      min_collection_interval: 5
+      refresh_beans_initial: 5
+      refresh_beans: 10
+      name: jmx_test_instance
+      conf:
+          - include:
+             domain: org.datadog.jmxfetch.test
+             attribute: 
+                 - ShouldBe100
+                 - ShouldBe1000

--- a/src/test/resources/jmx_refresh_beans.yaml
+++ b/src/test/resources/jmx_refresh_beans.yaml
@@ -2,9 +2,9 @@ init_config:
 
 instances:
   -   process_name_regex: .*surefire.*
-      min_collection_interval: 5
-      refresh_beans_initial: 5
-      refresh_beans: 10
+      min_collection_interval: 1
+      refresh_beans_initial: 1
+      refresh_beans: 3
       name: jmx_test_instance
       conf:
           - include:


### PR DESCRIPTION
Related to #349 

Adds tests for both `refresh_beans_initial` and `refresh_beans`

- AC-800