### PR TITLE
[release] Preparing pom, README and CHANGELOG for 0.42.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 Changelog
 =========
 
-# 0.42.0 / 2020-01-25 
+# 0.42.1 / 2020-03-30
+
+### Changes
+* [IMPROVEMENT] Move publishing pipeline from Bintray to Sonatype. See
+  [here](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/)
+  for more info.
+
+# 0.42.0 / 2020-01-25
 
 ### Changes
 * [FEATURE] Adds a configurable period for the initial bean refresh [#349][]

--- a/README.md
+++ b/README.md
@@ -124,5 +124,5 @@ otherwise the subsequent publishes will fail.
 
 ```
 Get help on usage:
-java -jar jmxfetch-0.42.0-jar-with-dependencies.jar --help
+java -jar jmxfetch-0.42.1-jar-with-dependencies.jar --help
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.datadoghq</groupId>
     <artifactId>jmxfetch</artifactId>
-    <version>0.42.0</version>
+    <version>0.42.1</version>
     <packaging>jar</packaging>
 
     <name>jmxfetch</name>


### PR DESCRIPTION
This release has no user-facing changes but it is required for us
to test end-to-end publishing to Sonatype.