### PR TITLE
[build] Prevent double signing of release artifacts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -45,7 +45,7 @@ deploy_to_sonatype:
     - set -x
 
     - echo "Building release..."
-    - mvn -DperformRelease=true --settings ./settings.xml clean verify deploy
+    - mvn -DperformRelease=true --settings ./settings.xml clean deploy
 
   artifacts:
     expire_in: 12 mos


### PR DESCRIPTION
The `mvn verify` step was creating `*.asc` files which were then signed
again when run with `mvn deploy` even though the `maven-gpg-plugin`
documentation explicitly mentions that they should be ignored. Since
`mvn deploy` will automatically invoke `verify`, this change ensures
that the artifacts are signed only once.