### PR TITLE
Add `jvm.gc.old_gen_size` as an alias for `Tenured Gen`

### DIFF
--- a/src/main/resources/org/datadog/jmxfetch/default-jmx-metrics.yaml
+++ b/src/main/resources/org/datadog/jmxfetch/default-jmx-metrics.yaml
@@ -189,6 +189,14 @@
 - include:
     domain: java.lang
     type: MemoryPool
+    name: Tenured Gen
+    attribute:
+      Usage.used:
+        alias: jvm.gc.old_gen_size
+        metric_type: gauge
+- include:
+    domain: java.lang
+    type: MemoryPool
     name: Metaspace
     attribute:
       Usage.used:


### PR DESCRIPTION
Add `jvm.gc.old_gen_size` as an alias for `Tenured Gen`.

Motivation:
`SerialGC` may be the default GC for `openjdk 11.0.10` and it exposes `Tenured Gen` beans.

See AC-907.