### PR TITLE
Sleep after over-long iteration

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -472,14 +472,15 @@ public class App {
             try {
                 long loopPeriod = appConfig.getCheckPeriod();
                 long sleepPeriod = loopPeriod - duration;
-                if (sleepPeriod <= 0) {
+                if (sleepPeriod < loopPeriod / 2) {
                     log.debug(
                         "The collection cycle took longer that the configured check period,"
-                        + " the next cycle will start immediatly");
+                        + " the next cycle will be delayed");
+                    sleepPeriod = loopPeriod / 2;
                 } else {
                     log.debug("Sleeping for " + sleepPeriod + " ms.");
-                    Thread.sleep(sleepPeriod);    
                 }
+                Thread.sleep(sleepPeriod);
             } catch (InterruptedException e) {
                 log.warn(e.getMessage(), e);
             }


### PR DESCRIPTION
Too short iteration interval is problematic for rate calculation on slow moving
counters: small time delta pushes calculated rate way above the average rate
for the couner.

This PR revises logic introduced in #323 and limits minimum interval between
iterations to a half of the configured check period to minimize negative effect
on the rate calculations.