### PR TITLE
Remove messages for non-ERROR can_connect service checks

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -1191,7 +1191,6 @@ public class App {
                                     + instance.getMaxNumberOfMetrics()
                                     + " metrics.";
 
-                    instanceStatus = Status.STATUS_OK;
                     CustomLogger.laconic(log, Level.WARN, instanceMessage, 0);
                 }
 

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -839,6 +839,11 @@ public class App {
     private void sendCanConnectServiceCheck(Reporter reporter, String checkName,
         String serviceCheckPrefix, String status, String message, String[] tags) {
         String serviceCheckName = String.format("%s.can_connect", serviceCheckPrefix);
+
+        if (status != Status.STATUS_ERROR) {
+            message = null;
+        }
+
         reporter.sendServiceCheck(
                 checkName, serviceCheckName, status, message, tags);
     }

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -840,7 +840,7 @@ public class App {
         String serviceCheckPrefix, String status, String message, String[] tags) {
         String serviceCheckName = String.format("%s.can_connect", serviceCheckPrefix);
 
-        if (status == Status.STATUS_OK) {
+        if (status != Status.STATUS_ERROR) {
             message = null;
         }
 
@@ -1191,6 +1191,7 @@ public class App {
                                     + instance.getMaxNumberOfMetrics()
                                     + " metrics.";
 
+                    instanceStatus = Status.STATUS_WARNING;
                     CustomLogger.laconic(log, Level.WARN, instanceMessage, 0);
                 }
 

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -840,7 +840,7 @@ public class App {
         String serviceCheckPrefix, String status, String message, String[] tags) {
         String serviceCheckName = String.format("%s.can_connect", serviceCheckPrefix);
 
-        if (status != Status.STATUS_ERROR) {
+        if (status == Status.STATUS_OK) {
             message = null;
         }
 
@@ -1191,7 +1191,7 @@ public class App {
                                     + instance.getMaxNumberOfMetrics()
                                     + " metrics.";
 
-                    instanceStatus = Status.STATUS_WARNING;
+                    instanceStatus = Status.STATUS_OK;
                     CustomLogger.laconic(log, Level.WARN, instanceMessage, 0);
                 }
 

--- a/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
+++ b/src/test/java/org/datadog/jmxfetch/TestServiceChecks.java
@@ -74,8 +74,9 @@ public class TestServiceChecks extends TestCommon {
         assertNotNull(sc.get("name"));
         assertNotNull(sc.get("status"));
 
-        // Message should not be null anymore and reports a high number of metrics warning
-        assertNotNull(sc.get("message"));
+        // Despite there being a high number of metrics warning, message should be null.
+        // Non-ERROR statuses are set to OK, and OK statuses should have null messages.
+        assertNull(sc.get("message"));
         assertNotNull(sc.get("tags"));
 
         String scName = (String) (sc.get("name"));


### PR DESCRIPTION
This PR removes messages for status that is not an ERROR for the `*.can_connect` service check.

Datadog is removing messages for integration checks that give OK status to reduce the load on the backend. There's a small scenario where `*.can_connect` gives a WARNING status along with a message. This WARNING is later converted into an OK, as only OK or ERROR statuses are used for `*.can_connect`. 

Once this is merged in, https://github.com/DataDog/integrations-core/pull/9958 can be merged.