### PR TITLE
[services] support adding multiple service tags to submitted metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,3 @@ target/*
 
 # jenv
 .java_version
-.java-version

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ target/*
 .euml2
 .umlproject
 .classpath
+.factorypath
 .project
 .settings/
 /target
@@ -18,3 +19,4 @@ target/*
 
 # jenv
 .java_version
+.java-version

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -858,7 +858,7 @@ public class App {
         Reporter reporter = appConfig.getReporter();
 
         try {
-            instance = new Instance(instanceMap, initConfig, checkName, appConfig);
+            instance = new Instance(instanceMap, initConfig, checkName, appConfig, null);
         } catch (Exception e) {
             String warning = "Unable to create instance. Please check your yaml file";
             appConfig.getStatus().addInitFailedCheck(checkName, warning, Status.STATUS_ERROR);

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -10,6 +10,7 @@ import org.datadog.jmxfetch.converter.ReporterConverter;
 import org.datadog.jmxfetch.reporter.ConsoleReporter;
 import org.datadog.jmxfetch.reporter.JsonReporter;
 import org.datadog.jmxfetch.reporter.Reporter;
+import org.datadog.jmxfetch.service.ServiceNameProvider;
 import org.datadog.jmxfetch.validator.Log4JLevelValidator;
 import org.datadog.jmxfetch.validator.PositiveIntegerValidator;
 import org.datadog.jmxfetch.validator.ReporterValidator;
@@ -250,6 +251,11 @@ public class AppConfig {
     private Integer refreshBeansPeriod;
     // This is used by things like APM agent to provide tags that should be set with all metrics
     private Map<String, String> globalTags;
+    /**
+     * This is used by things like APM agent to provide a custom ServiceNameProvider that should be
+     * used for all Instances.
+     */
+    private ServiceNameProvider serviceNameProvider;
 
     @Builder.Default
     private Status status = new Status();
@@ -409,6 +415,10 @@ public class AppConfig {
 
     public Map<String, String> getGlobalTags() {
         return globalTags;
+    }
+
+    public ServiceNameProvider getServiceNameProvider() {
+        return serviceNameProvider;
     }
 
     /**

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -581,7 +581,7 @@ public class Instance {
                             && !action.equals(AppConfig.ACTION_LIST_NOT_MATCHING)) {
                         reporter.displayMetricReached();
                         metricReachedDisplayed = true;
-                            }
+                    }
                 }
                 JmxAttribute jmxAttribute;
                 String attributeType = attributeInfo.getType();
@@ -674,7 +674,7 @@ public class Instance {
                                     && limitReached) {
                                 reporter.displayMatchingAttributeName(
                                         jmxAttribute, metricsCount, maxReturnedMetrics);
-                                    }
+                            }
                             break;
                         }
                     } catch (Exception e) {
@@ -691,7 +691,7 @@ public class Instance {
                         && (action.equals(AppConfig.ACTION_LIST_EVERYTHING)
                             || action.equals(AppConfig.ACTION_LIST_NOT_MATCHING))) {
                     reporter.displayNonMatchingAttributeName(jmxAttribute);
-                            }
+                }
             }
         }
         log.info("Found " + matchingAttributes.size() + " matching attributes");
@@ -750,8 +750,8 @@ public class Instance {
             }
         }
 
-        if(this.services != null) {
-            for(String service : this.services){
+        if (this.services != null) {
+            for (String service : this.services) {
                 tags.add("service:" + service);
             }
         }

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -161,7 +161,8 @@ public class Instance {
             this.initialRefreshBeansPeriod = this.refreshBeansPeriod;
         }
 
-        this.serviceNameProvider = new ConfigServiceNameProvider(instanceMap, initConfig, appConfig.getServiceNameProvider());
+        this.serviceNameProvider = new ConfigServiceNameProvider(
+                instanceMap, initConfig, appConfig.getServiceNameProvider());
 
         this.minCollectionPeriod = (Integer) instanceMap.get("min_collection_interval");
         if (this.minCollectionPeriod == null && initConfig != null) {

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -729,7 +729,7 @@ public class Instance {
             }
         }
 
-        List<String> services  = this.serviceNameProvider.getServiceNames();
+        Iterable<String> services  = this.serviceNameProvider.getServiceNames();
         if (services != null) {
             for (String service : services) {
                 tags.add("service:" + service);

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -161,12 +161,7 @@ public class Instance {
             this.initialRefreshBeansPeriod = this.refreshBeansPeriod;
         }
 
-        if (appConfig.getServiceNameProvider() == null) {
-            this.serviceNameProvider = new ConfigServiceNameProvider(instanceMap, initConfig);
-        } else {
-            // Allow global overrides
-            this.serviceNameProvider = appConfig.getServiceNameProvider();
-        }
+        this.serviceNameProvider = new ConfigServiceNameProvider(instanceMap, initConfig, appConfig.getServiceNameProvider());
 
         this.minCollectionPeriod = (Integer) instanceMap.get("min_collection_interval");
         if (this.minCollectionPeriod == null && initConfig != null) {

--- a/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
@@ -138,7 +138,7 @@ public abstract class JmxAttribute {
     }
 
     private void addServiceTags() {
-        List<String> serviceNames = this.serviceNameProvider.getServiceNames();
+        Iterable<String> serviceNames = this.serviceNameProvider.getServiceNames();
         if (serviceNames != null) {
             for (String serviceName : serviceNames) {
                 this.defaultTagsList.add("service:" + serviceName);

--- a/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
@@ -50,8 +50,8 @@ public abstract class JmxAttribute {
     private ObjectName beanName;
     private String domain;
     private String className;
-    private String serviceName;
     private String beanStringName;
+    private List<String> serviceNames;
     private Map<String, String> beanParameters;
     private String attributeName;
     private Map<String, Map<Object, Object>> valueConversions =
@@ -67,9 +67,9 @@ public abstract class JmxAttribute {
             ObjectName beanName,
             String className,
             String instanceName,
-            String serviceName,
             String checkName,
             Connection connection,
+            List<String> serviceNames,
             Map<String, String> instanceTags,
             boolean cassandraAliasing,
             boolean emptyDefaultHostname) {
@@ -82,7 +82,7 @@ public abstract class JmxAttribute {
         this.beanStringName = beanName.toString();
         this.cassandraAliasing = cassandraAliasing;
         this.checkName = checkName;
-        this.serviceName = serviceName;
+        this.serviceNames = serviceNames;
 
         // A bean name is formatted like that:
         // org.apache.cassandra.db:type=Caches,keyspace=system,cache=HintsColumnFamilyKeyCache
@@ -137,8 +137,10 @@ public abstract class JmxAttribute {
     }
 
     private void addServiceTag() {
-        if (serviceName != null && !serviceName.isEmpty()) {
-            this.defaultTagsList.add("service:" + serviceName);
+        if (serviceNames != null) {
+            for (String serviceName : serviceNames) {
+                this.defaultTagsList.add("service:" + serviceName);
+            }
         }
     }
 

--- a/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
@@ -1,5 +1,7 @@
 package org.datadog.jmxfetch;
 
+import org.datadog.jmxfetch.service.ServiceNameProvider;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -26,7 +28,7 @@ public class JmxComplexAttribute extends JmxSubAttribute {
             String instanceName,
             String checkName,
             Connection connection,
-            List<String> serviceNames,
+            ServiceNameProvider serviceNameProvider,
             Map<String, String> instanceTags,
             boolean emptyDefaultHostname) {
         super(
@@ -36,7 +38,7 @@ public class JmxComplexAttribute extends JmxSubAttribute {
                 instanceName,
                 checkName,
                 connection,
-                serviceNames,
+                serviceNameProvider,
                 instanceTags,
                 false,
                 emptyDefaultHostname);

--- a/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
@@ -24,9 +24,9 @@ public class JmxComplexAttribute extends JmxSubAttribute {
             ObjectName beanName,
             String className,
             String instanceName,
-            String serviceName,
             String checkName,
             Connection connection,
+            List<String> serviceNames,
             Map<String, String> instanceTags,
             boolean emptyDefaultHostname) {
         super(
@@ -34,9 +34,9 @@ public class JmxComplexAttribute extends JmxSubAttribute {
                 beanName,
                 className,
                 instanceName,
-                serviceName,
                 checkName,
                 connection,
+                serviceNames,
                 instanceTags,
                 false,
                 emptyDefaultHostname);

--- a/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
@@ -21,9 +21,9 @@ public class JmxSimpleAttribute extends JmxAttribute {
             ObjectName beanName,
             String className,
             String instanceName,
-            String serviceName,
             String checkName,
             Connection connection,
+            List<String> serviceNames,
             Map<String, String> instanceTags,
             boolean cassandraAliasing,
             Boolean emptyDefaultHostname) {
@@ -32,9 +32,9 @@ public class JmxSimpleAttribute extends JmxAttribute {
                 beanName,
                 className,
                 instanceName,
-                serviceName,
                 checkName,
                 connection,
+                serviceNames,
                 instanceTags,
                 cassandraAliasing,
                 emptyDefaultHostname);

--- a/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
@@ -1,5 +1,7 @@
 package org.datadog.jmxfetch;
 
+import org.datadog.jmxfetch.service.ServiceNameProvider;
+
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
@@ -23,7 +25,7 @@ public class JmxSimpleAttribute extends JmxAttribute {
             String instanceName,
             String checkName,
             Connection connection,
-            List<String> serviceNames,
+            ServiceNameProvider serviceNameProvider,
             Map<String, String> instanceTags,
             boolean cassandraAliasing,
             Boolean emptyDefaultHostname) {
@@ -34,7 +36,7 @@ public class JmxSimpleAttribute extends JmxAttribute {
                 instanceName,
                 checkName,
                 connection,
-                serviceNames,
+                serviceNameProvider,
                 instanceTags,
                 cassandraAliasing,
                 emptyDefaultHostname);

--- a/src/main/java/org/datadog/jmxfetch/JmxSubAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxSubAttribute.java
@@ -1,5 +1,7 @@
 package org.datadog.jmxfetch;
 
+import org.datadog.jmxfetch.service.ServiceNameProvider;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,7 +18,7 @@ abstract class JmxSubAttribute extends JmxAttribute {
             String instanceName,
             String checkName,
             Connection connection,
-            List<String> serviceNames,
+            ServiceNameProvider serviceNameProvider,
             Map<String, String> instanceTags,
             boolean cassandraAliasing,
             boolean emptyDefaultHostname) {
@@ -27,7 +29,7 @@ abstract class JmxSubAttribute extends JmxAttribute {
                 instanceName,
                 checkName,
                 connection,
-                serviceNames,
+                serviceNameProvider,
                 instanceTags,
                 cassandraAliasing,
                 emptyDefaultHostname);

--- a/src/main/java/org/datadog/jmxfetch/JmxSubAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxSubAttribute.java
@@ -1,6 +1,7 @@
 package org.datadog.jmxfetch;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.management.MBeanAttributeInfo;
 import javax.management.ObjectName;
@@ -8,12 +9,28 @@ import javax.management.ObjectName;
 abstract class JmxSubAttribute extends JmxAttribute {
     private Map<String, Metric> cachedMetrics = new HashMap<String, Metric>();
 
-    public JmxSubAttribute(MBeanAttributeInfo attribute, ObjectName beanName, String className,
-            String instanceName, String serviceName, String checkName, Connection connection,
-            Map<String, String> instanceTags, boolean cassandraAliasing,
+    public JmxSubAttribute(
+            MBeanAttributeInfo attribute,
+            ObjectName beanName,
+            String className,
+            String instanceName,
+            String checkName,
+            Connection connection,
+            List<String> serviceNames,
+            Map<String, String> instanceTags,
+            boolean cassandraAliasing,
             boolean emptyDefaultHostname) {
-        super(attribute, beanName, className, instanceName, serviceName, checkName, connection,
-                instanceTags, cassandraAliasing, emptyDefaultHostname);
+        super(
+                attribute,
+                beanName,
+                className,
+                instanceName,
+                checkName,
+                connection,
+                serviceNames,
+                instanceTags,
+                cassandraAliasing,
+                emptyDefaultHostname);
     }
 
     public Metric getCachedMetric(String name) {

--- a/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
@@ -1,6 +1,7 @@
 package org.datadog.jmxfetch;
 
 import lombok.extern.slf4j.Slf4j;
+import org.datadog.jmxfetch.service.ServiceNameProvider;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -35,7 +36,7 @@ public class JmxTabularAttribute extends JmxSubAttribute {
             String instanceName,
             String checkName,
             Connection connection,
-            List<String> serviceNames,
+            ServiceNameProvider serviceNameProvider,
             Map<String, String> instanceTags,
             boolean emptyDefaultHostname) {
         super(
@@ -45,7 +46,7 @@ public class JmxTabularAttribute extends JmxSubAttribute {
                 instanceName,
                 checkName,
                 connection,
-                serviceNames,
+                serviceNameProvider,
                 instanceTags,
                 false,
                 emptyDefaultHostname);

--- a/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
@@ -33,9 +33,9 @@ public class JmxTabularAttribute extends JmxSubAttribute {
             ObjectName beanName,
             String className,
             String instanceName,
-            String serviceName,
             String checkName,
             Connection connection,
+            List<String> serviceNames,
             Map<String, String> instanceTags,
             boolean emptyDefaultHostname) {
         super(
@@ -43,9 +43,9 @@ public class JmxTabularAttribute extends JmxSubAttribute {
                 beanName,
                 className,
                 instanceName,
-                serviceName,
                 checkName,
                 connection,
+                serviceNames,
                 instanceTags,
                 false,
                 emptyDefaultHostname);

--- a/src/main/java/org/datadog/jmxfetch/service/ConfigServiceNameProvider.java
+++ b/src/main/java/org/datadog/jmxfetch/service/ConfigServiceNameProvider.java
@@ -32,13 +32,20 @@ public class ConfigServiceNameProvider implements ServiceNameProvider {
         this.additionalServiceNames = additionalServiceNames;
     }
 
+    /**
+     * Returns a String Iterable with the relevant services defined in the init config and instance
+     * maps supplied in the constructor, as well as any additional services derived from the
+     * additional ServiceNameProvider (if any).
+     *
+     * @return the service String Iterable.
+     */
     public Iterable<String> getServiceNames() {
         if (this.additionalServiceNames == null) {
             return this.serviceNames;
         }
 
         List<String> names = new ArrayList<String>(this.serviceNames);
-        for(String service : this.additionalServiceNames.getServiceNames()) {
+        for (String service : this.additionalServiceNames.getServiceNames()) {
             names.add(service);
         }
         return names;

--- a/src/main/java/org/datadog/jmxfetch/service/ConfigServiceNameProvider.java
+++ b/src/main/java/org/datadog/jmxfetch/service/ConfigServiceNameProvider.java
@@ -10,6 +10,7 @@ import java.util.Map;
  */
 public class ConfigServiceNameProvider implements ServiceNameProvider {
     private List<String> serviceNames;
+    private ServiceNameProvider additionalServiceNames;
 
 
     /**
@@ -21,16 +22,26 @@ public class ConfigServiceNameProvider implements ServiceNameProvider {
      */
     public ConfigServiceNameProvider(
             Map<String, Object> instanceMap,
-            Map<String, Object> initConfig) {
+            Map<String, Object> initConfig,
+            ServiceNameProvider additionalServiceNames) {
         List<String> services = compileServiceList(instanceMap);
         if (services.size() == 0) {
             services = compileServiceList(initConfig);
         }
         this.serviceNames = services;
+        this.additionalServiceNames = additionalServiceNames;
     }
 
     public Iterable<String> getServiceNames() {
-        return this.serviceNames;
+        if (this.additionalServiceNames == null) {
+            return this.serviceNames;
+        }
+
+        List<String> names = new ArrayList<String>(this.serviceNames);
+        for(String service : this.additionalServiceNames.getServiceNames()) {
+            names.add(service);
+        }
+        return names;
     }
 
     @SuppressWarnings("unchecked")

--- a/src/main/java/org/datadog/jmxfetch/service/ConfigServiceNameProvider.java
+++ b/src/main/java/org/datadog/jmxfetch/service/ConfigServiceNameProvider.java
@@ -29,7 +29,7 @@ public class ConfigServiceNameProvider implements ServiceNameProvider {
         this.serviceNames = services;
     }
 
-    public List<String> getServiceNames() {
+    public Iterable<String> getServiceNames() {
         return this.serviceNames;
     }
 

--- a/src/main/java/org/datadog/jmxfetch/service/ConfigServiceNameProvider.java
+++ b/src/main/java/org/datadog/jmxfetch/service/ConfigServiceNameProvider.java
@@ -1,0 +1,55 @@
+package org.datadog.jmxfetch.service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * ConfigServiceNameProvider provides the list of service names based on the config maps passed to
+ * its constructor.
+ */
+public class ConfigServiceNameProvider implements ServiceNameProvider {
+    private List<String> serviceNames;
+
+
+    /**
+     * Builds a ConfigServiceNameProvider based on the maps of an instance config and init config,
+     * returning the initialized ServiceNameProvider.
+     *
+     * @param instanceMap The instance config map
+     * @param initConfig The init config map
+     */
+    public ConfigServiceNameProvider(
+            Map<String, Object> instanceMap,
+            Map<String, Object> initConfig) {
+        List<String> services = compileServiceList(instanceMap);
+        if (services.size() == 0) {
+            services = compileServiceList(initConfig);
+        }
+        this.serviceNames = services;
+    }
+
+    public List<String> getServiceNames() {
+        return this.serviceNames;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> compileServiceList(Map<String, Object> config) {
+        List<String> services = new ArrayList<>();
+        if (config == null || !config.containsKey("service")) {
+            return services;
+        }
+
+        try {
+            String svc = (String) config.get("service");
+            if (svc != null && !svc.isEmpty()) {
+                services.add(svc);
+            }
+        } catch (ClassCastException e) {
+            // must be a list then...
+            services = (List<String>) config.get("service");
+        }
+
+        return services;
+    }
+}

--- a/src/main/java/org/datadog/jmxfetch/service/ServiceNameProvider.java
+++ b/src/main/java/org/datadog/jmxfetch/service/ServiceNameProvider.java
@@ -1,0 +1,7 @@
+package org.datadog.jmxfetch.service;
+
+import java.util.List;
+
+public interface ServiceNameProvider {
+    List<String> getServiceNames();
+}

--- a/src/main/java/org/datadog/jmxfetch/service/ServiceNameProvider.java
+++ b/src/main/java/org/datadog/jmxfetch/service/ServiceNameProvider.java
@@ -1,7 +1,5 @@
 package org.datadog.jmxfetch.service;
 
-import java.util.List;
-
 public interface ServiceNameProvider {
-    List<String> getServiceNames();
+    Iterable<String> getServiceNames();
 }

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -78,9 +78,11 @@ public class TestInstance extends TestCommon {
         }
     }
 
-    // assertServiceTag is used by testServiceTagGlobal and testServiceTagInstanceOverride
-    private void assertServiceTag(List<String> tagList, String service) throws Exception {
-        assertTrue(tagList.contains(new String("service:" + service)));
+    // assertServiceTags is used by testServiceTagGlobal and testServiceTagInstanceOverride
+    private void assertServiceTag(List<String> tagList, List<String> services) throws Exception {
+        for (String service: services) {
+            assertTrue(tagList.contains(new String("service:" + service)));
+        }
     }
 
     @Test
@@ -93,14 +95,35 @@ public class TestInstance extends TestCommon {
         assertEquals(28, metrics.size());
         for (Map<String, Object> metric : metrics) {
             String[] tags = (String[]) metric.get("tags");
-            this.assertServiceTag(Arrays.asList(tags), "global");
+            this.assertServiceTag(Arrays.asList(tags), Arrays.asList("global"));
         }
 
         List<Map<String, Object>> serviceChecks = getServiceChecks();
         assertEquals(4, serviceChecks.size());
         for (Map<String, Object> sc : serviceChecks) {
             String[] tags = (String[]) sc.get("tags");
-            this.assertServiceTag(Arrays.asList(tags), "global");
+            this.assertServiceTag(Arrays.asList(tags), Arrays.asList("global"));
+        }
+    }
+
+    @Test
+    public void testServiceTagGlobalList() throws Exception {
+        registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:foo=Bar,qux=Baz");
+        initApplication("jmx_service_tag_global_list.yaml");
+        run();
+
+        List<Map<String, Object>> metrics = getMetrics();
+        assertEquals(28, metrics.size());
+        for (Map<String, Object> metric : metrics) {
+            String[] tags = (String[]) metric.get("tags");
+            this.assertServiceTag(Arrays.asList(tags), Arrays.asList("global", "foo", "bar"));
+        }
+
+        List<Map<String, Object>> serviceChecks = getServiceChecks();
+        assertEquals(4, serviceChecks.size());
+        for (Map<String, Object> sc : serviceChecks) {
+            String[] tags = (String[]) sc.get("tags");
+            this.assertServiceTag(Arrays.asList(tags), Arrays.asList("global", "foo", "bar"));
         }
     }
 
@@ -114,14 +137,14 @@ public class TestInstance extends TestCommon {
         assertEquals(28, metrics.size());
         for (Map<String, Object> metric : metrics) {
             String[] tags = (String[]) metric.get("tags");
-            this.assertServiceTag(Arrays.asList(tags), "override");
+            this.assertServiceTag(Arrays.asList(tags), Arrays.asList("override"));
         }
 
         List<Map<String, Object>> serviceChecks = getServiceChecks();
         assertEquals(4, serviceChecks.size());
         for (Map<String, Object> sc : serviceChecks) {
             String[] tags = (String[]) sc.get("tags");
-            this.assertServiceTag(Arrays.asList(tags), "override");
+            this.assertServiceTag(Arrays.asList(tags), Arrays.asList("override"));
         }
     }
 

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -100,6 +100,9 @@ public class TestInstance extends TestCommon {
         assertEquals(4, serviceChecks.size());
         for (Map<String, Object> sc : serviceChecks) {
             String[] tags = (String[]) sc.get("tags");
+            for (String tag : tags) {
+                System.out.println("THIS IS A TAG WE GOT " + tag);
+            }
             this.assertServiceTag(Arrays.asList(tags), "global");
         }
     }

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -100,9 +100,6 @@ public class TestInstance extends TestCommon {
         assertEquals(4, serviceChecks.size());
         for (Map<String, Object> sc : serviceChecks) {
             String[] tags = (String[]) sc.get("tags");
-            for (String tag : tags) {
-                System.out.println("THIS IS A TAG WE GOT " + tag);
-            }
             this.assertServiceTag(Arrays.asList(tags), "global");
         }
     }

--- a/src/test/java/org/datadog/jmxfetch/service/ConfigServiceNameProviderTest.java
+++ b/src/test/java/org/datadog/jmxfetch/service/ConfigServiceNameProviderTest.java
@@ -1,0 +1,64 @@
+package org.datadog.jmxfetch.service;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(Parameterized.class)
+public class ConfigServiceNameProviderTest {
+
+    @Parameterized.Parameters
+    public static Iterable<Object[]> testCases() {
+        return Arrays.asList(new Object[][] {
+                {
+                    Collections.singletonMap("service", "foo-instance"),
+                    Collections.singletonMap("service", "foo-init"),
+                    Arrays.asList("foo-instance")
+                },
+                {
+                    Collections.singletonMap("not-service", "foo-instance"),
+                    Collections.singletonMap("service", "foo-init"),
+                    Arrays.asList("foo-init")
+                },
+                {
+                    Collections.singletonMap("not-service", "foo-instance"),
+                    Collections.singletonMap("not-service", "foo-init"),
+                    new ArrayList<>()
+                },
+                {
+                    Collections.singletonMap("service", Arrays.asList("foo1-instance", "foo2-instance")),
+                    Collections.singletonMap("service", "foo-init"),
+                    Arrays.asList("foo1-instance", "foo2-instance")
+                },
+        });
+    }
+
+    private final Map<String, Object> instanceMap;
+    private final Map<String, Object> initConfigMap;
+    private final List<String> expected;
+
+    public ConfigServiceNameProviderTest(Map<String, Object> instanceMap, Map<String, Object> initConfigMap, List<String> expected) {
+        this.instanceMap = instanceMap;
+        this.initConfigMap = initConfigMap;
+        this.expected = expected;
+    }
+
+    @Test
+    public void testConfigServiceNameProvider() {
+        ConfigServiceNameProvider configServiceNameProvider = new ConfigServiceNameProvider(
+            instanceMap,
+            initConfigMap
+        );
+
+        assertEquals(expected, configServiceNameProvider.getServiceNames());
+    }
+}

--- a/src/test/java/org/datadog/jmxfetch/service/ConfigServiceNameProviderTest.java
+++ b/src/test/java/org/datadog/jmxfetch/service/ConfigServiceNameProviderTest.java
@@ -16,39 +16,57 @@ import static org.junit.Assert.assertEquals;
 @RunWith(Parameterized.class)
 public class ConfigServiceNameProviderTest {
 
+    private static class CustomConfigServiceNameProvider implements ServiceNameProvider {
+        public Iterable<String> getServiceNames() {
+            return new ArrayList<String>(Arrays.asList("foo-provider"));
+        }
+    }
+
     @Parameterized.Parameters
     public static Iterable<Object[]> testCases() {
         return Arrays.asList(new Object[][] {
                 {
                     Collections.singletonMap("service", "foo-instance"),
                     Collections.singletonMap("service", "foo-init"),
+                    null,
                     Arrays.asList("foo-instance")
                 },
                 {
                     Collections.singletonMap("not-service", "foo-instance"),
                     Collections.singletonMap("service", "foo-init"),
+                    null,
                     Arrays.asList("foo-init")
                 },
                 {
                     Collections.singletonMap("not-service", "foo-instance"),
                     Collections.singletonMap("not-service", "foo-init"),
+                    null,
                     new ArrayList<>()
                 },
                 {
                     Collections.singletonMap("service", Arrays.asList("foo1-instance", "foo2-instance")),
                     Collections.singletonMap("service", "foo-init"),
+                    null,
                     Arrays.asList("foo1-instance", "foo2-instance")
+                },
+                {
+                    Collections.singletonMap("service", Arrays.asList("foo1-instance", "foo2-instance")),
+                    Collections.singletonMap("service", "foo-init"),
+                    new ConfigServiceNameProviderTest.CustomConfigServiceNameProvider(),
+                    Arrays.asList("foo1-instance", "foo2-instance", "foo-provider")
                 },
         });
     }
 
     private final Map<String, Object> instanceMap;
     private final Map<String, Object> initConfigMap;
+    private final ServiceNameProvider provider;
     private final List<String> expected;
 
-    public ConfigServiceNameProviderTest(Map<String, Object> instanceMap, Map<String, Object> initConfigMap, List<String> expected) {
+    public ConfigServiceNameProviderTest(Map<String, Object> instanceMap, Map<String, Object> initConfigMap, ServiceNameProvider provider, List<String> expected) {
         this.instanceMap = instanceMap;
         this.initConfigMap = initConfigMap;
+        this.provider = provider;
         this.expected = expected;
     }
 
@@ -56,7 +74,8 @@ public class ConfigServiceNameProviderTest {
     public void testConfigServiceNameProvider() {
         ConfigServiceNameProvider configServiceNameProvider = new ConfigServiceNameProvider(
             instanceMap,
-            initConfigMap
+            initConfigMap,
+            provider
         );
 
         assertEquals(expected, configServiceNameProvider.getServiceNames());

--- a/src/test/resources/jmx_service_tag_global_list.yaml
+++ b/src/test/resources/jmx_service_tag_global_list.yaml
@@ -1,0 +1,31 @@
+init_config:
+  service:
+    - global
+    - foo
+    - bar
+    - test
+
+instances:
+  -   process_name_regex: .*surefire.*
+      name: jmx_test_1
+      tags:
+        - jmx:fetch
+      conf:
+          - include:
+             domain: org.datadog.jmxfetch.test
+             attribute:
+                  ShouldBe100:
+                      metric_type: gauge
+                      alias: this.is.100.$foo.$qux
+
+  -   process_name_regex: .*surefire.*
+      name: jmx_test_2
+      tags:
+        - jmx:fetch
+      conf:
+          - include:
+             domain: org.datadog.jmxfetch.test
+             attribute:
+                  ShouldBe100:
+                      metric_type: gauge
+                      alias: this.is.100.$foo.$qux


### PR DESCRIPTION
This PR is an alternative approach to #374. This proposal, instead of submitting multiple "copies" of the same instance with different `service` tags as we implemented in the aforementioned PR, will send a single time-series tagged with multiple service tags. 

The approach proposed here should allow for more sensible querying as the datadog backend is able to identify this consists of a *single* time-series despite the various `service` tags and thus provides more sensible values when dealing with aggregation functions like `sum`. 

Before deciding between this approach or #374 we need to understand if what we do here may cause issues with service correlation. 

### Implementation details

This introduces a `ServiceNameProvider` interface, an implementation of which can be passed to JMXFetch's `AppConfig` builder:
* In a standalone JMXFetch scenario, a default implementation of this provider (`ConfigServiceNameProvider`) is used, which pulls the `service` defined in yaml config. This implementation supports defining multiple services under `service` in configuration.
* When configured on `AppConfig` (typically from the APM tracer):
  
  * the configured `ServiceNameProvider` applies to all the JMXFetch Instances that are configured on JMXFetch (i.e.: when a `ServiceNameProvider` is configured on JMXFetch, all the metrics submitted by JMXFetch will be submitted with the service names provided by `ServiceNameProvider`). No possibility at the moment to configure this at the level of a single JMXFetch `Instance`.
  * the configured `ServiceNameProvider` does not read the `service` defined in yaml config. Note that for the APM tracer, this can constitute a breaking change for APM users that have defined custom JMXFetch yaml configs in which they've defined a `service`: previously JMXFetch would send both the tracer-provided `service` name and the config-provided `service`, with this change JMXFetch will only send the trace-provided `service`.

* it's best for the `ServiceNameProvider` to return an immutable List, to avoid race conditions/thread-safety issues.