### PR TITLE
[build] bumping log4j2 to 2.12.2 for sanity + pinning mvn-deploy-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,15 +40,17 @@
         <java-dogstatsd-client.version>2.10.5</java-dogstatsd-client.version>
         <jcommander.version>1.35</jcommander.version>
         <!-- log4j 2.13+ drops support for Java 7, so stick to 2.12 -->
-        <log4j.version>2.12.1</log4j.version>
+        <log4j.version>2.12.2</log4j.version>
         <slf4j.version>1.7.26</slf4j.version>
         <jackson.version>2.12.3</jackson.version>
         <snakeyaml.version>1.26</snakeyaml.version>
+        <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <!-- Note: using project checkstyle with AOSP style
         find the default google java checkstyle config here -
         <checkstyle.config.location>google_checks.xml</checkstyle.config.location>
          -->
         <checkstyle.config.location>style.xml</checkstyle.config.location>
+
 
         <junit.version>4.13.1</junit.version>
         <mockito.version>2.2.27</mockito.version>
@@ -330,6 +332,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-deploy-plugin</artifactId>
+                <version>${maven-deploy-plugin.version}</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -68,8 +68,6 @@ public class App {
     private static final String COLLECTION_POOL_NAME = "jmxfetch-collectionPool";
     private static final String RECOVERY_POOL_NAME = "jmxfetch-recoveryPool";
 
-    private static final String LOG4J2_FMT_MSG_NOLOOKUPS = "log4j2.formatMsgNoLookups";
-
     private static final ByteArraySearcher CONFIG_TERM_SEARCHER
             = new ByteArraySearcher(App.AD_CONFIG_TERM.getBytes());
     private static final ByteArraySearcher LEGACY_CONFIG_TERM_SEARCHER
@@ -144,9 +142,6 @@ public class App {
         {
             // Running these commands here because they are logging specific,
             // not needed in dd-java-agent, which calls run directly.
-
-            // Nasty but no easy programmatic way to enable behavior otherwise
-            System.setProperty(LOG4J2_FMT_MSG_NOLOOKUPS, "True");
 
             // Set up the logger to add file handler
             CustomLogger.setup(Level.toLevel(config.getLogLevel()),


### PR DESCRIPTION
Despite being unaffected by https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45046 after our previous mitigation effort, the Apache foundation has released log4j `v2.12.2` which remains Java7 compatible while entirely removing the message lookups feature and explicitly disabling JNDI access as per: https://logging.apache.org/log4j/2.x/.

As such, and for sanity and housekeeping we should bump to said log4j version number. 

Finally, this PR also sets a pin on the `mvn-deploy-plugin` to guarantee the stability of the build (and is entirely unrelated to the log4j change).