### PR TITLE
[release] preparing for 0.45.2 + changelog update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+# 0.45.2 / 2021-12-15 
+
+### Changes
+
+* [BUGFIX] bumping log4j to v2.12.2 [#380][]
+
 # 0.45.1 / 2021-12-13 
 
 ### Changes
@@ -643,6 +649,7 @@ Changelog
 [#369]: https://github.com/DataDog/jmxfetch/issues/369
 [#375]: https://github.com/DataDog/jmxfetch/issues/375
 [#376]: https://github.com/DataDog/jmxfetch/issues/376
+[#380]: https://github.com/DataDog/jmxfetch/issues/380
 [@alz]: https://github.com/alz
 [@aoking]: https://github.com/aoking
 [@arrawatia]: https://github.com/arrawatia

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Changelog
 
 ### Changes
 
+* [BUGFIX] bumping log4j to v2.12.2 [#380][] 
+
+# 0.44.5 / 2021-12-14 
+
+### Changes
+
 * [BUGFIX] bumping log4j to v2.12.2 [#380][]
 
 # 0.45.1 / 2021-12-13 

--- a/README.md
+++ b/README.md
@@ -124,5 +124,5 @@ otherwise the subsequent publishes will fail.
 
 ```
 Get help on usage:
-java -jar jmxfetch-0.45.1-jar-with-dependencies.jar --help
+java -jar jmxfetch-0.45.2-jar-with-dependencies.jar --help
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.datadoghq</groupId>
     <artifactId>jmxfetch</artifactId>
-    <version>0.45.1</version>
+    <version>0.45.2</version>
     <packaging>jar</packaging>
 
     <name>jmxfetch</name>


### PR DESCRIPTION
This PR bumps the corresponding version number to `0.45.2` in preparation for an upcoming release.

It also takes the opportunity to cherry-pick the changes made in 0.44.5 into the changelog.