### PR TITLE
Update jcommander to avoid unsafe dependency resolution vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <commons-io.version>2.4</commons-io.version>
         <apache-commons-lang3.version>3.5</apache-commons-lang3.version>
         <java-dogstatsd-client.version>2.10.5</java-dogstatsd-client.version>
-        <jcommander.version>1.35</jcommander.version>
+        <jcommander.version>1.82</jcommander.version>
         <slf4j.version>1.7.32</slf4j.version>
         <jackson.version>2.12.3</jackson.version>
         <snakeyaml.version>1.26</snakeyaml.version>


### PR DESCRIPTION
## What's in this PR?
- update to jcommander dependency to avoid: https://security.snyk.io/vuln/SNYK-JAVA-COMBEUST-174815
- jcommander fixed the issue in [this commit](https://github.com/cbeust/jcommander/commit/3ae95595febbed9c13f367b6bda5c0be1c572c53)