### PR TITLE
Add ZGC Cycles and ZGC Pauses beans support out of the box

### DIFF
--- a/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
+++ b/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
@@ -104,6 +104,19 @@
 - include:
     domain: java.lang
     type: GarbageCollector
+    name: Shenandoah Cycles
+    attribute:
+      CollectionCount:
+        alias: jvm.gc.major_collection_count
+        metric_type: counter
+      CollectionTime:
+        alias: jvm.gc.major_collection_time
+        metric_type: counter
+
+# Z Garbage Collector
+- include:
+    domain: java.lang
+    type: GarbageCollector
     name: ZGC
     attribute:
       CollectionCount:
@@ -115,11 +128,22 @@
 - include:
     domain: java.lang
     type: GarbageCollector
-    name: Shenandoah Cycles
+    name: ZGC Cycles
     attribute:
       CollectionCount:
-        alias: jvm.gc.major_collection_count
+        alias: jvm.gc.zgc_cycles_collection_count
         metric_type: counter
       CollectionTime:
-        alias: jvm.gc.major_collection_time
+        alias: jvm.gc.zgc_cycles_collection_time
+        metric_type: counter
+- include:
+    domain: java.lang
+    type: GarbageCollector
+    name: ZGC Pauses
+    attribute:
+      CollectionCount:
+        alias: jvm.gc.zgc_pauses_collection_count
+        metric_type: counter
+      CollectionTime:
+        alias: jvm.gc.zgc_pauses_collection_time
         metric_type: counter


### PR DESCRIPTION
This PR aims to add OOTB support for ZGC beans.

There are some points that might be worth to discuss : 

- Metrics names : 
     - concept of `minor` and `major` doesn't apply to ZGC, so using the same names doesn't make sense.
     - Nonetheless, using the same names will make thing easier for getting generic dashboard for instance 
- ZGC bean : 
     - `ZGC` doesn't exist with Java 17 but exists with JDK 14 as state in [this PR](https://github.com/DataDog/jmxfetch/pull/303) (tested again and can confirm 👍).  That is something we might want to write in documentation if not already here.
     - Also, what about the metrics names for `ZGC` ?
- GC order :
     - I think it will be easier to check if some beans are missing or to add new beans in the file if we organize it by GC instead of by `Old` and `Young` Gen collectors, especially when ZGC breaks this logic. Not so important anyway.