### PR TITLE
Splits the JCommander code into it's own class to allow embedded applications to exclude it

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.datadoghq</groupId>
     <artifactId>jmxfetch</artifactId>
-    <version>0.46.0</version>
+    <version>0.47.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>jmxfetch</name>
@@ -264,7 +264,7 @@
                 <configuration>
                     <archive>
                         <manifest>
-                            <mainClass>org.datadog.jmxfetch.App</mainClass>
+                            <mainClass>org.datadog.jmxfetch.JmxFetch</mainClass>
                             <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
                         </manifest>
                         <manifestEntries>

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -2,8 +2,6 @@ package org.datadog.jmxfetch;
 
 import static org.datadog.jmxfetch.Instance.isDirectInstance;
 
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.ParameterException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.extern.slf4j.Slf4j;
 
@@ -18,8 +16,6 @@ import org.datadog.jmxfetch.util.FileHelper;
 import org.datadog.jmxfetch.util.LogLevel;
 import org.datadog.jmxfetch.util.MetadataHelper;
 import org.datadog.jmxfetch.util.ServiceCheckHelper;
-import org.slf4j.Marker;
-import org.slf4j.MarkerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -109,53 +105,6 @@ public class App {
     }
 
     /**
-     * Main entry of JMXFetch.
-     *
-     * <p>See AppConfig class for more details on the args
-     */
-    public static void main(String[] args) {
-
-        // Load the config from the args
-        AppConfig config = AppConfig.builder().build();
-        JCommander commander = null;
-        try {
-            // Try to parse the args using JCommander
-            commander = new JCommander(config, args);
-        } catch (ParameterException e) {
-            System.out.println(e.getMessage());
-            System.exit(1);
-        }
-
-        // Display the version and quit
-        if (config.isVersion() || AppConfig.ACTION_VERSION.equals(config.getAction())) {
-            JCommander.getConsole().println("JMX Fetch " + MetadataHelper.getVersion());
-            System.exit(0);
-        }
-
-        // Display the help and quit
-        if (config.isHelp() || AppConfig.ACTION_HELP.equals(config.getAction())) {
-            commander.usage();
-            System.exit(0);
-        }
-
-        {
-            // Running these commands here because they are logging specific,
-            // not needed in dd-java-agent, which calls run directly.
-
-            // Set up the logger to add file handler
-            CustomLogger.setup(LogLevel.fromString(config.getLogLevel()),
-                    config.getLogLocation(),
-                    config.isLogFormatRfc3339());
-
-            // Set up the shutdown hook to properly close resources
-            attachShutdownHook();
-        }
-
-        App app = new App(config);
-        System.exit(app.run());
-    }
-
-    /**
      * Main entry point of JMXFetch that returns integer on exit instead of calling {@code
      * System#exit}.
      */
@@ -217,20 +166,6 @@ public class App {
             displayRateMetrics();
         }
         return 0;
-    }
-
-    /** Attach a Shutdown Hook that will be called when SIGTERM is sent to JMXFetch. */
-    private static void attachShutdownHook() {
-        Runtime.getRuntime().addShutdownHook(
-            new Thread() {
-                @Override
-                public void run() {
-                    log.info("JMXFetch is closing");
-                    // make sure log handlers are properly closed
-                    CustomLogger.shutdown();
-                }
-            }
-        );
     }
 
     /** Sets reinitialization flag. */

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -83,6 +83,14 @@ public class App {
     private AppConfig appConfig;
     private HttpClient client;
 
+    /**
+     * Main method for backwards compatibility in case someone is launching process by class
+     * instead of by jar IE: java -classpath jmxfetch.jar org.datadog.jmxfetch.App
+     */
+    public static void main(String[] args) {
+        JmxFetch.main(args);
+    }
+
     /** Application constructor. */
     public App(AppConfig appConfig) {
         this.appConfig = appConfig;

--- a/src/main/java/org/datadog/jmxfetch/JmxFetch.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxFetch.java
@@ -1,0 +1,73 @@
+package org.datadog.jmxfetch;
+
+import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterException;
+
+import lombok.extern.slf4j.Slf4j;
+import org.datadog.jmxfetch.util.CustomLogger;
+import org.datadog.jmxfetch.util.LogLevel;
+import org.datadog.jmxfetch.util.MetadataHelper;
+
+@Slf4j
+public class JmxFetch {
+    /**
+     * Main entry of JMXFetch.
+     *
+     * <p>See AppConfig class for more details on the args
+     */
+    public static void main(String[] args) {
+
+        // Load the config from the args
+        AppConfig config = AppConfig.builder().build();
+        JCommander commander = null;
+        try {
+            // Try to parse the args using JCommander
+            commander = new JCommander(config, args);
+        } catch (ParameterException e) {
+            System.out.println(e.getMessage());
+            System.exit(1);
+        }
+
+        // Display the version and quit
+        if (config.isVersion() || AppConfig.ACTION_VERSION.equals(config.getAction())) {
+            JCommander.getConsole().println("JMX Fetch " + MetadataHelper.getVersion());
+            System.exit(0);
+        }
+
+        // Display the help and quit
+        if (config.isHelp() || AppConfig.ACTION_HELP.equals(config.getAction())) {
+            commander.usage();
+            System.exit(0);
+        }
+
+        {
+            // Running these commands here because they are logging specific,
+            // not needed in dd-java-agent, which calls run directly.
+
+            // Set up the logger to add file handler
+            CustomLogger.setup(LogLevel.fromString(config.getLogLevel()),
+                    config.getLogLocation(),
+                    config.isLogFormatRfc3339());
+
+            // Set up the shutdown hook to properly close resources
+            attachShutdownHook();
+        }
+
+        App app = new App(config);
+        System.exit(app.run());
+    }
+
+    /** Attach a Shutdown Hook that will be called when SIGTERM is sent to JMXFetch. */
+    private static void attachShutdownHook() {
+        Runtime.getRuntime().addShutdownHook(
+                new Thread() {
+                    @Override
+                    public void run() {
+                        log.info("JMXFetch is closing");
+                        // make sure log handlers are properly closed
+                        CustomLogger.shutdown();
+                    }
+                }
+        );
+    }
+}


### PR DESCRIPTION
`dd-trace-java` doesn't require JCommander code in order to execute JMXFetch so spliting it like this allows us to exclude the dependency entirely, removing exposure to the vulnerabilities and making our Jar smaller
