### PR TITLE
Upgrade snakeyaml to 1.31 to mitigate CVE-2022-25857

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
         <jcommander.version>1.35</jcommander.version>
         <slf4j.version>1.7.32</slf4j.version>
         <jackson.version>2.12.3</jackson.version>
-        <snakeyaml.version>1.26</snakeyaml.version>
+        <snakeyaml.version>1.31</snakeyaml.version>
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <!-- Note: using project checkstyle with AOSP style
         find the default google java checkstyle config here -


### PR DESCRIPTION
We got a ticket here DataDog/dd-trace-java#3787 to upgrade snakeyaml, and it comes from our embedded JMXFetch.