### PR TITLE
Prevent agent from adding origin detection tags when using UDS.

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -49,7 +49,7 @@ public class StatsdReporter extends Reporter {
                 .errorHandler(handler)
                 .entityID(entityId);
 
-        // When using UDS set the datagram size to 8k
+        // When using UDS set the datagram size to 8k and disable origin detection
         if (this.statsdPort == 0) {
             builder.maxPacketSizeBytes(8192);
             builder.constantTags("dd.internal.card:none");

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -52,6 +52,7 @@ public class StatsdReporter extends Reporter {
         // When using UDS set the datagram size to 8k
         if (this.statsdPort == 0) {
             builder.maxPacketSizeBytes(8192);
+            builder.constantTags("dd.internal.card:none");
         }
         statsDClient = builder.build();
     }


### PR DESCRIPTION
dd.internal.entity_id:none, which jmxfetch already uses, only works with non-default agent configuration (dogstatsd_entity_id_precedence: true).

To avoid this issue, agent 7.41.0 supports new dd.internal.card:none which also opts-out from the origin detection, but without the need for non-default configuration. The dd.interna.card tag prefix is recognized since 7.27.0, and will be removed from metrics.