### PR TITLE
Fixed issue where TabularData would not be returned if the metrics do not have tags

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
@@ -96,19 +96,22 @@ public class JmxTabularAttribute extends JmxSubAttribute {
         Map<String, ?> attributeParams = getAttributesFor(fullMetricKey);
         if (attributeParams != null) {
             Map<String, String> yamlTags = (Map) attributeParams.get("tags");
-            for (String tagName : yamlTags.keySet()) {
-                String tag = tagName;
-                String value = yamlTags.get(tagName);
-                Object resolvedValue;
 
-                if (value.startsWith("$")) {
-                    resolvedValue = getValue(key, value.substring(1));
-                    if (resolvedValue != null) {
-                        value = (String) resolvedValue;
+            if (yamlTags != null) {
+                for (String tagName : yamlTags.keySet()) {
+                    String tag = tagName;
+                    String value = yamlTags.get(tagName);
+                    Object resolvedValue;
+
+                    if (value.startsWith("$")) {
+                        resolvedValue = getValue(key, value.substring(1));
+                        if (resolvedValue != null) {
+                            value = (String) resolvedValue;
+                        }
                     }
-                }
 
-                tagsList.add(tag + ":" + value);
+                    tagsList.add(tag + ":" + value);
+                }
             }
         }
         String[] defaultTags = super.getTags();

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -990,5 +990,60 @@ public class TestApp extends TestCommon {
 
         assertCoverage();
     }
+    @Test
+    public void testTabularDataTagless() throws Exception {
+        // We expose a few metrics through JMX
+        SimpleTestJavaApp testApp = new SimpleTestJavaApp();
+        registerMBean(testApp, "org.datadog.jmxfetch.test:type=SimpleTestJavaApp");
 
+        // We do a first collection
+        when(appConfig.isTargetDirectInstances()).thenReturn(true);
+        initApplication("jmx_tabular_data_tagless.yaml");
+
+        run();
+        List<Map<String, Object>> metrics = getMetrics();
+
+        // 13 metrics from java.lang + 2 defined - 1 error
+        assertEquals(14, metrics.size());
+
+        List<String> tags = Arrays.asList(
+                "instance:jmx_test_instance",
+                "jmx_domain:org.datadog.jmxfetch.test",
+                "type:SimpleTestJavaApp",
+                "newTag:test"
+        );
+
+        assertMetric("multiattr.foo_tagless", 1.0, tags, -1);
+
+        assertCoverage();
+    }
+    @Test
+    public void testTabularDataTagged() throws Exception {
+        // We expose a few metrics through JMX
+        SimpleTestJavaApp testApp = new SimpleTestJavaApp();
+        registerMBean(testApp, "org.datadog.jmxfetch.test:type=SimpleTestJavaApp");
+
+        // We do a first collection
+        when(appConfig.isTargetDirectInstances()).thenReturn(true);
+        initApplication("jmx_tabular_data_tagged.yaml");
+
+        run();
+        List<Map<String, Object>> metrics = getMetrics();
+
+        // 13 metrics from java.lang + 2 defined - 1 error
+        assertEquals(14, metrics.size());
+
+        List<String> tags = Arrays.asList(
+                "instance:jmx_test_instance",
+                "jmx_domain:org.datadog.jmxfetch.test",
+                "type:SimpleTestJavaApp",
+                "foo:1",
+                "toto:tata",
+                "newTag:test"
+        );
+
+        assertMetric("multiattr.foo_tagged", 1.0, tags, -1);
+
+        assertCoverage();
+    }
 }

--- a/src/test/resources/jmx_tabular_data_tagged.yaml
+++ b/src/test/resources/jmx_tabular_data_tagged.yaml
@@ -1,0 +1,22 @@
+---
+init_config:
+
+instances:
+  - jvm_direct: true
+    refresh_beans: 4
+    name: jmx_test_instance
+    tags:
+      - "env:stage"
+      - "newTag:test"
+    conf:
+      - include:
+          domain: org.datadog.jmxfetch.test
+          attribute:
+            Tabulardata.foo:
+              metric_type: gauge
+              alias: multiattr.foo_tagged
+              tags:
+                foo: $foo
+                toto: $toto
+              limit: 1
+              sort: desc

--- a/src/test/resources/jmx_tabular_data_tagless.yaml
+++ b/src/test/resources/jmx_tabular_data_tagless.yaml
@@ -1,0 +1,19 @@
+---
+init_config:
+
+instances:
+  - jvm_direct: true
+    refresh_beans: 4
+    name: jmx_test_instance
+    tags:
+      - "env:stage"
+      - "newTag:test"
+    conf:
+      - include:
+          domain: org.datadog.jmxfetch.test
+          attribute:
+            Tabulardata.foo:
+              metric_type: gauge
+              alias: multiattr.foo_tagless
+              limit: 1
+              sort: desc


### PR DESCRIPTION
This PR fixes an issue where [TabularData](https://sites.radford.edu/~acm/midatl/docs/jdk11/api/java.management/javax/management/openmbean/TabularData.html) was not correctly returned if the config had no mappings for tags.

i.e. The following config would work:

```yaml
      - include:
          domain: org.datadog.jmxfetch.test
          attribute:
            Tabulardata.foo:
              metric_type: gauge
              alias: multiattr.foo
              tags:
                foo: $foo
                toto: $toto
              limit: 1
              sort: desc
```

But if you remove the tag section (like bellow) it would not return any data back.


```yaml
      - include:
          domain: org.datadog.jmxfetch.test
          attribute:
            Tabulardata.foo:
              metric_type: gauge
              alias: multiattr.foo
              limit: 1
              sort: desc
```