### PR TITLE
Statsd client blocks by default allowing backpressure instead of dropping data

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -231,6 +231,13 @@ public class AppConfig {
     @Builder.Default
     private int ipcPort = 0;
 
+    @Parameter(
+           names = {"--statsd-nonblocking"},
+           description = "Use non-blocking mode when sending metrics via statsd",
+           required = false)
+    @Builder.Default
+    private boolean statsdNonBlocking = false;
+
     /**
      * Boolean setting to determine whether to ignore jvm_direct instances.
      * If set to true, other instances will be ignored.
@@ -461,5 +468,9 @@ public class AppConfig {
 
     public boolean isEmbedded() {
         return embedded;
+    }
+
+    public boolean isStatsdNonBlocking() {
+        return statsdNonBlocking;
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
@@ -27,7 +27,8 @@ public class ReporterFactory {
                         host,
                         port,
                         appConfig.getStatsdTelemetry(),
-                        appConfig.getStatsdQueueSize());
+                        appConfig.getStatsdQueueSize(),
+                        appConfig.isStatsdNonBlocking());
             }
 
             matcher = Pattern.compile("^statsd:unix://(.*)$").matcher(type);
@@ -37,7 +38,8 @@ public class ReporterFactory {
                         socketPath,
                         0,
                         appConfig.getStatsdTelemetry(),
-                        appConfig.getStatsdQueueSize());
+                        appConfig.getStatsdQueueSize(),
+                        appConfig.isStatsdNonBlocking());
             }
         }
         throw new IllegalArgumentException("Invalid reporter type: " + type);

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -18,13 +18,15 @@ public class StatsdReporter extends Reporter {
     private Boolean telemetry;
     private int queueSize;
     private long initializationTime;
+    private boolean nonBlocking;
 
     /** Constructor, instantiates statsd reported to provided host and port. */
-    public StatsdReporter(String statsdHost, int statsdPort, boolean telemetry, int queueSize) {
+    public StatsdReporter(String statsdHost, int statsdPort, boolean telemetry, int queueSize, boolean nonBlocking) {
         this.statsdHost = statsdHost;
         this.statsdPort = statsdPort;
         this.telemetry = telemetry;
         this.queueSize = queueSize;
+        this.nonBlocking = nonBlocking;
         this.init();
     }
 
@@ -46,7 +48,7 @@ public class StatsdReporter extends Reporter {
                 .port(this.statsdPort)
                 .enableTelemetry(this.telemetry)
                 .queueSize(this.queueSize)
-                .blocking(true)
+                .blocking(!nonBlocking)
                 .errorHandler(handler)
                 .entityID(entityId);
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -38,14 +38,15 @@ public class StatsdReporter extends Reporter {
         /* Create the StatsDClient with "entity-id" set to "none" to avoid
            having dogstatsd server adding origin tags, when the connection is
            done with UDS. */
-        log.info("Initializing Statsd reporter with parameters host={} port={} telemetry={} "
-                        + "queueSize={} entityId={}",
+        log.info("Initializing blocking Statsd reporter with parameters host={} port={} "
+                        + "telemetry={} queueSize={} entityId={}",
                 this.statsdHost, this.statsdPort, this.telemetry, this.queueSize, entityId);
         NonBlockingStatsDClientBuilder builder = new NonBlockingStatsDClientBuilder()
                 .hostname(this.statsdHost)
                 .port(this.statsdPort)
                 .enableTelemetry(this.telemetry)
                 .queueSize(this.queueSize)
+                .blocking(true)
                 .errorHandler(handler)
                 .entityID(entityId);
 

--- a/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/StatsdReporter.java
@@ -21,7 +21,9 @@ public class StatsdReporter extends Reporter {
     private boolean nonBlocking;
 
     /** Constructor, instantiates statsd reported to provided host and port. */
-    public StatsdReporter(String statsdHost, int statsdPort, boolean telemetry, int queueSize, boolean nonBlocking) {
+    public StatsdReporter(String statsdHost, int statsdPort, boolean telemetry, int queueSize,
+        boolean nonBlocking
+    ) {
         this.statsdHost = statsdHost;
         this.statsdPort = statsdPort;
         this.telemetry = telemetry;


### PR DESCRIPTION
The default mode for java-dogstatsd-client is to be non-blocking as this is what most java applications want (submitting some telemetry data should not hold up the rest of their application), however for JMXFetch, there is nothing else to be delayed by doing blocking IO.

Blocking IO by default should allow large batches of metrics to block (not drop) if the underlying socket is temporarily full, and since JMXFetch only collects data on a relatively large interval (15s by default), there should be plenty of time for any back-pressure to be drained.

