### PR TITLE
Abort bean refresh if connection error occurs during bean refresh

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -527,6 +527,9 @@ public class Instance {
                     break;
                 }
             }
+            if (!connection.isAlive()) {
+                throw new IOException("Connection to application died during bean refresh");
+            }
             String className;
             MBeanAttributeInfo[] attributeInfos;
             try {
@@ -539,7 +542,7 @@ public class Instance {
             } catch (IOException e) {
                 // we should not continue
                 log.warn("Cannot get bean attributes or class name: " + e.getMessage());
-                if (e.getMessage() == connection.CLOSED_CLIENT_CAUSE) {
+                if (e.getMessage().equals(connection.CLOSED_CLIENT_CAUSE)) {
                     throw e;
                 }
                 continue;


### PR DESCRIPTION
We've identified an issue where a check instance with many beans could get stuck attempting to process all beans when a connection failure occurs.

This change ensures that the connection is alive before continuing to process each bean.

If this condition occurs, the existing logic will properly mark this instance as broken and attempt to recover it later.