### PR TITLE
Adds config options for statsd client socket buffer size and socket timeou

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -131,6 +131,29 @@ public class AppConfig {
     private int statsdQueueSize = DEFAULT_STATSD_QUEUE_SIZE;
 
     @Parameter(
+           names = {"--statsd_nonblocking"},
+           description = "Use non-blocking mode when sending metrics via statsd",
+           required = false)
+    @Builder.Default
+    private boolean statsdNonBlocking = false;
+
+    @Parameter(
+           names = {"--statsd_buffer_size"},
+           description = "Configure the statsd socket buffer size (in bytes)",
+           validateWith = PositiveIntegerValidator.class,
+           required = false)
+    @Builder.Default
+    private int statsdBufferSize = 0;
+
+    @Parameter(
+           names = {"--statsd_socket_timeout"},
+           description = "Configure the statsd socket timeout (in milliseconds)",
+           validateWith = PositiveIntegerValidator.class,
+           required = false)
+    @Builder.Default
+    private int statsdSocketTimeout = 0;
+
+    @Parameter(
             names = {"--check", "-c"},
             description = "Yaml file name to read (must be in the confd directory)",
             required = false,
@@ -230,27 +253,6 @@ public class AppConfig {
             required = false)
     @Builder.Default
     private int ipcPort = 0;
-
-    @Parameter(
-           names = {"--statsd-nonblocking"},
-           description = "Use non-blocking mode when sending metrics via statsd",
-           required = false)
-    @Builder.Default
-    private boolean statsdNonBlocking = false;
-
-    @Parameter(
-           names = {"--statsd-client-buffer-size"},
-           description = "Configure the statsd socket buffer size (in bytes)",
-           required = false)
-    @Builder.Default
-    private int statsdClientBufferSize = 0;
-
-    @Parameter(
-           names = {"--statsd-client-socket-timeout"},
-           description = "Configure the statsd socket timeout (in milliseconds)",
-           required = false)
-    @Builder.Default
-    private int statsdClientSocketTimeout = 0;
 
     /**
      * Boolean setting to determine whether to ignore jvm_direct instances.
@@ -488,11 +490,11 @@ public class AppConfig {
         return statsdNonBlocking;
     }
 
-    public int getStatsdClientBufferSize() {
-        return statsdClientBufferSize;
+    public int getStatsdBufferSize() {
+        return statsdBufferSize;
     }
 
     public int getSocketTimeout() {
-        return statsdClientSocketTimeout;
+        return statsdSocketTimeout;
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -238,6 +238,20 @@ public class AppConfig {
     @Builder.Default
     private boolean statsdNonBlocking = false;
 
+    @Parameter(
+           names = {"--statsd-client-buffer-size"},
+           description = "Configure the statsd socket buffer size (in bytes)",
+           required = false)
+    @Builder.Default
+    private int statsdClientBufferSize = 0;
+
+    @Parameter(
+           names = {"--statsd-client-socket-timeout"},
+           description = "Configure the statsd socket timeout (in milliseconds)",
+           required = false)
+    @Builder.Default
+    private int statsdClientSocketTimeout = 0;
+
     /**
      * Boolean setting to determine whether to ignore jvm_direct instances.
      * If set to true, other instances will be ignored.
@@ -472,5 +486,13 @@ public class AppConfig {
 
     public boolean isStatsdNonBlocking() {
         return statsdNonBlocking;
+    }
+
+    public int getStatsdClientBufferSize() {
+        return statsdClientBufferSize;
+    }
+
+    public int getSocketTimeout() {
+        return statsdClientSocketTimeout;
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
@@ -28,7 +28,9 @@ public class ReporterFactory {
                         port,
                         appConfig.getStatsdTelemetry(),
                         appConfig.getStatsdQueueSize(),
-                        appConfig.isStatsdNonBlocking());
+                        appConfig.isStatsdNonBlocking(),
+                        appConfig.getStatsdClientBufferSize(),
+                        appConfig.getSocketTimeout());
             }
 
             matcher = Pattern.compile("^statsd:unix://(.*)$").matcher(type);
@@ -39,7 +41,9 @@ public class ReporterFactory {
                         0,
                         appConfig.getStatsdTelemetry(),
                         appConfig.getStatsdQueueSize(),
-                        appConfig.isStatsdNonBlocking());
+                        appConfig.isStatsdNonBlocking(),
+                        appConfig.getStatsdClientBufferSize(),
+                        appConfig.getSocketTimeout());
             }
         }
         throw new IllegalArgumentException("Invalid reporter type: " + type);

--- a/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/reporter/ReporterFactory.java
@@ -29,7 +29,7 @@ public class ReporterFactory {
                         appConfig.getStatsdTelemetry(),
                         appConfig.getStatsdQueueSize(),
                         appConfig.isStatsdNonBlocking(),
-                        appConfig.getStatsdClientBufferSize(),
+                        appConfig.getStatsdBufferSize(),
                         appConfig.getSocketTimeout());
             }
 
@@ -42,7 +42,7 @@ public class ReporterFactory {
                         appConfig.getStatsdTelemetry(),
                         appConfig.getStatsdQueueSize(),
                         appConfig.isStatsdNonBlocking(),
-                        appConfig.getStatsdClientBufferSize(),
+                        appConfig.getStatsdBufferSize(),
                         appConfig.getSocketTimeout());
             }
         }


### PR DESCRIPTION
- Adds 2 new cli args to control the `java-dogstatsd-client` used by jmxfetch:
    - `--statsd_buffer_size` takes an integer in bytes to use as the client socket send buffer size
    - `--statsd_socket_timeout` takes an integer in milliseconds to use as the client socket timeout
- Fixes small logging error in the blocking mode of the client. (obsoletes #418)
- Changes `--statsd-non-blocking` -> `--statsd_non_blocking` to be consistent with other cli args
    - Technically this is a backwards incompatible change, but nobody is using the new jmxfetch version yet and definitely not this undocumented option.

There is a bit of extra logic around the `maxPacketSize` to ensure we don't exceed the `socketBufferSize`. 

Importantly, if we create payloads that are **bigger** than the socket send buffer size, we get an exception on send. Eg, when payloadSize was set to 8192 and socket buffer size was 1024, I see:
```
2023-03-31 20:55:16 UTC | JMX | ERROR | LoggingErrorHandler | statsd client error:
java.io.IOException: Message too long
        at jnr.unixsocket.UnixDatagramChannel.send(UnixDatagramChannel.java:176)
        at com.timgroup.statsd.StatsDSender$2.run(StatsDSender.java:103)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```