### PR TITLE
Updates lombok dependency to remove need for tools.jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,13 +137,6 @@
             <version>${jcommander.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.sun</groupId>
-            <artifactId>tools</artifactId>
-            <version>1.4.2</version>
-            <scope>system</scope>
-            <systemPath>${java.home}/../lib/tools.jar</systemPath>
-        </dependency>
-        <dependency>
             <groupId>com.datadoghq</groupId>
             <artifactId>java-dogstatsd-client</artifactId>
             <version>${java-dogstatsd-client.version}</version>
@@ -156,7 +149,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.8</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
I reviewed the [lombok changelog](https://github.com/projectlombok/lombok/blob/master/doc/changelog.markdown) and I don't see anything that should cause issues (tested this locally as well).
The lombok issue that discusses this fix is a bit of a mess, but [here](https://github.com/projectlombok/lombok/issues/2681) it is.

Newer JDKs don't ship with tools.jar from what I understand, this should make it easier to work on this project with a wider variety of java dev environments