### PR TITLE
Better connection failure handling during attribute matching

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Connection.java
+++ b/src/main/java/org/datadog/jmxfetch/Connection.java
@@ -30,7 +30,6 @@ import javax.management.remote.JMXServiceURL;
 @Slf4j
 public class Connection {
     private static final long CONNECTION_TIMEOUT = 10000;
-    public static final String CLOSED_CLIENT_CAUSE = "The client has been closed";
     private JMXConnector connector;
     protected MBeanServerConnection mbs;
     protected Map<String, Object> env;

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -538,8 +538,6 @@ public class Instance {
                 attributeInfos = connection.getAttributesForBean(beanName);
             } catch (IOException e) {
                 // we should not continue
-                log.warn("[IOException] Cannot get bean attributes or class name: {}",
-                    e.getMessage());
                 throw e;
             } catch (Exception e) {
                 log.warn("Cannot get bean attributes or class name: " + e.getMessage());

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -69,7 +69,6 @@ public class Instance {
     public static final String PROCESS_NAME_REGEX = "process_name_regex";
     public static final String JVM_DIRECT = "jvm_direct";
     public static final String ATTRIBUTE = "Attribute: ";
-    private static final int ATTR_MATCH_IO_EXCEPTION_THRESHOLD = 10;
 
     private static final ThreadLocal<Yaml> YAML =
         new ThreadLocal<Yaml>() {
@@ -516,7 +515,6 @@ public class Instance {
         this.matchingAttributes.clear();
         this.failingAttributes.clear();
         int metricsCount = 0;
-        int ioExceptionsSeen = 0;
 
         if (!action.equals(AppConfig.ACTION_COLLECT)) {
             reporter.displayInstanceName(this);
@@ -542,12 +540,7 @@ public class Instance {
                 // we should not continue
                 log.warn("[IOException] Cannot get bean attributes or class name: {}",
                     e.getMessage());
-                if (e.getMessage().equals(Connection.CLOSED_CLIENT_CAUSE)
-                    || ioExceptionsSeen > Instance.ATTR_MATCH_IO_EXCEPTION_THRESHOLD) {
-                    throw e;
-                }
-                ioExceptionsSeen++;
-                continue;
+                throw e;
             } catch (Exception e) {
                 log.warn("Cannot get bean attributes or class name: " + e.getMessage());
                 continue;


### PR DESCRIPTION
In #419 the attribute matching code got some improved connection failure error handling code, however the call to `connection.isAlive` ends up making an RMI call which can be expensive in a tight loop like this.

Instead, we'll consider `IOException`s to be fatal similar to `getMetrics`.


