### PR TITLE
Bean subscription

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/BeanListener.java
+++ b/src/main/java/org/datadog/jmxfetch/BeanListener.java
@@ -1,0 +1,8 @@
+package org.datadog.jmxfetch;
+
+import javax.management.ObjectName;
+
+public interface BeanListener {
+    public void beanRegistered(ObjectName mBeanName);
+    public void beanUnregistered(ObjectName mBeanName);
+}

--- a/src/main/java/org/datadog/jmxfetch/Connection.java
+++ b/src/main/java/org/datadog/jmxfetch/Connection.java
@@ -46,25 +46,6 @@ public class Connection {
     protected Map<String, Object> env;
     protected JMXServiceURL address;
 
-    private static class MyConnectionNotificationListener implements NotificationListener {
-        public void handleNotification(Notification notification, Object handback) {
-            if (!(notification instanceof JMXConnectionNotification)) {
-                return;
-            }
-            if (!(handback instanceof Connection)) {
-                return;
-            }
-
-            JMXConnectionNotification connNotif = (JMXConnectionNotification) notification;
-            Connection conn = (Connection) handback;
-            if (connNotif.getType() == JMXConnectionNotification.CLOSED
-                    || connNotif.getType() == JMXConnectionNotification.FAILED) {
-                //conn.closeConnector();
-            }
-            log.info("Received connection notification: " + connNotif.getType() + " Message: " + connNotif.getMessage());
-        }
-    }
-
     private static class BeanNotificationListener implements NotificationListener {
         private BeanListener bl;
 
@@ -77,7 +58,6 @@ public class Connection {
             }
             MBeanServerNotification mbs = (MBeanServerNotification) notification;
             ObjectName mBeanName = mbs.getMBeanName();
-            // TODO run this beanRegistered/unRegistered in a new thread or threadpool
             if (mbs.getType().equals(MBeanServerNotification.REGISTRATION_NOTIFICATION)) {
                 bl.beanRegistered(mBeanName);
             } else if (mbs.getType().equals(MBeanServerNotification.UNREGISTRATION_NOTIFICATION)) {
@@ -123,9 +103,6 @@ public class Connection {
         log.info("Connecting to: " + this.address);
         connector = JMXConnectorFactory.connect(this.address, this.env);
         mbs = connector.getMBeanServerConnection();
-
-        NotificationListener listener = new MyConnectionNotificationListener();
-        connector.addConnectionNotificationListener(listener, null, this);
     }
 
     /** Gets attribute for matching bean and attribute name. */


### PR DESCRIPTION
Currently there is a periodic refresh of the beans (and their attributes) which can result in CPU spikes as these remote RMI calls are expensive.

This PR aims to implement a "subscription mode" for beans where a `javax.management.NotificationListener` is used to subscribe to bean registration/unregistration events.

This approach should spread out the expensive RMI calls over time and will reduce the total amount of calls needed. Each bean refresh empties out the current set of "known beans" and re-queries the MBeanServer for all matching beans and attributes. This creates an inefficiency when the monitored app does not frequently change the beans as each refresh cycle will repeat the same queries.

Can be enabled per-instance by adding `enable_bean_subscription: true` to the instance config.