### PR TITLE
Adding a Maven profile that is only active when tools.jar is detected

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,23 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>tools-jar-profile</id>
+            <activation>
+                <file>
+                    <exists>${java.home}/../lib/tools.jar</exists>
+                </file>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.sun</groupId>
+                    <artifactId>tools</artifactId>
+                    <version>1.4.2</version>
+                    <scope>system</scope>
+                    <systemPath>${java.home}/../lib/tools.jar</systemPath>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 
     <dependencies>
@@ -135,13 +152,6 @@
             <groupId>com.beust</groupId>
             <artifactId>jcommander</artifactId>
             <version>${jcommander.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.sun</groupId>
-            <artifactId>tools</artifactId>
-            <version>1.4.2</version>
-            <scope>system</scope>
-            <systemPath>${java.home}/../lib/tools.jar</systemPath>
         </dependency>
         <dependency>
             <groupId>com.datadoghq</groupId>


### PR DESCRIPTION
This should make it easier to work with this project using newer JDKs as `tools.jar` was removed in JDK9 and is now shipped  in a different format in the the JDK lib directory.

This has been tested with JDK 8 and JDK 11 on Ubuntu 22.04. 