### PR TITLE
Enabling Docker in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ jobs:
       - image: circleci/openjdk:8-jdk
     steps:
       - checkout
+      - setup_remote_docker
       - run: mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configurationFile=log4j2.travis.properties -Dtests.log_level=info
       - run:
           when: on_fail


### PR DESCRIPTION
This now allows the Testcontainers for Java to run on CI.