### PR TITLE
Updates dummyTrustManager to use more supported security protocol

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/HttpClient.java
+++ b/src/main/java/org/datadog/jmxfetch/HttpClient.java
@@ -26,7 +26,7 @@ public class HttpClient {
     // I found 'TLS' was the appropriate protocol (will use the latest support TLSv? version)
     // rather than specifically 'TLSv1' as the docs recommend
     // https://docs.oracle.com/javase/7/docs/api/javax/net/ssl/SSLContext.html
-    private static final String minRequiredSSLProtocol = "TLS";
+    private static final String sslProtocol = System.getProperty("jmxfetch.min_tls_version", "TLS");
 
     public static class HttpResponse {
         private int responseCode;
@@ -94,10 +94,10 @@ public class HttpClient {
                                         String authType) {}
                             }
                         };
-                sc = SSLContext.getInstance(minRequiredSSLProtocol);
+                sc = SSLContext.getInstance(sslProtocol);
                 sc.init(null, this.dummyTrustManager, new java.security.SecureRandom());
                 HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-                log.info("Successfully installed dummyTrustManager");
+                log.info("Successfully installed dummyTrustManager with {}", sslProtocol);
             } catch (Exception e) {
                 log.error("Error installing dummyTrustManager. Communications with the Agent will "
                         + "be affected. Agent Status will be unreliable and AutoDiscovery of new "

--- a/src/main/java/org/datadog/jmxfetch/HttpClient.java
+++ b/src/main/java/org/datadog/jmxfetch/HttpClient.java
@@ -94,7 +94,8 @@ public class HttpClient {
                 try {
                     sc = SSLContext.getInstance("SSL");
                 } catch (NoSuchAlgorithmException e) {
-                    log.warn("Unable to get the SSLContext 'SSL' algorithm from any of the installed providers. Providers: ");
+                    log.warn("Unable to get the SSLContext 'SSL' algorithm from any of the installed providers. e: ", e);
+                    log.warn("Providers: ");
                     for (Provider prov : Security.getProviders()) {
                         log.warn("{}", prov.toString());
                     }

--- a/src/main/java/org/datadog/jmxfetch/HttpClient.java
+++ b/src/main/java/org/datadog/jmxfetch/HttpClient.java
@@ -92,6 +92,7 @@ public class HttpClient {
                 sc.init(null, this.dummyTrustManager, new java.security.SecureRandom());
                 HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
             } catch (Exception e) {
+                log.info("Exception during dummyTrustManager configuration: ", e);
                 log.debug("session token unavailable - not setting");
                 this.token = "";
             }


### PR DESCRIPTION
Some customers run JMXFetch on a host install where their own JVM is used. These JVMs may restrict the available security algorithms to exclude SSL which would lead to an error similar to this:
```
java.security.NoSuchAlgorithmException: SSL SSLContext not available
   at java.base/sun.security.jca.GetInstance.getInstance(GetInstance.java:159)
   at java.base/javax.net.ssl.SSLContext.getInstance(SSLContext.java:168)
   at org.datadog.jmxfetch.HttpClient.<init>(HttpClient.java:91)
   at org.datadog.jmxfetch.App.<init>(App.java:115)
   at org.datadog.jmxfetch.JmxFetch.main(JmxFetch.java:56)
   at org.datadog.jmxfetch.App.main(App.java:91)
```

This PR changes our `dummyTrustManager` to use `TLS` instead of `SSL` (allowing the JVM to pick the specific version of TLS supported), which should have wider support across JVMs. 

Also adds an `error` log specifying the impact of a missing `dummyTrustManager` to help with future triage.