### PR TITLE
Updates deps and and adds more JDK versions in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,22 @@ jobs:
     docker:
       - image: circleci/openjdk:8-jdk
     <<: *build_steps
+  test_openjdk11:
+    docker:
+      - image: circleci/openjdk:11-jdk
+    <<: *build_steps
+  test_openjdk15:
+    docker:
+      - image: circleci/openjdk:15-jdk
+    <<: *build_steps
+  test_openjdk19:
+    docker:
+      - image: circleci/openjdk:19-jdk
+    <<: *build_steps
+  test_openjdk21:
+    docker:
+      - image: circleci/openjdk:21-jdk
+    <<: *build_steps
 
 workflows:
   version: 2
@@ -27,3 +43,7 @@ workflows:
     jobs:
       - lint_openjdk8
       - test_openjdk8
+      - test_openjdk11
+      - test_openjdk15
+      - test_openjdk19
+      - test_openjdk21

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,15 +26,15 @@ jobs:
     <<: *build_steps
   test_openjdk15:
     docker:
-      - image: circleci/openjdk:15-jdk
+      - image: circleci/openjdk:15-jdk-buster
     <<: *build_steps
-  test_openjdk19:
+  test_openjdk17:
     docker:
-      - image: circleci/openjdk:19-jdk
+      - image: circleci/openjdk:17-jdk-buster
     <<: *build_steps
-  test_openjdk21:
+  test_openjdk18:
     docker:
-      - image: circleci/openjdk:21-jdk
+      - image: circleci/openjdk:18-jdk-buster
     <<: *build_steps
 
 workflows:
@@ -45,5 +45,5 @@ workflows:
       - test_openjdk8
       - test_openjdk11
       - test_openjdk15
-      - test_openjdk19
-      - test_openjdk21
+      - test_openjdk17
+      - test_openjdk18

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,26 @@
 version: 2
+lint_steps: &lint_steps
+  steps:
+    - checkout
+    - run: mvn verify -B -Dhttps.protocols=TLSv1.2 -DskipTests -Dlog4j.configuration=log4j2.travis.properties
+build_steps: &build_steps
+  steps:
+    - checkout
+    - run: mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configurationFile=log4j2.travis.properties -Dtests.log_level=info
+    - run:
+        when: on_fail
+        command: for log in target/surefire-reports/*.txt; do  echo "$log ========================" ; cat $log ; done
+
 jobs:
   lint_openjdk8:
     docker:
       - image: circleci/openjdk:8-jdk
-    steps:
-      - checkout
-      - run: mvn verify -B -Dhttps.protocols=TLSv1.2 -DskipTests -Dlog4j.configuration=log4j2.travis.properties
+    <<: *lint_steps
   test_openjdk8:
     docker:
       - image: circleci/openjdk:8-jdk
-    steps:
-      - checkout
-      - run: mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configurationFile=log4j2.travis.properties -Dtests.log_level=info
-      - run:
-          when: on_fail
-          command: for log in target/surefire-reports/*.txt; do  echo "$log ========================" ; cat $log ; done
+    <<: *build_steps
+
 workflows:
   version: 2
   workflow:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ lint_steps: &lint_steps
 build_steps: &build_steps
   steps:
     - checkout
-    - run: mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configurationFile=log4j2.travis.properties -Dtests.log_level=info
+    - run: mvn test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dlog4j.configurationFile=log4j2.travis.properties -Dtests.log_level=info -Djdk.attach.allowAttachSelf=true
     - run:
         when: on_fail
         command: for log in target/surefire-reports/*.txt; do  echo "$log ========================" ; cat $log ; done
@@ -22,19 +22,19 @@ jobs:
     <<: *build_steps
   test_openjdk11:
     docker:
-      - image: circleci/openjdk:11-jdk
+      - image: cimg/openjdk:11.0
     <<: *build_steps
   test_openjdk15:
     docker:
-      - image: circleci/openjdk:15-jdk-buster
+      - image: cimg/openjdk:15.0
     <<: *build_steps
   test_openjdk17:
     docker:
-      - image: circleci/openjdk:17-jdk-buster
+      - image: cimg/openjdk:17.0
     <<: *build_steps
-  test_openjdk18:
+  test_openjdk19:
     docker:
-      - image: circleci/openjdk:18-jdk-buster
+      - image: cimg/openjdk:19.0
     <<: *build_steps
 
 workflows:
@@ -46,4 +46,4 @@ workflows:
       - test_openjdk11
       - test_openjdk15
       - test_openjdk17
-      - test_openjdk18
+      - test_openjdk19

--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
                 <configuration>
+                    <!-- required for tests in jdk9+ ref https://bugs.openjdk.org/browse/JDK-8180425 -->
                     <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -215,6 +215,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${maven-surefire-plugin.version}</version>
+                <configuration>
+                    <argLine>-Djdk.attach.allowAttachSelf=true</argLine>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
 
         <junit.version>4.13.1</junit.version>
-        <mockito.version>2.2.27</mockito.version>
+        <mockito.version>2.28.2</mockito.version>
 
         <maven-surefire-plugin.version>2.9</maven-surefire-plugin.version>
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
@@ -166,7 +166,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.8</version>
+            <version>1.18.22</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
@@ -67,7 +67,9 @@ public class AttachApiConnection extends Connection {
         try {
             vm.loadAgent(agent);
         } catch (Exception e) {
-            log.warn("Error initializing JMX agent", e);
+            log.warn("Error initializing JMX agent from management-agent.jar, trying 'startLocalManagementAgent' instead", e);
+            // TODO this option doesn't exist in java 7, which we still support. How to call invoke it in a way that is safe for java7?
+            vm.startLocalManagementAgent();
         }
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
@@ -58,6 +58,10 @@ public class AttachApiConnection extends Connection {
                 "No match found. Available JVMs can be listed with the `list_jvms` command.");
     }
 
+    // management-agent.jar has been removed in java 8+
+    // Once JMXFetch drops java7 support, this should be simplified to simply invoke
+    // vm.startLocalManagementAgent
+    // ref https://bugs.openjdk.org/browse/JDK-8179063
     private void loadJmxAgent(com.sun.tools.attach.VirtualMachine vm) throws IOException {
         String agent =
                 vm.getSystemProperties().getProperty("java.home")
@@ -71,7 +75,8 @@ public class AttachApiConnection extends Connection {
             log.warn("Error initializing JMX agent from management-agent.jar", e);
 
             try {
-                Method method = com.sun.tools.attach.VirtualMachine.class.getMethod("startLocalManagementAgent");
+                Method method = com.sun.tools.attach.VirtualMachine
+                    .class.getMethod("startLocalManagementAgent");
                 log.info("Found startLocalManagementAgent API, attempting to use it.");
                 method.invoke(vm);
             } catch (NoSuchMethodException noMethodE) {


### PR DESCRIPTION
Now that #427 has been merged, this PR should take care of the remaining issues preventing tests from running on more modern JDK versions.

Main changes here:
- Updates lombok and mockito to resolve `tools.jar` dependency errors
- Updates how local management agent is started in java 8+
- Adds more JDK versions to test matrix using new circleci convenience images.