### PR TITLE
Corrects package decl in customloggerperftest for better jdk compat

### DIFF
--- a/src/test/java/org/datadog/jmxfetch/util/CustomLoggerPerfTest.java
+++ b/src/test/java/org/datadog/jmxfetch/util/CustomLoggerPerfTest.java
@@ -1,4 +1,4 @@
-package com.timgroup.statsd;
+package org.datadog.jmxfetch.util;
 
 import lombok.extern.slf4j.Slf4j;
 


### PR DESCRIPTION
This was failing for me locally with openjdk 19, looks like an oversight that older mavens/javas were more tolerant of.