### PR TITLE
Skip tests during release process, CI from release PR should be sufficient

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ deploy_to_sonatype:
     - set -x
 
     - echo "Building release..."
-    - mvn -DperformRelease=true -Daether.checksums.algorithms=SHA-512,SHA-256,SHA-1,MD5 --settings ./settings.xml clean deploy
+    - mvn -DperformRelease=true -DskipTests -Daether.checksums.algorithms=SHA-512,SHA-256,SHA-1,MD5 --settings ./settings.xml clean deploy
 
   artifacts:
     expire_in: 12 mos


### PR DESCRIPTION
In #433 we added a dependency on docker to run the tests, however our gitlab runner does not expose a docker socket.

The release job is started manually and should only be started if the CI is green in the release PR, so I think its safe to skip tests during the actual release process.