### PR TITLE
Revert "Skip tests during release process (#443)"

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,7 @@ deploy_to_sonatype:
     - set -x
 
     - echo "Building release..."
-    - mvn -DperformRelease=true -DskipTests -Daether.checksums.algorithms=SHA-512,SHA-256,SHA-1,MD5 --settings ./settings.xml clean deploy
+    - mvn -DperformRelease=true -Daether.checksums.algorithms=SHA-512,SHA-256,SHA-1,MD5 --settings ./settings.xml clean deploy
 
   artifacts:
     expire_in: 12 mos


### PR DESCRIPTION
This reverts commit 1846a0c63abc19b41cdce4afb1148dd5f2426ed5.

We should find a way to enable docker execution so that we don't have to skip tests to release