### PR TITLE
Skips container-based tests when -DskipContainerTests is set

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -44,7 +44,9 @@ deploy_to_sonatype:
     - set -x
 
     - echo "Building release..."
-    - mvn -DperformRelease=true -Daether.checksums.algorithms=SHA-512,SHA-256,SHA-1,MD5 --settings ./settings.xml clean deploy
+    # container-based tests aren't working in our gitlab CI (only circleCI), so we disable them before release.
+    # Hopefully we can get these running in gitlab during the release process as well
+    - mvn -DperformRelease=true -DskipContainerTests -Daether.checksums.algorithms=SHA-512,SHA-256,SHA-1,MD5 --settings ./settings.xml clean deploy
 
   artifacts:
     expire_in: 12 mos

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ mvn test
 
 Some tests utilize [TestContainers](https://www.testcontainers.org/) which requires a docker client.
 You can rely on the CI to run these, or if you have docker installed on Linux these should work out of the box.
+> If you need to skip these tests, **all tests that rely on containers can be disabled by setting the system property `-DskipContainerTests`**
 
 If you're on macOS or Windows, docker desktop is architected to run a linux VM which then runs all your containers.
 This makes the networking a bit different and you should use the following command to run the tests.

--- a/src/test/java/org/datadog/jmxfetch/TestReconnectContainer.java
+++ b/src/test/java/org/datadog/jmxfetch/TestReconnectContainer.java
@@ -1,6 +1,7 @@
 package org.datadog.jmxfetch;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -49,6 +50,7 @@ public class TestReconnectContainer extends TestCommon {
 
     @Before
     public void setup() {
+        assumeTrue("Skip container tests", System.getProperty("skipContainerTests") == null);
         this.controlClient = new JMXServerControlClient(cont.getHost(), cont.getMappedPort(controlPort));
     }
 


### PR DESCRIPTION
In our gitlab environment, the container-based tests are not working yet.

We have great unit test coverage using the process attach API, so we can rely on those for release validation.

These should be run on every PR by circleCI, so while its not ideal to skip this set of tests during release, it will unblock our releases for now.