### PR TITLE
Avoiding app shutdown race condition

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -155,8 +155,13 @@ public class App {
         // set up the config status
         this.appConfig.updateStatus();
 
-        // Adding another shutdown hook for App related tasks
-        Runtime.getRuntime().addShutdownHook(new AppShutdownHook(this));
+        try {
+            // Adding another shutdown hook for App related tasks
+            Runtime.getRuntime().addShutdownHook(new AppShutdownHook(this));
+        } catch (IllegalStateException illegalStateException) {
+            // this exception is thrown if shutdown is already happening when the hook is added
+            return 0;
+        }
 
         // Get config from the ipc endpoint for "list_*" actions
         if (!action.equals(AppConfig.ACTION_COLLECT)) {


### PR DESCRIPTION
When an application received SIGTERM, if the data dog agent has not completely finished it's initialization, adding the shutdown hook results in an exception. Catching the exception and stopping the initialization process should avoid this.

Example stack trace when this happens:

```
java.lang.IllegalStateException: Shutdown in progress
	at java.base/java.lang.ApplicationShutdownHooks.add(Unknown Source)
	at java.base/java.lang.Runtime.addShutdownHook(Unknown Source)
	at org.datadog.jmxfetch.App.run(App.java:154)
	at datadog.trace.agent.jmxfetch.JMXFetch$1.run(JMXFetch.java:131)
	at java.base/java.lang.Thread.run(Unknown Source)
```