### PR TITLE
TestContainer-based tests use container IP instead of port mapping

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,38 @@
 stages:
   - deploy_to_sonatype
   - create_key
+  - run_tests
 
 variables:
   REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com
+  # ryuk is a privileged container started by testcontainers which cleans up containers at the end of testing
+  # It is not necessary if the docker env cleans itself up (which I'm assuming gitlab 'runner:docker' runners do)
+  TESTCONTAINERS_RYUK_DISABLED: "true"
+
+
+# Testing is handled by circleCI for PRs, but we also run maven tests as part of the deploy process
+# This run_tests job is useful for ensuring the tests run fine without any of the deployment bits
+run_tests:
+  stage: run_tests
+
+  rules:
+    - when: manual
+      allow_failure: true
+
+  tags:
+    - "runner:docker"
+
+  image: maven:3.9.1-eclipse-temurin-8
+
+  script:
+    - export TESTCONTAINERS_RYUK_DISABLED=true
+    - mvn -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dtests.log_level=info -Djdk.attach.allowAttachSelf=true -B test
+
+  artifacts:
+    expire_in: 1 mos
+    paths:
+      - ./target/surefire-reports/*.txt
+
 
 # From the tagged repo, push the release artifact
 deploy_to_sonatype:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ stages:
 variables:
   REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com
   # ryuk is a privileged container started by testcontainers which cleans up containers at the end of testing
-  # It is not necessary if the docker env cleans itself up (which I'm assuming gitlab 'runner:docker' runners do)
+  # It is not necessary for our gitlab CI env as #ci-cd infra tears everything down at the end of a gitlab run
   TESTCONTAINERS_RYUK_DISABLED: "true"
 
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,7 @@
 stages:
   - deploy_to_sonatype
   - create_key
-  - run_tests
+  - run_unit_tests
 
 variables:
   REGISTRY: 486234852809.dkr.ecr.us-east-1.amazonaws.com
@@ -11,9 +11,9 @@ variables:
 
 
 # Testing is handled by circleCI for PRs, but we also run maven tests as part of the deploy process
-# This run_tests job is useful for ensuring the tests run fine without any of the deployment bits
-run_tests:
-  stage: run_tests
+# This run_unit_tests job is useful for ensuring the tests run fine without any of the deployment bits
+run_unit_tests:
+  stage: run_unit_tests
 
   rules:
     - when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,6 @@ run_tests:
   image: maven:3.9.1-eclipse-temurin-8
 
   script:
-    - export TESTCONTAINERS_RYUK_DISABLED=true
     - mvn -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dtests.log_level=info -Djdk.attach.allowAttachSelf=true -B test
 
   artifacts:
@@ -73,7 +72,7 @@ deploy_to_sonatype:
     - set -x
 
     - echo "Building release..."
-    - mvn -DperformRelease=true -Daether.checksums.algorithms=SHA-512,SHA-256,SHA-1,MD5 --settings ./settings.xml clean deploy
+    - mvn -Djdk.attach.allowAttachSelf=true -DperformRelease=true -Daether.checksums.algorithms=SHA-512,SHA-256,SHA-1,MD5 --settings ./settings.xml clean deploy
 
   artifacts:
     expire_in: 12 mos

--- a/src/test/java/org/datadog/jmxfetch/JMXServerClient.java
+++ b/src/test/java/org/datadog/jmxfetch/JMXServerClient.java
@@ -1,0 +1,73 @@
+package org.datadog.jmxfetch;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public abstract class JMXServerClient {
+    private final String host;
+    private final int port;
+    JMXServerClient(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    protected void sendPostRequestWithPayload(String endpoint, String jsonPayload) throws IOException {
+        URL url = new URL("http://" + host + ":" + port + endpoint);
+        log.info("Sending POST to {} with payload {}", url, jsonPayload);
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        con.setRequestMethod("POST");
+        con.setRequestProperty("Content-Type", "application/json");
+        con.setDoOutput(true);
+
+        OutputStream os = con.getOutputStream();
+        os.write(jsonPayload.getBytes("UTF-8"));
+        os.flush();
+        os.close();
+
+        int responseCode = con.getResponseCode();
+
+        BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+        if (responseCode == HttpURLConnection.HTTP_OK) {
+            log.info("HTTP Resp: {}", response.toString());
+        } else {
+            log.warn("HTTP POST request failed with status code: {} err: {}", responseCode, response.toString());
+        }
+    }
+
+    protected String sendGetRequest(String endpoint) throws IOException {
+        URL url = new URL("http://" + host + ":" + port + endpoint);
+        log.info("Sending GET to {} ", url);
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        con.setRequestMethod("GET");
+
+        int responseCode = con.getResponseCode();
+
+        if (responseCode == HttpURLConnection.HTTP_OK) {
+            BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+            String inputLine;
+            StringBuffer response = new StringBuffer();
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
+            }
+            in.close();
+            return response.toString();
+        } else {
+            log.warn("HTTP GET request failed with status code: {}", responseCode);
+            return "";
+        }
+    }
+}

--- a/src/test/java/org/datadog/jmxfetch/JMXServerControlClient.java
+++ b/src/test/java/org/datadog/jmxfetch/JMXServerControlClient.java
@@ -4,27 +4,19 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
-import java.net.HttpURLConnection;
-import java.net.URL;
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
 
 @Slf4j
-public class JMXServerControlClient {
-    private final String host;
-    private final int port;
-
+public class JMXServerControlClient extends JMXServerClient{
     public JMXServerControlClient(String host, int port) {
-        this.host = host;
-        this.port = port;
+        super(host, port);
     }
 
     public List<String> getMBeans(String domain) throws IOException {
         String endpoint = "/beans/" + domain;
-        return sendGetRequest(endpoint);
+        String response = sendGetRequest(endpoint);
+        return Arrays.asList(response.toString().split(","));
+
     }
 
     public void createMBeans(String domain, int numDesiredBeans) throws IOException {
@@ -34,85 +26,10 @@ public class JMXServerControlClient {
     }
 
     public void jmxCutNetwork() throws IOException {
-        sendPostRequest("/cutNetwork");
+        sendPostRequestWithPayload("/cutNetwork", "");
     }
 
     public void jmxRestoreNetwork() throws IOException {
-        sendPostRequest("/restoreNetwork");
-    }
-
-    private List<String> sendGetRequest(String endpoint) throws IOException {
-        URL url = new URL("http://" + host + ":" + port + endpoint);
-        log.info("Sending GET to {} ", url);
-        HttpURLConnection con = (HttpURLConnection) url.openConnection();
-        con.setRequestMethod("GET");
-
-        int responseCode = con.getResponseCode();
-
-        if (responseCode == HttpURLConnection.HTTP_OK) {
-            BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
-            String inputLine;
-            StringBuffer response = new StringBuffer();
-            while ((inputLine = in.readLine()) != null) {
-                response.append(inputLine);
-            }
-            in.close();
-            // currently tied to the only GET request made from this client, list the mbeans for a domain
-            return Arrays.asList(response.toString().split(","));
-        } else {
-            log.warn("HTTP GET request failed with status code: {}", responseCode);
-            return Collections.emptyList();
-        }
-    }
-
-    private void sendPostRequestWithPayload(String endpoint, String jsonPayload) throws IOException {
-        URL url = new URL("http://" + host + ":" + port + endpoint);
-        log.info("Sending POST to {} with payload {}", url, jsonPayload);
-        HttpURLConnection con = (HttpURLConnection) url.openConnection();
-        con.setRequestMethod("POST");
-        con.setRequestProperty("Content-Type", "application/json");
-        con.setDoOutput(true);
-
-        OutputStream os = con.getOutputStream();
-        os.write(jsonPayload.getBytes("UTF-8"));
-        os.flush();
-        os.close();
-
-        int responseCode = con.getResponseCode();
-
-        if (responseCode == HttpURLConnection.HTTP_OK) {
-            BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
-            String inputLine;
-            StringBuffer response = new StringBuffer();
-            while ((inputLine = in.readLine()) != null) {
-                response.append(inputLine);
-            }
-            in.close();
-            log.info("HTTP Resp: {}", response.toString());
-        } else {
-            log.warn("HTTP POST request failed with status code: {}", responseCode);
-        }
-    }
-
-    private void sendPostRequest(String endpoint) throws IOException {
-        URL url = new URL("http://" + host + ":" + port + endpoint);
-        log.info("Sending POST to {} ", url);
-        HttpURLConnection con = (HttpURLConnection) url.openConnection();
-        con.setRequestMethod("POST");
-
-        int responseCode = con.getResponseCode();
-
-        if (responseCode == HttpURLConnection.HTTP_OK) {
-            BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
-            String inputLine;
-            StringBuffer response = new StringBuffer();
-            while ((inputLine = in.readLine()) != null) {
-                response.append(inputLine);
-            }
-            in.close();
-            log.info("HTTP Resp: {}", response.toString());
-        } else {
-            log.warn("HTTP POST request failed with status code: {}", responseCode);
-        }
+        sendPostRequestWithPayload("/restoreNetwork", "");
     }
 }

--- a/src/test/java/org/datadog/jmxfetch/JMXServerSupervisorClient.java
+++ b/src/test/java/org/datadog/jmxfetch/JMXServerSupervisorClient.java
@@ -1,0 +1,81 @@
+package org.datadog.jmxfetch;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class JMXServerSupervisorClient {
+    private final String host;
+    private final int port;
+
+    public JMXServerSupervisorClient(String host, int port) {
+        this.host = host;
+        this.port = port;
+    }
+
+    public void setRmiHostname(String rmiHostname) throws IOException {
+        sendPostRequestWithFormParams("/config", Collections.singletonMap("rmiHostname", rmiHostname));
+    }
+
+    private void sendPostRequestWithFormParams(String endpoint, Map<String, String> formParams) throws IOException {
+        URL url = new URL("http://" + host + ":" + port + endpoint);
+        log.info("Sending POST to {} ", url);
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        con.setRequestMethod("POST");
+
+        // Enable output and input streams for the connection
+        con.setDoOutput(true);
+        con.setDoInput(true);
+
+
+        // Create the form parameter string
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<String, String> entry : formParams.entrySet()) {
+            if (sb.length() > 0) {
+                sb.append("&");
+            }
+            sb.append(entry.getKey()).append("=").append(entry.getValue());
+        }
+        String formParamsString = sb.toString();
+
+        // Set the content type to form-urlencoded
+        con.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+
+        // Convert the form parameters to bytes
+        byte[] postData = formParamsString.getBytes(StandardCharsets.UTF_8);
+
+        // Set the content length of the request
+        con.setRequestProperty("Content-Length", String.valueOf(postData.length));
+
+        // Write the form parameters to the output stream
+        try (DataOutputStream outputStream = new DataOutputStream(con.getOutputStream())) {
+            outputStream.write(postData);
+            outputStream.flush();
+        }
+
+
+        int responseCode = con.getResponseCode();
+
+        if (responseCode == HttpURLConnection.HTTP_OK) {
+            BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+            String inputLine;
+            StringBuffer response = new StringBuffer();
+            while ((inputLine = in.readLine()) != null) {
+                response.append(inputLine);
+            }
+            in.close();
+            log.info("HTTP Resp: {}", response.toString());
+        } else {
+            log.warn("HTTP POST request failed with status code: {}", responseCode);
+        }
+    }
+}

--- a/src/test/java/org/datadog/jmxfetch/JMXServerSupervisorClient.java
+++ b/src/test/java/org/datadog/jmxfetch/JMXServerSupervisorClient.java
@@ -1,14 +1,11 @@
 package org.datadog.jmxfetch;
 
 import java.io.BufferedReader;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.OutputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -22,60 +19,39 @@ public class JMXServerSupervisorClient {
         this.port = port;
     }
 
-    public void setRmiHostname(String rmiHostname) throws IOException {
-        sendPostRequestWithFormParams("/config", Collections.singletonMap("rmiHostname", rmiHostname));
+    public void initializeJMXServer(String rmiHostname) throws IOException {
+        String endpoint = "/init";
+        String jsonPayload = "{\"rmiHostname\": \""  + rmiHostname + "\"}";
+        sendPostRequestWithPayload(endpoint, jsonPayload);
     }
 
-    private void sendPostRequestWithFormParams(String endpoint, Map<String, String> formParams) throws IOException {
+    private void sendPostRequestWithPayload(String endpoint, String jsonPayload) throws IOException {
         URL url = new URL("http://" + host + ":" + port + endpoint);
-        log.info("Sending POST to {} ", url);
+        log.info("Sending POST to {} with payload {}", url, jsonPayload);
         HttpURLConnection con = (HttpURLConnection) url.openConnection();
         con.setRequestMethod("POST");
-
-        // Enable output and input streams for the connection
+        con.setRequestProperty("Content-Type", "application/json");
         con.setDoOutput(true);
-        con.setDoInput(true);
 
-
-        // Create the form parameter string
-        StringBuilder sb = new StringBuilder();
-        for (Map.Entry<String, String> entry : formParams.entrySet()) {
-            if (sb.length() > 0) {
-                sb.append("&");
-            }
-            sb.append(entry.getKey()).append("=").append(entry.getValue());
-        }
-        String formParamsString = sb.toString();
-
-        // Set the content type to form-urlencoded
-        con.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
-
-        // Convert the form parameters to bytes
-        byte[] postData = formParamsString.getBytes(StandardCharsets.UTF_8);
-
-        // Set the content length of the request
-        con.setRequestProperty("Content-Length", String.valueOf(postData.length));
-
-        // Write the form parameters to the output stream
-        try (DataOutputStream outputStream = new DataOutputStream(con.getOutputStream())) {
-            outputStream.write(postData);
-            outputStream.flush();
-        }
-
+        OutputStream os = con.getOutputStream();
+        os.write(jsonPayload.getBytes("UTF-8"));
+        os.flush();
+        os.close();
 
         int responseCode = con.getResponseCode();
 
+        BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer response = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
         if (responseCode == HttpURLConnection.HTTP_OK) {
-            BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
-            String inputLine;
-            StringBuffer response = new StringBuffer();
-            while ((inputLine = in.readLine()) != null) {
-                response.append(inputLine);
-            }
-            in.close();
             log.info("HTTP Resp: {}", response.toString());
         } else {
-            log.warn("HTTP POST request failed with status code: {}", responseCode);
+            log.warn("HTTP POST request failed with status code: {} err: {}", responseCode, response.toString());
         }
     }
+
 }

--- a/src/test/java/org/datadog/jmxfetch/JMXServerSupervisorClient.java
+++ b/src/test/java/org/datadog/jmxfetch/JMXServerSupervisorClient.java
@@ -1,22 +1,10 @@
 package org.datadog.jmxfetch;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.OutputStream;
-import java.net.HttpURLConnection;
-import java.net.URL;
 
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
-public class JMXServerSupervisorClient {
-    private final String host;
-    private final int port;
-
+public class JMXServerSupervisorClient extends JMXServerClient {
     public JMXServerSupervisorClient(String host, int port) {
-        this.host = host;
-        this.port = port;
+        super(host, port);
     }
 
     public void initializeJMXServer(String rmiHostname) throws IOException {
@@ -24,34 +12,4 @@ public class JMXServerSupervisorClient {
         String jsonPayload = "{\"rmiHostname\": \""  + rmiHostname + "\"}";
         sendPostRequestWithPayload(endpoint, jsonPayload);
     }
-
-    private void sendPostRequestWithPayload(String endpoint, String jsonPayload) throws IOException {
-        URL url = new URL("http://" + host + ":" + port + endpoint);
-        log.info("Sending POST to {} with payload {}", url, jsonPayload);
-        HttpURLConnection con = (HttpURLConnection) url.openConnection();
-        con.setRequestMethod("POST");
-        con.setRequestProperty("Content-Type", "application/json");
-        con.setDoOutput(true);
-
-        OutputStream os = con.getOutputStream();
-        os.write(jsonPayload.getBytes("UTF-8"));
-        os.flush();
-        os.close();
-
-        int responseCode = con.getResponseCode();
-
-        BufferedReader in = new BufferedReader(new InputStreamReader(con.getInputStream()));
-        String inputLine;
-        StringBuffer response = new StringBuffer();
-        while ((inputLine = in.readLine()) != null) {
-            response.append(inputLine);
-        }
-        in.close();
-        if (responseCode == HttpURLConnection.HTTP_OK) {
-            log.info("HTTP Resp: {}", response.toString());
-        } else {
-            log.warn("HTTP POST request failed with status code: {} err: {}", responseCode, response.toString());
-        }
-    }
-
 }

--- a/tools/misbehaving-jmx-server/Dockerfile
+++ b/tools/misbehaving-jmx-server/Dockerfile
@@ -23,5 +23,5 @@ WORKDIR /app
 # Copy the JAR file from the Maven image to the final image
 COPY  --from=build /app/target/misbehavingjmxserver-1.0-SNAPSHOT-jar-with-dependencies.jar .
 
-# Set the command to run the JAR file
-CMD ["java", "-jar", "misbehavingjmxserver-1.0-SNAPSHOT-jar-with-dependencies.jar"]
+# Run the supervisor class from the jar
+CMD ["java", "-cp", "misbehavingjmxserver-1.0-SNAPSHOT-jar-with-dependencies.jar", "org.datadog.supervisor.App"]

--- a/tools/misbehaving-jmx-server/README.md
+++ b/tools/misbehaving-jmx-server/README.md
@@ -7,8 +7,8 @@ to intentionally cause connection issues.
 
 ## Implementation
 - `org.datadog.misbehavingjmxserver.App` is a JMX server exposing custom mbeans
-as well as an HTTP control interface to allow injection of network errors. Main class for the jar
-- `org.datadog.supervisor.App` is the entrypoint for the JAR and its job is to wait for
+as well as an HTTP control interface to allow injection of network errors. Entrypoint class for the jar.
+- `org.datadog.supervisor.App` is a secondary class (non-entrypoint) for the JAR and its job is to wait for
 a secondary `init` payload that contains the correct RMI Hostname. It is designed for use in a container where you may not know the hostname before starting the container.
 
 ## Build

--- a/tools/misbehaving-jmx-server/pom.xml
+++ b/tools/misbehaving-jmx-server/pom.xml
@@ -87,7 +87,7 @@
           <configuration>
             <archive>
               <manifest>
-                <mainClass>org.datadog.supervisor.App</mainClass>
+                <mainClass>org.datadog.misbehavingjmxserver.App</mainClass>
               </manifest>
             </archive>
             <descriptorRefs>

--- a/tools/misbehaving-jmx-server/pom.xml
+++ b/tools/misbehaving-jmx-server/pom.xml
@@ -87,7 +87,7 @@
           <configuration>
             <archive>
               <manifest>
-                <mainClass>org.datadog.misbehavingjmxserver.App</mainClass>
+                <mainClass>org.datadog.supervisor.App</mainClass>
               </manifest>
             </archive>
             <descriptorRefs>

--- a/tools/misbehaving-jmx-server/src/main/java/org/datadog/Defaults.java
+++ b/tools/misbehaving-jmx-server/src/main/java/org/datadog/Defaults.java
@@ -1,0 +1,7 @@
+package org.datadog;
+
+public class Defaults {
+    public static final int JMXSERVER_CONTROL_PORT = 8080;
+    public static final int JMXSERVER_RMI_PORT = 1099;
+    public static final String JMXSERVER_RMI_INTERFACE = "localhost";
+}

--- a/tools/misbehaving-jmx-server/src/main/java/org/datadog/misbehavingjmxserver/App.java
+++ b/tools/misbehaving-jmx-server/src/main/java/org/datadog/misbehavingjmxserver/App.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
 import javax.management.InstanceAlreadyExistsException;
@@ -28,16 +29,18 @@ import com.beust.jcommander.Parameter;
 import io.javalin.*;
 import lombok.extern.slf4j.Slf4j;
 
+import org.datadog.Defaults;
+
 class AppConfig {
     // RMI Port is used for both registry and the JMX service
     @Parameter(names = {"--rmi-port", "-rp"})
-    public int rmiPort = 1099;
+    public int rmiPort = Defaults.JMXSERVER_RMI_PORT;
 
     @Parameter(names = {"--rmi-host", "-rh"})
-    public String rmiHost = "localhost";
+    public String rmiHost = Defaults.JMXSERVER_RMI_INTERFACE;
 
-    @Parameter(names = {"--control-port", "-cp"})
-    public int controlPort = 8080;
+    // Can only be set via env var
+    public int controlPort = Defaults.JMXSERVER_CONTROL_PORT;
 
     public void overrideFromEnv() {
         String val;
@@ -61,8 +64,9 @@ class BeanSpec {
 }
 
 @Slf4j
-public class App 
+public class App
 {
+    private static boolean started = false;
     final static String testDomain = "Bohnanza";
     public static void main( String[] args ) throws IOException, MalformedObjectNameException, InstanceAlreadyExistsException, MBeanRegistrationException, NotCompliantMBeanException
     {
@@ -99,6 +103,14 @@ public class App
         mbs.registerMBean(mbean, mbeanName);
 
         Javalin controlServer = Javalin.create();
+
+        controlServer.get("/ready", ctx -> {
+            if (started) {
+                ctx.status(200);
+            } else {
+                ctx.status(500);
+            }
+        });
 
         controlServer.post("/cutNetwork", ctx -> {
             customRMISocketFactory.setClosed(true);
@@ -150,7 +162,7 @@ public class App
         JMXConnectorServer connector = JMXConnectorServerFactory.newJMXConnectorServer(url, env, mbs);
 
         connector.start();
-        log.info("IAMREADY");
+        started = true;
         try {
             Thread.currentThread().join();
         } catch (InterruptedException e) {

--- a/tools/misbehaving-jmx-server/src/main/java/org/datadog/supervisor/App.java
+++ b/tools/misbehaving-jmx-server/src/main/java/org/datadog/supervisor/App.java
@@ -1,0 +1,165 @@
+package org.datadog.supervisor;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.ConnectException;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.datadog.Defaults;
+
+import lombok.extern.slf4j.Slf4j;
+
+import io.javalin.*;
+
+class AppConfig {
+    public int controlHttpPort;
+    public String rmiHostname;
+
+    public AppConfig() {
+        String controlHttpPortStr = System.getenv("SUPERVISOR_PORT");
+        this.rmiHostname = null;
+        if (controlHttpPortStr != null) {
+            this.controlHttpPort = Integer.parseInt(controlHttpPortStr);
+        } else {
+            this.controlHttpPort = 8088;
+        }
+    }
+}
+
+@Slf4j
+public class App {
+    private static Process process = null;
+    // marked when OS process is started
+    private static AtomicBoolean running = new AtomicBoolean(false);
+    // marked when the JMX server indicates that its ready
+    private static AtomicBoolean started = new AtomicBoolean(false);
+    private static final String jmxServerEntrypoint = "org.datadog.misbehavingjmxserver.App";
+    private static String selfJarPath;
+    private static AppConfig config;
+
+    public static void main(String[] args) throws IOException {
+        App.config = new AppConfig();
+
+        try {
+            selfJarPath = new File(App.class.getProtectionDomain().getCodeSource().getLocation().toURI().getPath())
+                    .getAbsolutePath();
+        } catch (Exception e) {
+            log.warn("Could not get self jar path");
+            e.printStackTrace();
+            System.exit(1);
+        }
+
+        Javalin app = Javalin.create();
+
+        app.post("/config/", ctx -> {
+            if (ctx.formParam("rmiHostname") != null) {
+                App.config.rmiHostname = ctx.formParam("rmiHostname");
+                log.info("Setting RMI Hostname to {}. Restarting now...", App.config.rmiHostname);
+                stopJMXServer();
+                try {
+                    startJMXServer();
+                    ctx.result("Process restarted").status(200);
+                } catch (Exception e) {
+                    ctx.result("Error restarting process: " + e.getMessage()).status(500);
+                }
+            }
+        });
+        app.get("/ready", ctx -> {
+            if (started.get()) {
+                ctx.status(200);
+            } else {
+                ctx.status(500);
+            }
+        });
+
+        log.info("Supervisor HTTP control interface at :{}", App.config.controlHttpPort);
+        app.start(App.config.controlHttpPort);
+
+        log.info("Starting JMX subprocess");
+        startJMXServer();
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            if (running.get()) {
+                log.info("Stopping the sub-process....");
+                try {
+                    stopJMXServer();
+                } catch (IOException | InterruptedException e) {
+                    log.error("Encountered error while shutting down JMX server: ", e);
+                }
+            }
+        }));
+    }
+
+    static void stopJMXServer() throws IOException, InterruptedException {
+        // Restart the process
+        if (process != null) {
+            process.destroyForcibly().waitFor();
+            running.set(false);
+            started.set(false);
+        }
+    }
+
+    static void startJMXServer() throws IOException {
+        ProcessBuilder pb;
+        if (App.config.rmiHostname != null) {
+            pb = new ProcessBuilder("java",
+                    "-cp",
+                    selfJarPath,
+                    jmxServerEntrypoint,
+                    "--rmi-host",
+                    App.config.rmiHostname);
+        } else {
+            pb = new ProcessBuilder("java",
+                    "-cp",
+                    selfJarPath,
+                    jmxServerEntrypoint);
+        }
+        pb.inheritIO();
+        process = pb.start();
+        running.set(true);
+
+        try {
+            checkForJMXServerReady();
+        } catch (IOException | InterruptedException e) {
+            log.error("Error while waiting for JMX server to be ready: ", e);
+        }
+    }
+
+    private static int getJMXServerControlPort() {
+        String env = System.getenv("CONTROL_PORT");
+        if (env == null) {
+            return Defaults.JMXSERVER_CONTROL_PORT;
+        }
+        return Integer.parseInt(env);
+    }
+
+    private static void checkForJMXServerReady() throws MalformedURLException, IOException, InterruptedException {
+        int delayBetweenAttemptsInMs = 100;
+        int timeoutInMs = 2000;
+        int elapsedMs = 0;
+        URL endpointUrl = new URL("http://localhost:" + getJMXServerControlPort() + "/ready");
+        while (!started.get() && elapsedMs < timeoutInMs) {
+            HttpURLConnection connection = (HttpURLConnection) endpointUrl.openConnection();
+            try {
+                int responseCode = connection.getResponseCode();
+                log.info("JMXServer returned code {}", responseCode);
+                connection.disconnect();
+
+                if (responseCode == HttpURLConnection.HTTP_OK) {
+                    log.info("JMX server has started");
+                    started.set(true);
+                }
+            } catch (ConnectException e) {
+                // ignore
+            }
+            Thread.sleep(delayBetweenAttemptsInMs);
+            elapsedMs += delayBetweenAttemptsInMs;
+        }
+    }
+}


### PR DESCRIPTION
## What is changing:
1. When TestContainers unit tests start the `misbehaving-jmx-server`, they now communicate directly via the container's IP address instead of utilizing a mapped port on the docker-host.
2. The `misbehaving-jmx-server` jar now has 2 entrypoints, one is the existing misbehaving jmx server, and the second is a supervisor process which is responsible for starting the jmx server with the correct RMI hostname.
    - This introduces a 2-phase startup for the `misbehaving-jmx-server` as the JMX server _must_ have the correct RMI hostname set in order for the TestContainer client to connect successfully. That is the container's IP address, which can't be known until the container starts.
    - If you have a better idea for addressing the container to make this a one-stage startup, please point it out! This is the best I was able to think up.

## Why is this changing?
Short answer: for compatibility with gitlab CI environment.
Longer answer: In our gitlab environment, there are iptable rules preventing a container from communicating with the docker-host on anything except for the docker daemon port. The recommended TestContainers approach here is to communicate to spawned containers via the docker-host (ie, gateway of the bridge network) to support cases where the docker containers are spawned in a remote network that you don't have access to. In our case, we don't need to support that scenario as we actually require direct connectivity to support RMI, so this simplifies things a bit and adds support for more environments to run in.

## Diagram please?
Of course! 
![image](https://github.com/DataDog/jmxfetch/assets/996472/3350de79-24d1-4aa7-96c7-af500d2047cf)

