### PR TITLE
Splits up flakey test running each instance separately to avoid a jvm threading bug

### DIFF
--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -62,14 +62,35 @@ public class TestInstance extends TestCommon {
         run();
 
         List<Map<String, Object>> metrics = getMetrics();
-        assertEquals(28, metrics.size());
+        assertEquals(14, metrics.size());
         for (Map<String, Object> metric : metrics) {
             String[] tags = (String[]) metric.get("tags");
             this.assertHostnameTags(Arrays.asList(tags));
         }
 
         List<Map<String, Object>> serviceChecks = getServiceChecks();
-        assertEquals(4, serviceChecks.size());
+        assertEquals(2, serviceChecks.size());
+        for (Map<String, Object> sc : serviceChecks) {
+            String[] tags = (String[]) sc.get("tags");
+            this.assertHostnameTags(Arrays.asList(tags));
+        }
+    }
+
+    @Test
+    public void testBaselineDefaultHostname() throws Exception {
+        registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:foo=Bar,qux=Baz");
+        initApplication("jmx_baseline_default_hostname.yaml");
+        run();
+
+        List<Map<String, Object>> metrics = getMetrics();
+        assertEquals(14, metrics.size());
+        for (Map<String, Object> metric : metrics) {
+            String[] tags = (String[]) metric.get("tags");
+            this.assertHostnameTags(Arrays.asList(tags));
+        }
+
+        List<Map<String, Object>> serviceChecks = getServiceChecks();
+        assertEquals(2, serviceChecks.size());
         for (Map<String, Object> sc : serviceChecks) {
             String[] tags = (String[]) sc.get("tags");
             this.assertHostnameTags(Arrays.asList(tags));

--- a/src/test/resources/jmx_baseline_default_hostname.yaml
+++ b/src/test/resources/jmx_baseline_default_hostname.yaml
@@ -2,8 +2,7 @@ init_config:
 
 instances:
   -   process_name_regex: .*surefire.*
-      empty_default_hostname: true
-      name: jmx_test_no_hostname
+      name: jmx_test_default_hostname
       tags:
         - jmx:fetch
       conf:


### PR DESCRIPTION
Fix for #440 , details are there.