### PR TITLE
Adds jdk20 to our CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,10 @@ jobs:
     docker:
       - image: cimg/openjdk:19.0
     <<: *build_steps
+  test_openjdk20:
+    docker:
+      - image: cimg/openjdk:20.0
+    <<: *build_steps
 
 workflows:
   version: 2
@@ -48,3 +52,4 @@ workflows:
       - test_openjdk15
       - test_openjdk17
       - test_openjdk19
+      - test_openjdk20


### PR DESCRIPTION
This currently fails in two ways.

1) `java.version` in `pom.xml` cannot be 7 as openjdk20 has dropped support for compiling java 7
2) New beans with type `java.lang` have been added which causes a majority of our unit tests to fail. For reasons unknown to me, we currently manually take into account how many "default" java beans there are and add that to the expected number of metrics collected from our test runs. [example](https://github.com/DataDog/jmxfetch/blob/master/src/test/java/org/datadog/jmxfetch/TestApp.java#L232-L234).

Fixing (1) will require us to either officially drop java 7 support or get creative with maven profiles (cc @carlosroman who knows these things).
Fixing (2) can be done by setting the instance option [`collect_default_jvm_metrics`](https://github.com/DataDog/jmxfetch/blob/ae35f9f2f3bb038585a18e243fc103be5a50b6a3/src/main/java/org/datadog/jmxfetch/Instance.java#L253-L260) to false and fixing the expected number of matching metrics in each test case.