### PR TITLE
Update management agent logic and comments for java 7 vs 8 vs 9

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/AttachApiConnection.java
@@ -65,7 +65,8 @@ public class AttachApiConnection extends Connection {
     // ref https://bugs.openjdk.org/browse/JDK-8179063
     private void loadJmxAgent(com.sun.tools.attach.VirtualMachine vm) throws IOException {
         try {
-            Method method = com.sun.tools.attach.VirtualMachine.class.getMethod("startLocalManagementAgent");
+            Method method = com.sun.tools.attach.VirtualMachine
+                .class.getMethod("startLocalManagementAgent");
             log.info("Found startLocalManagementAgent API, attempting to use it.");
             method.invoke(vm);
         } catch (NoSuchMethodException noMethodE) {

--- a/src/main/java/org/datadog/jmxfetch/ConnectionFactory.java
+++ b/src/main/java/org/datadog/jmxfetch/ConnectionFactory.java
@@ -24,7 +24,8 @@ public class ConnectionFactory {
 
         if (connectionParams.get(PROCESS_NAME_REGEX) != null) {
             try {
-                // AttachNotSupportedException is accessible in java 7 and 8 through tools.jar and java 9+ by default
+                // AttachNotSupportedException is accessible in java 7 and 8 through tools.jar 
+                // and java 9+ by default
                 Class.forName("com.sun.tools.attach.AttachNotSupportedException");
             } catch (ClassNotFoundException e) {
                 throw new IOException(


### PR DESCRIPTION
This pr updates some minor logic and comments regarding the state of the localManagementAgent across java versions and its role in attaching to a local running java process. The goal is to have a better understanding of how we can use process_regex to configure a jmxfetch check that attaches to itself.