### PR TITLE
remove quotes from bean parameter based tags (#456)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ target/*
 .idea
 .vscode
 *.iml
-
 *.ucls
 
 *.png

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ Changelog
 =========
 # Next / TBD
 
+* [FEATURE] Added an option to enable removal of extra quotation marks during tag extraction from Java management beans' parameters/attributes [#469][]
+
 # 0.47.10 / 2023-08-10
 
 * [IMPROVEMENT] Improvements in how JMXFetch handles communicating back to the Agent. The TLS of the HTTP client used can now be configured, extra logging has been added around the SSL Context, and 'TLS' as min protocol version used in the `dummyTrustManager` (configurable using the flag `jmxfetch.min_tls_version`, e.g. `-Djmxfetch.min_tls_version=TLS`) [#436][] 
@@ -748,6 +750,7 @@ Changelog
 [#437]: https://github.com/DataDog/jmxfetch/issues/437
 [#457]: https://github.com/DataDog/jmxfetch/issues/457
 [#449]: https://github.com/DataDog/jmxfetch/issues/449
+[#469]: https://github.com/DataDog/jmxfetch/pull/469
 [@alz]: https://github.com/alz
 [@aoking]: https://github.com/aoking
 [@arrawatia]: https://github.com/arrawatia

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -103,6 +103,7 @@ public class Instance {
     private AppConfig appConfig;
     private Boolean cassandraAliasing;
     private boolean emptyDefaultHostname;
+    private Boolean normalizeBeanParamTags;
 
     /** Constructor, instantiates Instance based of a previous instance and appConfig. */
     public Instance(Instance instance, AppConfig appConfig) {
@@ -210,6 +211,12 @@ public class Instance {
         if (initConfig != null) {
             this.serviceCheckPrefix = (String) initConfig.get("service_check_prefix");
         }
+
+        this.normalizeBeanParamTags = (Boolean) instanceMap.get("normalize_bean_param_tags");
+        if (this.normalizeBeanParamTags == null) {
+            this.normalizeBeanParamTags = false;
+        }
+
 
         // Alternative aliasing for CASSANDRA-4009 metrics
         // More information: https://issues.apache.org/jira/browse/CASSANDRA-4009
@@ -578,7 +585,8 @@ public class Instance {
                                 serviceNameProvider,
                                 tags,
                                 cassandraAliasing,
-                                emptyDefaultHostname);
+                                emptyDefaultHostname,
+                                normalizeBeanParamTags);
                 } else if (COMPOSED_TYPES.contains(attributeType)) {
                     log.debug(
                             ATTRIBUTE
@@ -596,7 +604,8 @@ public class Instance {
                                 connection,
                                 serviceNameProvider,
                                 tags,
-                                emptyDefaultHostname);
+                                emptyDefaultHostname,
+                                normalizeBeanParamTags);
                 } else if (MULTI_TYPES.contains(attributeType)) {
                     log.debug(
                             ATTRIBUTE
@@ -614,7 +623,8 @@ public class Instance {
                                 connection,
                                 serviceNameProvider,
                                 tags,
-                                emptyDefaultHostname);
+                                emptyDefaultHostname,
+                                normalizeBeanParamTags);
                 } else {
                     try {
                         log.debug(

--- a/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxAttribute.java
@@ -62,6 +62,7 @@ public abstract class JmxAttribute {
     private List<String> defaultTagsList;
     private boolean cassandraAliasing;
     protected String checkName;
+    private boolean normalizeBeanParamTags;
 
     JmxAttribute(
             MBeanAttributeInfo attribute,
@@ -73,7 +74,8 @@ public abstract class JmxAttribute {
             ServiceNameProvider serviceNameProvider,
             Map<String, String> instanceTags,
             boolean cassandraAliasing,
-            boolean emptyDefaultHostname) {
+            boolean emptyDefaultHostname,
+            boolean normalizeBeanParamTags) {
         this.attribute = attribute;
         this.beanName = beanName;
         this.className = className;
@@ -84,6 +86,7 @@ public abstract class JmxAttribute {
         this.cassandraAliasing = cassandraAliasing;
         this.checkName = checkName;
         this.serviceNameProvider = serviceNameProvider;
+        this.normalizeBeanParamTags = normalizeBeanParamTags;
 
         // A bean name is formatted like that:
         // org.apache.cassandra.db:type=Caches,keyspace=system,cache=HintsColumnFamilyKeyCache
@@ -192,14 +195,33 @@ public abstract class JmxAttribute {
     }
 
     /**
+     * Wrapper for javax.management.ObjectName.unqoute that removes quotes from the bean parameter
+     * value if possible. If not, it hits the catch block and returns the original parameter.
+     */
+    private String unquote(String beanParameter) {
+        int valueIndex = beanParameter.indexOf(':') + 1;
+        try {
+            return beanParameter.substring(0,valueIndex)
+                    + ObjectName.unquote(beanParameter.substring(valueIndex));
+        } catch (IllegalArgumentException e) {
+            return beanParameter;
+        }
+    }
+
+    /**
      * Sanitize MBean parameter names and values, i.e. - Rename parameter names conflicting with
      * existing tags - Remove illegal characters
      */
-    private static List<String> sanitizeParameters(List<String> beanParametersList) {
+    private List<String> sanitizeParameters(List<String> beanParametersList) {
         List<String> defaultTagsList = new ArrayList<String>(beanParametersList.size());
         for (String rawBeanParameter : beanParametersList) {
             // Remove `|` characters
             String beanParameter = rawBeanParameter.replace("|", "");
+
+            // Unquote bean parameters that have been quoted and escaped by ObjectName.quote()
+            if (normalizeBeanParamTags == true) {
+                beanParameter = unquote(beanParameter);
+            }
 
             // 'host' parameter is renamed to 'bean_host'
             if (beanParameter.startsWith("host:")) {

--- a/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
@@ -30,7 +30,8 @@ public class JmxComplexAttribute extends JmxSubAttribute {
             Connection connection,
             ServiceNameProvider serviceNameProvider,
             Map<String, String> instanceTags,
-            boolean emptyDefaultHostname) {
+            boolean emptyDefaultHostname,
+            boolean normalizeBeanParamTags) {
         super(
                 attribute,
                 beanName,
@@ -41,7 +42,8 @@ public class JmxComplexAttribute extends JmxSubAttribute {
                 serviceNameProvider,
                 instanceTags,
                 false,
-                emptyDefaultHostname);
+                emptyDefaultHostname,
+                normalizeBeanParamTags);
     }
 
     private void populateSubAttributeList(Object attributeValue) {

--- a/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
@@ -28,7 +28,8 @@ public class JmxSimpleAttribute extends JmxAttribute {
             ServiceNameProvider serviceNameProvider,
             Map<String, String> instanceTags,
             boolean cassandraAliasing,
-            Boolean emptyDefaultHostname) {
+            Boolean emptyDefaultHostname,
+            Boolean normalizeBeanParamTags) {
         super(
                 attribute,
                 beanName,
@@ -39,7 +40,8 @@ public class JmxSimpleAttribute extends JmxAttribute {
                 serviceNameProvider,
                 instanceTags,
                 cassandraAliasing,
-                emptyDefaultHostname);
+                emptyDefaultHostname,
+                normalizeBeanParamTags);
     }
 
     @Override

--- a/src/main/java/org/datadog/jmxfetch/JmxSubAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxSubAttribute.java
@@ -21,7 +21,8 @@ abstract class JmxSubAttribute extends JmxAttribute {
             ServiceNameProvider serviceNameProvider,
             Map<String, String> instanceTags,
             boolean cassandraAliasing,
-            boolean emptyDefaultHostname) {
+            boolean emptyDefaultHostname,
+            boolean normalizeBeanParamTags) {
         super(
                 attribute,
                 beanName,
@@ -32,7 +33,8 @@ abstract class JmxSubAttribute extends JmxAttribute {
                 serviceNameProvider,
                 instanceTags,
                 cassandraAliasing,
-                emptyDefaultHostname);
+                emptyDefaultHostname,
+                normalizeBeanParamTags);
     }
 
     public Metric getCachedMetric(String name) {

--- a/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
@@ -38,7 +38,8 @@ public class JmxTabularAttribute extends JmxSubAttribute {
             Connection connection,
             ServiceNameProvider serviceNameProvider,
             Map<String, String> instanceTags,
-            boolean emptyDefaultHostname) {
+            boolean emptyDefaultHostname,
+            boolean normalizeBeanParamTags) {
         super(
                 attribute,
                 beanName,
@@ -49,7 +50,8 @@ public class JmxTabularAttribute extends JmxSubAttribute {
                 serviceNameProvider,
                 instanceTags,
                 false,
-                emptyDefaultHostname);
+                emptyDefaultHostname,
+                normalizeBeanParamTags);
         subAttributeList = new HashMap<String, List<String>>();
     }
 

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import javax.management.ObjectName;
+
 import org.junit.Test;
 
 public class TestApp extends TestCommon {
@@ -68,6 +70,66 @@ public class TestApp extends TestCommon {
                         "component");
 
         assertMetric("this.is.100", tags, 6);
+    }
+
+    /** Tag metrics with MBeans parameters with normalize_bean_param_tags option enabled. */
+    @Test
+    public void testBeanTagsNormalizeParams() throws Exception {
+        // We expose a few metrics through JMX
+        registerMBean(
+                new SimpleTestJavaApp(),
+                "org.datadog.jmxfetch.test:type=\"SimpleTestJavaApp\",scope=\"Co|olScope\",host=\"localhost\",component=,target_instance="
+                + ObjectName.quote(".*example.process.regex.*"));
+        initApplication("jmx_bean_tags_normalize_params.yaml");
+
+        // Collecting metrics
+        run();
+        List<Map<String, Object>> metrics = getMetrics();
+
+        // 14 = 13 metrics from java.lang + 1 metric explicitly defined in the yaml config file
+        assertEquals(14, metrics.size());
+
+        List<String> tags =
+                Arrays.asList(
+                        "type:SimpleTestJavaApp",
+                        "scope:CoolScope",
+                        "instance:jmx_test_instance",
+                        "jmx_domain:org.datadog.jmxfetch.test",
+                        "bean_host:localhost",
+                        "component",
+                        "target_instance:.*example.process.regex.*");
+
+        assertMetric("this.is.100", tags, 7);
+    }
+
+    /** Tag metrics with MBeans parameters with normalize_bean_param_tags option disabled. */
+    @Test
+    public void testBeanTagsDontNormalizeParams() throws Exception {
+        // We expose a few metrics through JMX
+        registerMBean(
+                new SimpleTestJavaApp(),
+                "org.datadog.jmxfetch.test:type=\"SimpleTestJavaApp\",scope=\"Co|olScope\",host=\"localhost\",component=,target_instance="
+                + ObjectName.quote(".*example.process.regex.*"));
+        initApplication("jmx_bean_tags_dont_normalize_params.yaml");
+
+        // Collecting metrics
+        run();
+        List<Map<String, Object>> metrics = getMetrics();
+
+        // 14 = 13 metrics from java.lang + 1 metric explicitly defined in the yaml config file
+        assertEquals(14, metrics.size());
+
+        List<String> tags =
+                Arrays.asList(
+                        "type:\"SimpleTestJavaApp\"",
+                        "scope:\"CoolScope\"",
+                        "instance:jmx_test_instance",
+                        "jmx_domain:org.datadog.jmxfetch.test",
+                        "bean_host:\"localhost\"",
+                        "component",
+                        "target_instance:\".\\*example.process.regex.\\*\"");
+
+        assertMetric("this.is.100", tags, 7);
     }
 
     /** Generate metric aliases from a `alias_match` regular expression. */

--- a/src/test/resources/jmx_bean_tags_dont_normalize_params.yaml
+++ b/src/test/resources/jmx_bean_tags_dont_normalize_params.yaml
@@ -1,0 +1,18 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        conf:
+            - include:
+               bean: org.datadog.jmxfetch.test:type="SimpleTestJavaApp",scope="Co|olScope",host="localhost",component=,target_instance=".\*example.process.regex.\*"
+               attribute:
+                    ShouldBe100:
+                        metric_type: gauge
+                        alias: this.is.100
+            - include:
+               bean: org.datadog.jmxfetch.test:type=WrongType,scope=WrongScope,host=localhost,component=
+               attribute:
+                    Hashmap.thisis0:
+                        metric_type: gauge
+                        alias: bean.parameters.should.not.match

--- a/src/test/resources/jmx_bean_tags_normalize_params.yaml
+++ b/src/test/resources/jmx_bean_tags_normalize_params.yaml
@@ -1,0 +1,19 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        conf:
+            - include:
+               bean: org.datadog.jmxfetch.test:type="SimpleTestJavaApp",scope="Co|olScope",host="localhost",component=,target_instance=".\*example.process.regex.\*"
+               attribute:
+                    ShouldBe100:
+                        metric_type: gauge
+                        alias: this.is.100
+            - include:
+               bean: org.datadog.jmxfetch.test:type=WrongType,scope=WrongScope,host=localhost,component=
+               attribute:
+                    Hashmap.thisis0:
+                        metric_type: gauge
+                        alias: bean.parameters.should.not.match
+        normalize_bean_param_tags: true


### PR DESCRIPTION
From original PR #456:

Java management beans with parameters/attributes with values including any [special characters](https://docs.oracle.com/javase%2F7%2Fdocs%2Fapi%2F%2F/javax/management/ObjectName.html) must be a quoted value in order to escape special characters. However, our intake does some normalization while extracting tag values that results in weird formatting when converting these extra quotation marks. Therefore, we want to add an option that allows users to remove these quotation marks in the tag extraction process.

To understand exactly what this applies to, if a java application specifies a bean that the customer would like to monitor, by default we add the “bean parameters” on that bean as tags in the resulting Datadog metric.

As an example, without quotation removal, if a bean specifies a bean parameter that has a quoted value, ie partition="my-first-partition", then this will be translated into a dogstatsd message specifying this tag: partition:"my-first-partition". This is then processed by intake according to the rules linked above which will translate each quote character to a space, resulting in partition: my-first-partition , note the whitespace at the end. Next the intake trims beginning and trailing whitespace which results in partition: my-first-partition. The last step is for spaces to be replaced by underscores, so the final resulting tag will be partition:_my-first-partition.

With this config option enabled, the final result will be partition:my-first-partition which is almost certainly a better result, however since this is a backwards incompatible change, this must be behind a config option.