### PR TITLE
custom jmxfetch bean to track number of ingested beans, attributes, and metrics

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -388,11 +388,13 @@ public class App {
                             System.arraycopy(minibuff, 0, buffer, oldLen, len);
                         }
                     }
-                    this.setReinit(processAutoDiscovery(buffer));
+                    boolean result = processAutoDiscovery(buffer);
+                    this.setReinit(result);
                 }
 
                 if (this.appConfig.remoteEnabled()) {
-                    this.setReinit(getJsonConfigs());
+                    boolean result = getJsonConfigs();
+                    this.setReinit(result);
                 }
             } catch (IOException e) {
                 log.warn(

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -4,13 +4,17 @@ import lombok.extern.slf4j.Slf4j;
 import org.datadog.jmxfetch.reporter.Reporter;
 import org.datadog.jmxfetch.service.ConfigServiceNameProvider;
 import org.datadog.jmxfetch.service.ServiceNameProvider;
+import org.datadog.jmxfetch.util.InstanceTelemetry;
 import org.yaml.snakeyaml.Yaml;
+
+
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -20,8 +24,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.InstanceNotFoundException;
 import javax.management.MBeanAttributeInfo;
 import javax.management.MBeanInfo;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
 import javax.security.auth.login.FailedLoginException;
 
@@ -103,6 +114,9 @@ public class Instance {
     private AppConfig appConfig;
     private Boolean cassandraAliasing;
     private boolean emptyDefaultHostname;
+    private InstanceTelemetry instanceTelemetryBean;
+    private ObjectName instanceTelemetryBeanName;
+    private MBeanServer mbs;
     private Boolean normalizeBeanParamTags;
 
     /** Constructor, instantiates Instance based of a previous instance and appConfig. */
@@ -264,7 +278,33 @@ public class Instance {
         } else {
             log.info("collect_default_jvm_metrics is false - not collecting default JVM metrics");
         }
+
+        instanceTelemetryBean = createJmxBean();
     }
+
+    private ObjectName getObjName(String domain,String instance)
+            throws MalformedObjectNameException {
+        return new ObjectName(domain + ":target_instance=" + ObjectName.quote(instance));
+    }
+
+    private InstanceTelemetry createJmxBean() {
+        mbs =  ManagementFactory.getPlatformMBeanServer();
+        InstanceTelemetry bean = new InstanceTelemetry();
+        log.debug("Created jmx bean for instance: " + this.getCheckName());
+
+        try {
+            instanceTelemetryBeanName = getObjName("JMXFetch" , this.getName());
+            mbs.registerMBean(bean,instanceTelemetryBeanName);
+            log.debug("Succesfully registered jmx bean for instance: " + this.getCheckName());
+
+        } catch (MalformedObjectNameException | InstanceAlreadyExistsException
+                | MBeanRegistrationException | NotCompliantMBeanException e) {
+            log.warn("Could not register bean for instance: " + this.getCheckName(),e);
+        }
+
+        return bean;
+    }
+
 
     public static boolean isDirectInstance(Map<String, Object> configInstance) {
         Object directInstance = configInstance.get(JVM_DIRECT);
@@ -460,7 +500,7 @@ public class Instance {
             ? this.initialRefreshBeansPeriod : this.refreshBeansPeriod;
 
         if (isPeriodDue(this.lastRefreshTime, period)) {
-            log.info("Refreshing bean list");
+            log.info("Refreshing bean list for " + this.getCheckName());
             this.refreshBeansList();
             this.getMatchingAttributes();
         }
@@ -492,6 +532,13 @@ public class Instance {
                 }
             }
         }
+        instanceTelemetryBean.setBeanCount(beans.size());
+        instanceTelemetryBean.setAttributeCount(matchingAttributes.size());
+        instanceTelemetryBean.setMetricCount(metrics.size());
+        log.debug("Updated jmx bean for instance: " + this.getCheckName()
+                + " With number of beans = " + instanceTelemetryBean.getBeanCount()
+                + " attributes = " + instanceTelemetryBean.getAttributeCount()
+                + " metrics = " + instanceTelemetryBean.getMetricCount());
         return metrics;
     }
 
@@ -783,8 +830,18 @@ public class Instance {
         return this.limitReached;
     }
 
+    private void cleanupTelemetryBean() {
+        try {
+            mbs.unregisterMBean(instanceTelemetryBeanName);
+            log.debug("Successfully unregistered bean for instance: " + this.getCheckName());
+        } catch (MBeanRegistrationException | InstanceNotFoundException e) {
+            log.debug("Unable to unregister bean for instance: " + this.getCheckName());
+        }
+    }
+
     /** Clean up config and close connection. */
     public void cleanUp() {
+        cleanupTelemetryBean();
         this.appConfig = null;
         if (connection != null) {
             connection.closeConnector();
@@ -797,7 +854,7 @@ public class Instance {
      * */
     public synchronized void cleanUpAsync() {
         appConfig = null;
-
+        cleanupTelemetryBean();
         class AsyncCleaner implements Runnable {
             Connection conn;
 

--- a/src/main/java/org/datadog/jmxfetch/util/InstanceTelemetry.java
+++ b/src/main/java/org/datadog/jmxfetch/util/InstanceTelemetry.java
@@ -1,0 +1,44 @@
+package org.datadog.jmxfetch.util;
+
+
+/** Jmxfetch telemetry JMX MBean. */
+public class InstanceTelemetry implements InstanceTelemetryMBean {
+
+    private int beanCount;
+    private int attributeCount;
+    private int metricCount;
+
+    /** Jmxfetch telemetry bean constructor. */
+    public InstanceTelemetry() {
+        beanCount = 0;
+        attributeCount = 0;
+        metricCount = 0;
+    }
+
+    public int getBeanCount() {
+        return beanCount;
+    }
+
+    public int getAttributeCount() {
+        return attributeCount;
+    }
+
+    public int getMetricCount() {
+        return metricCount;
+    }
+
+
+    public void setBeanCount(int count) {
+        beanCount = count;
+    }
+
+    public void setAttributeCount(int count) {
+        attributeCount = count;
+    }
+
+    public void setMetricCount(int count) {
+        metricCount = count;
+    }
+
+
+}

--- a/src/main/java/org/datadog/jmxfetch/util/InstanceTelemetryMBean.java
+++ b/src/main/java/org/datadog/jmxfetch/util/InstanceTelemetryMBean.java
@@ -1,0 +1,11 @@
+package org.datadog.jmxfetch.util;
+
+public interface InstanceTelemetryMBean {
+
+    int getBeanCount();
+
+    int getAttributeCount();
+
+    int getMetricCount();
+
+}


### PR DESCRIPTION
This pr is part of a multi stage process to increase observability within jmxfetch. Another [pr](https://github.com/DataDog/jmxfetch/pull/467) adds a check that uses proccess_regex to attach to jmxfetch's jvm in order to collect mbean data from our own application. In this pr I have added jmx MBeans that are registered for each instance of jmxfetch and track the number of beans, metrics, and attributes that each instance collects and exposes this under the jmxFetch domain where the check from my other pr will be able to pick up this data in addition to general jmfetch metrics.