### PR TITLE
Update jmxfetch telemetry to jvm_direct

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -968,7 +968,7 @@ public class App {
         config.put("name","jmxfetch_telemetry_instance");
         config.put("collect_default_jvm_metrics",true);
         config.put("new_gc_metrics",true);
-        config.put("process_name_regex",".*org.datadog.jmxfetch.App.*");
+        config.put("jvm_direct",true);
         config.put("normalize_bean_param_tags",true);
 
         List<Object> conf = new ArrayList<Object>();

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -479,7 +479,11 @@ public class Instance {
     @Override
     public String toString() {
         if (isDirectInstance(instanceMap)) {
-            return "jvm_direct";
+            if (this.instanceMap.get("name") != null) {
+                return "jvm_direct - name: `" + (String) this.instanceMap.get("name") + "`";
+            } else {
+                return "jvm_direct";
+            }
         } else if (this.instanceMap.get(PROCESS_NAME_REGEX) != null) {
             return "process_regex: `" + this.instanceMap.get(PROCESS_NAME_REGEX) + "`";
         } else if (this.instanceMap.get("name") != null) {


### PR DESCRIPTION
This PR updates the jmxfetch telemetry check to use jvm_direct rather than proccess_regex to attach to the local MBeanServer. It also updated the toString for jvm_direct instances. Previously the check was using proccess_regex to attach, but it is a more intensive connection process then just accessing your platform MBeanServer which is what jvm_direct does. This was only possible because we configured the check in code, after all the validation that usually inhibits using jvm_direct.