### PR TITLE
Adding some composite data tests

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -38,44 +38,6 @@ import javax.security.auth.login.FailedLoginException;
 
 @Slf4j
 public class Instance {
-    private static final List<String> SIMPLE_TYPES =
-            Arrays.asList(
-                    "long",
-                    "java.lang.String",
-                    "int",
-                    "float",
-                    "double",
-                    "java.lang.Double",
-                    "java.lang.Float",
-                    "java.lang.Integer",
-                    "java.lang.Long",
-                    "java.util.concurrent.atomic.AtomicInteger",
-                    "java.util.concurrent.atomic.AtomicLong",
-                    "java.lang.Object",
-                    "java.lang.Boolean",
-                    "boolean",
-                    "java.lang.Number",
-                    //Workaround for jasperserver, which returns attribute types as `class <type>`
-                    "class java.lang.String",
-                    "class java.lang.Double",
-                    "class java.lang.Float",
-                    "class java.lang.Integer",
-                    "class java.lang.Long",
-                    "class java.util.concurrent.atomic.AtomicInteger",
-                    "class java.util.concurrent.atomic.AtomicLong",
-                    "class java.lang.Object",
-                    "class java.lang.Boolean",
-                    "class java.lang.Number");
-    private static final List<String> COMPOSED_TYPES =
-            Arrays.asList(
-                    "javax.management.openmbean.CompositeData",
-                    "java.util.HashMap",
-                    "java.util.Map");
-    private static final List<String> MULTI_TYPES =
-            Arrays.asList(
-                    "javax.management.openmbean.TabularData",
-                    //Adding TabularDataSupport as it implements TabularData
-                    "javax.management.openmbean.TabularDataSupport");
     private static final int MAX_RETURNED_METRICS = 350;
     private static final int DEFAULT_REFRESH_BEANS_PERIOD = 600;
     public static final String PROCESS_NAME_REGEX = "process_name_regex";
@@ -295,13 +257,17 @@ public class Instance {
         try {
             instanceTelemetryBeanName = getObjName(appConfig.getJmxfetchTelemetryDomain(),
                      this.getName());
+        } catch (MalformedObjectNameException e) {
+            log.warn("Could not construct bean name for jmxfetch_telemetry_domain '{}' and name '{}'", appConfig.getJmxfetchTelemetryDomain(), this.getName());
+            return bean;
+        }
+
+        try {
             mbs.registerMBean(bean,instanceTelemetryBeanName);
             log.debug("Succesfully registered jmx bean for instance: " + this.getCheckName()
                     + " with ObjectName = " + instanceTelemetryBeanName);
-
-        } catch (MalformedObjectNameException | InstanceAlreadyExistsException
-                | MBeanRegistrationException | NotCompliantMBeanException e) {
-            log.warn("Could not register bean for instance: " + this.getCheckName(),e);
+        } catch (InstanceAlreadyExistsException | MBeanRegistrationException | NotCompliantMBeanException e) {
+            log.warn("Could not register bean named '{}' for instance: ", instanceTelemetryBeanName.toString(), this.getCheckName(),e);
         }
 
         return bean;
@@ -620,7 +586,8 @@ public class Instance {
                 }
                 JmxAttribute jmxAttribute;
                 String attributeType = attributeInfo.getType();
-                if (SIMPLE_TYPES.contains(attributeType)) {
+
+                if (JmxSimpleAttribute.matchAttributeType(attributeType)) {
                     log.debug(
                             ATTRIBUTE
                             + beanName
@@ -640,7 +607,7 @@ public class Instance {
                                 cassandraAliasing,
                                 emptyDefaultHostname,
                                 normalizeBeanParamTags);
-                } else if (COMPOSED_TYPES.contains(attributeType)) {
+                } else if (JmxComplexAttribute.matchAttributeType(attributeType)) {
                     log.debug(
                             ATTRIBUTE
                             + beanName
@@ -659,7 +626,7 @@ public class Instance {
                                 tags,
                                 emptyDefaultHostname,
                                 normalizeBeanParamTags);
-                } else if (MULTI_TYPES.contains(attributeType)) {
+                } else if (JmxTabularAttribute.matchAttributeType(attributeType)) {
                     log.debug(
                             ATTRIBUTE
                             + beanName

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -257,17 +257,13 @@ public class Instance {
         try {
             instanceTelemetryBeanName = getObjName(appConfig.getJmxfetchTelemetryDomain(),
                      this.getName());
-        } catch (MalformedObjectNameException e) {
-            log.warn("Could not construct bean name for jmxfetch_telemetry_domain '{}' and name '{}'", appConfig.getJmxfetchTelemetryDomain(), this.getName());
-            return bean;
-        }
-
-        try {
             mbs.registerMBean(bean,instanceTelemetryBeanName);
             log.debug("Succesfully registered jmx bean for instance: " + this.getCheckName()
                     + " with ObjectName = " + instanceTelemetryBeanName);
-        } catch (InstanceAlreadyExistsException | MBeanRegistrationException | NotCompliantMBeanException e) {
-            log.warn("Could not register bean named '{}' for instance: ", instanceTelemetryBeanName.toString(), this.getCheckName(),e);
+
+        } catch (MalformedObjectNameException | InstanceAlreadyExistsException
+                | MBeanRegistrationException | NotCompliantMBeanException e) {
+            log.warn("Could not register bean for instance: " + this.getCheckName(),e);
         }
 
         return bean;

--- a/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
@@ -47,14 +47,12 @@ public class JmxComplexAttribute extends JmxSubAttribute {
     }
 
     private void populateSubAttributeList(Object attributeValue) {
-        String attributeType = getAttribute().getType();
-        if ("javax.management.openmbean.CompositeData".equals(attributeType)) {
+        if (attributeValue instanceof javax.management.openmbean.CompositeData) {
             CompositeData data = (CompositeData) attributeValue;
             for (String key : data.getCompositeType().keySet()) {
                 this.subAttributeList.add(key);
             }
-        } else if (("java.util.HashMap".equals(attributeType))
-                || ("java.util.Map".equals(attributeType))) {
+        } else if (attributeValue instanceof java.util.Map) {
             Map<String, Double> data = (Map<String, Double>) attributeValue;
             for (String key : data.keySet()) {
                 this.subAttributeList.add(key);
@@ -80,13 +78,11 @@ public class JmxComplexAttribute extends JmxSubAttribute {
                     ReflectionException, IOException {
 
         Object value = this.getJmxValue();
-        String attributeType = getAttribute().getType();
 
-        if ("javax.management.openmbean.CompositeData".equals(attributeType)) {
+        if (value instanceof CompositeData) {
             CompositeData data = (CompositeData) value;
             return data.get(subAttribute);
-        } else if (("java.util.HashMap".equals(attributeType))
-                || ("java.util.Map".equals(attributeType))) {
+        } else if (value instanceof java.util.Map) {
             Map<String, Object> data = (Map<String, Object>) value;
             return data.get(subAttribute);
         }

--- a/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
@@ -99,24 +99,7 @@ public class JmxComplexAttribute extends JmxSubAttribute {
     }
 
     public static boolean matchAttributeType(String attributeType) {
-        if (COMPOSED_TYPES.contains(attributeType)) {
-            return true;
-        }
-        try {
-            Class<?> classObj = Class.forName(attributeType);
-
-            if (javax.management.openmbean.CompositeData.class.isAssignableFrom(classObj)) {
-                log.info("Found that type {} is assignable to CompositeData.", attributeType);
-                return true;
-            }
-            if (java.util.Map.class.isAssignableFrom(classObj)) {
-                log.info("Found that type {} is assignable to Map.", attributeType);
-                return true;
-            }
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
-        return false;
+        return COMPOSED_TYPES.contains(attributeType);
     }
 
     @Override

--- a/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
@@ -24,6 +24,7 @@ public class JmxComplexAttribute extends JmxSubAttribute {
     private static final List<String> COMPOSED_TYPES =
             Arrays.asList(
                     "javax.management.openmbean.CompositeData",
+                    "javax.management.openmbean.CompositeDataSupport",
                     "java.util.HashMap",
                     "java.util.Map");
 

--- a/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxComplexAttribute.java
@@ -1,8 +1,9 @@
 package org.datadog.jmxfetch;
 
-import org.datadog.jmxfetch.service.ServiceNameProvider;
 
 import lombok.extern.slf4j.Slf4j;
+
+import org.datadog.jmxfetch.service.ServiceNameProvider;
 
 import java.io.IOException;
 import java.util.ArrayList;

--- a/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxSimpleAttribute.java
@@ -3,6 +3,7 @@ package org.datadog.jmxfetch;
 import org.datadog.jmxfetch.service.ServiceNameProvider;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -15,6 +16,34 @@ import javax.management.ReflectionException;
 
 @SuppressWarnings("unchecked")
 public class JmxSimpleAttribute extends JmxAttribute {
+    private static final List<String> SIMPLE_TYPES =
+            Arrays.asList(
+                    "long",
+                    "java.lang.String",
+                    "int",
+                    "float",
+                    "double",
+                    "java.lang.Double",
+                    "java.lang.Float",
+                    "java.lang.Integer",
+                    "java.lang.Long",
+                    "java.util.concurrent.atomic.AtomicInteger",
+                    "java.util.concurrent.atomic.AtomicLong",
+                    "java.lang.Object",
+                    "java.lang.Boolean",
+                    "boolean",
+                    "java.lang.Number",
+                    //Workaround for jasperserver, which returns attribute types as `class <type>`
+                    "class java.lang.String",
+                    "class java.lang.Double",
+                    "class java.lang.Float",
+                    "class java.lang.Integer",
+                    "class java.lang.Long",
+                    "class java.util.concurrent.atomic.AtomicInteger",
+                    "class java.util.concurrent.atomic.AtomicLong",
+                    "class java.lang.Object",
+                    "class java.lang.Boolean",
+                    "class java.lang.Number");
     private Metric cachedMetric;
 
     /** JmxSimpleAttribute constructor. */
@@ -57,6 +86,10 @@ public class JmxSimpleAttribute extends JmxAttribute {
         double value = castToDouble(getValue(), null);
         cachedMetric.setValue(value);
         return Collections.singletonList(cachedMetric);
+    }
+
+    public static boolean matchAttributeType(String attributeType) {
+        return SIMPLE_TYPES.contains(attributeType);
     }
 
     /** Returns whether an attribute matches in a configuration spec. */

--- a/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
@@ -25,6 +25,11 @@ import javax.management.openmbean.TabularData;
 
 @Slf4j
 public class JmxTabularAttribute extends JmxSubAttribute {
+    private static final List<String> MULTI_TYPES =
+            Arrays.asList(
+                    "javax.management.openmbean.TabularData",
+                    //Adding TabularDataSupport as it implements TabularData
+                    "javax.management.openmbean.TabularDataSupport");
     private String instanceName;
     private Map<String, List<String>> subAttributeList;
 
@@ -53,6 +58,22 @@ public class JmxTabularAttribute extends JmxSubAttribute {
                 emptyDefaultHostname,
                 normalizeBeanParamTags);
         subAttributeList = new HashMap<String, List<String>>();
+    }
+
+    public static boolean matchAttributeType(String attributeType) {
+        if (MULTI_TYPES.contains(attributeType)) {
+            return true;
+        }
+        try {
+            Class<?> classObj = Class.forName(attributeType);
+
+            if (javax.management.openmbean.TabularData.class.isAssignableFrom(classObj)) {
+                return true;
+            }
+        } catch (ClassNotFoundException e) {
+            return false;
+        }
+        return false;
     }
 
     private String getMultiKey(Collection keys) {

--- a/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
+++ b/src/main/java/org/datadog/jmxfetch/JmxTabularAttribute.java
@@ -61,19 +61,7 @@ public class JmxTabularAttribute extends JmxSubAttribute {
     }
 
     public static boolean matchAttributeType(String attributeType) {
-        if (MULTI_TYPES.contains(attributeType)) {
-            return true;
-        }
-        try {
-            Class<?> classObj = Class.forName(attributeType);
-
-            if (javax.management.openmbean.TabularData.class.isAssignableFrom(classObj)) {
-                return true;
-            }
-        } catch (ClassNotFoundException e) {
-            return false;
-        }
-        return false;
+        return MULTI_TYPES.contains(attributeType);
     }
 
     private String getMultiKey(Collection keys) {

--- a/src/test/java/org/datadog/jmxfetch/SimpleTestJavaApp.java
+++ b/src/test/java/org/datadog/jmxfetch/SimpleTestJavaApp.java
@@ -43,6 +43,8 @@ public class SimpleTestJavaApp implements SimpleTestJavaAppMBean {
     private final TabularDataSupport tabulardata;
     private final CompositeType compositetype;
 
+    private final CompositeData nestedCompositeData;
+
     SimpleTestJavaApp() {
         hashmap.put("thisis0", 0);
         hashmap.put("thisis10", 10);
@@ -53,6 +55,8 @@ public class SimpleTestJavaApp implements SimpleTestJavaAppMBean {
         if (tabulardata != null) {
             tabulardata.put(buildCompositeData(1));
         }
+
+        nestedCompositeData = buildNestedCompositeData();
     }
 
     public int getShouldBe100() {
@@ -158,6 +162,45 @@ public class SimpleTestJavaApp implements SimpleTestJavaAppMBean {
         } catch (OpenDataException e) {
             return null;
         }
+    }
+
+    private CompositeDataSupport buildNestedCompositeData() {
+        try {
+            // Define the inner CompositeData
+            String[] innerNames = { "aLong", "aDouble", "aString" };
+            Object[] innerValues = { 123456L, 123.456, "Test String" };
+            OpenType<?>[] innerTypes = { SimpleType.LONG, SimpleType.DOUBLE, SimpleType.STRING };
+
+            CompositeType innerType = new CompositeType(
+                    "InnerType",
+                    "Description for Inner CompositeData",
+                    innerNames,
+                    innerNames,
+                    innerTypes);
+
+            CompositeData innerComposite = new CompositeDataSupport(innerType, innerNames, innerValues);
+
+            // Define the outer CompositeData
+            String[] outerNames = { "anInt", "aBoolean", "nestedData" };
+            Object[] outerValues = { 42, true, innerComposite };
+            OpenType<?>[] outerTypes = { SimpleType.INTEGER, SimpleType.BOOLEAN, innerType };
+
+            CompositeType outerType = new CompositeType(
+                    "OuterType",
+                    "Description for Outer CompositeData",
+                    outerNames,
+                    outerNames,
+                    outerTypes);
+
+            return new CompositeDataSupport(outerType, outerNames, outerValues);
+        } catch (Exception e) {
+            // should never happen
+            return null;
+        }
+    }
+
+    public CompositeData getNestedCompositeData() {
+        return this.nestedCompositeData;
     }
 
     private CompositeData buildCompositeData(Integer i) {

--- a/src/test/java/org/datadog/jmxfetch/SimpleTestJavaAppMBean.java
+++ b/src/test/java/org/datadog/jmxfetch/SimpleTestJavaAppMBean.java
@@ -3,6 +3,9 @@ package org.datadog.jmxfetch;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+
+import javax.management.openmbean.CompositeData;
+import javax.management.openmbean.CompositeDataSupport;
 import javax.management.openmbean.TabularData;
 import javax.management.openmbean.TabularDataSupport;
 
@@ -40,4 +43,6 @@ public interface SimpleTestJavaAppMBean {
 
     TabularData getTabulardata();
     TabularDataSupport getTabularDataSupport();
+
+    CompositeData getNestedCompositeData();
 }

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -1138,6 +1138,10 @@ public class TestApp extends TestCommon {
 
         assertMetric("one_level_int", 42, tags, -1);
 
+        // This assertion currently fails as JMXFetch does not support accessing
+        // data from a nested compositedata object
+        //assertMetric("second_level_long", 123456L, tags, -1);
+
         assertCoverage();
     }
 }

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -1114,4 +1114,30 @@ public class TestApp extends TestCommon {
 
         assertCoverage();
     }
+
+    @Test
+    public void testNestedCompositeData() throws Exception {
+        SimpleTestJavaApp testApp = new SimpleTestJavaApp();
+        registerMBean(testApp, "org.datadog.jmxfetch.test:type=SimpleTestJavaApp");
+
+        // We do a first collection
+        when(appConfig.isTargetDirectInstances()).thenReturn(true);
+        initApplication("jmx_composite_data.yaml");
+
+        run();
+        List<Map<String, Object>> metrics = getMetrics();
+
+        assertEquals(1, metrics.size());
+
+        List<String> tags = Arrays.asList(
+                "instance:jmx_test_instance",
+                "jmx_domain:org.datadog.jmxfetch.test",
+                "type:SimpleTestJavaApp",
+                "env:stage",
+                "newTag:test");
+
+        assertMetric("one_level_int", 42, tags, -1);
+
+        assertCoverage();
+    }
 }

--- a/src/test/resources/jmx_composite_data.yaml
+++ b/src/test/resources/jmx_composite_data.yaml
@@ -16,3 +16,11 @@ instances:
             NestedCompositeData.anInt:
               metric_type: gauge
               alias: one_level_int
+      - include:
+          domain: org.datadog.jmxfetch.test
+          attribute:
+            # Warning!! This is currently not supported!
+            # See corresponding unit test
+            NestedCompositeData.nestedData.aLong:
+              metric_type: gauge
+              alias: second_level_long

--- a/src/test/resources/jmx_composite_data.yaml
+++ b/src/test/resources/jmx_composite_data.yaml
@@ -1,0 +1,18 @@
+---
+init_config:
+
+instances:
+  - jvm_direct: true
+    refresh_beans: 4
+    collect_default_jvm_metrics: false
+    name: jmx_test_instance
+    tags:
+      - "env:stage"
+      - "newTag:test"
+    conf:
+      - include:
+          domain: org.datadog.jmxfetch.test
+          attribute:
+            NestedCompositeData.anInt:
+              metric_type: gauge
+              alias: one_level_int


### PR DESCRIPTION
This make a few changes:

1. Moves the "is attribute of type XYZ" check inside each attribute class
2. Adds a test case with both a simple compositedata attribute and a nested compositedata attribute (the latter is not supported)
3. Small exception handler cleanup with telemetry bean registration.

I wanted to change the "is attribute of type XYZ" check to use a more dynamic method to avoid having to list all possible subclasses (ref `TabularData` vs `TabularDataSupport`).

Unfortunately this is not an easy change due to the fact that `TabularDataSupport` actually implements `Map`, so TabularDataSupport was getting picked up as a `JmxComplexAttribute` vs a `JmxTabularAttribute`.
Change was attempted in https://github.com/DataDog/jmxfetch/commit/baa60df420751fd384f7113280514b909173f8c3