### PR TITLE
Clean up instance telemetry bean in tests

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -242,6 +242,10 @@ public class App {
         }
     }
 
+    protected void clearAllInstances() {
+        this.clearInstances(this.instances);
+    }
+
     /**
      * Builds an {@link ExecutorService} of the specified fixed size. Threads will be created
      * and executed as daemons if {@link AppConfig#isDaemon()} is true. Defaults to false.

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -152,7 +152,7 @@ public class TestApp extends TestCommon {
         List<String> tags =
                 Arrays.asList(
                         "jmx_domain:org.datadog.jmxfetch.test",
-                        "instance:jmx_test_instance",
+                        "instance:jmx_test_instance1",
                         "foo:Bar",
                         "qux:Baz");
 
@@ -963,7 +963,7 @@ public class TestApp extends TestCommon {
         List<String> tags = Arrays.asList(
             "type:SimpleTestJavaApp",
             "scope:CoolScope",
-            "instance:jmx_test_instance",
+            "instance:jmx_test_instance2",
             "jmx_domain:org.datadog.jmxfetch.test",
             "bean_host:localhost",
             "component"
@@ -998,7 +998,7 @@ public class TestApp extends TestCommon {
         tags =
                 Arrays.asList(
                         "jmx_domain:org.datadog.jmxfetch.test",
-                        "instance:jmx_test_instance",
+                        "instance:jmx_test_instance1",
                         "foo:Bar",
                         "qux:Baz");
 

--- a/src/test/java/org/datadog/jmxfetch/TestCommon.java
+++ b/src/test/java/org/datadog/jmxfetch/TestCommon.java
@@ -110,6 +110,16 @@ public class TestCommon {
         }
     }
 
+    /**
+     * Clear instances and their instance telemetry bean after execution of every test.
+     */
+    @After
+    public void clearInstances() {
+        if (app != null) {
+            app.clearAllInstances();
+        }
+    }
+
     /** Init JMXFetch with the given YAML configuration file. */
     protected void initApplication(String yamlFileName, String autoDiscoveryPipeFile)
             throws FileNotFoundException, IOException {

--- a/src/test/resources/jmx_alias_match.yaml
+++ b/src/test/resources/jmx_alias_match.yaml
@@ -2,7 +2,7 @@ init_config:
 
 instances:
     -   process_name_regex: .*surefire.*
-        name: jmx_test_instance
+        name: jmx_test_instance1
         conf:
             - include:
                domain: org.datadog.jmxfetch.test

--- a/src/test/resources/jmx_counter_rate.yaml
+++ b/src/test/resources/jmx_counter_rate.yaml
@@ -3,7 +3,7 @@ init_config:
 instances:
   -   process_name_regex: .*surefire.*
       refresh_beans: 4
-      name: jmx_test_instance
+      name: jmx_test_instance1
       conf:
         - include:
             domain: org.datadog.jmxfetch.test
@@ -13,7 +13,7 @@ instances:
                 alias: test.counter
   -   process_name_regex: .*surefire.*
       refresh_beans: 4
-      name: jmx_test_instance
+      name: jmx_test_instance2
       conf:
         - include:
             domain: org.datadog.jmxfetch.test

--- a/src/test/resources/jmx_sd_pipe.txt
+++ b/src/test/resources/jmx_sd_pipe.txt
@@ -25,7 +25,7 @@ init_config:
 
 instances:
     -   process_name_regex: .*surefire.*
-        name: jmx_test_instance
+        name: jmx_test_instance2
         conf:
             - include:
                bean: org.datadog.jmxfetch.test:type=SimpleTestJavaApp,scope=Co|olScope,host=localhost,component=

--- a/src/test/resources/jmx_sd_pipe_longname.txt
+++ b/src/test/resources/jmx_sd_pipe_longname.txt
@@ -4,7 +4,7 @@ init_config:
 
 instances:
     -   process_name_regex: .*surefire.*
-        name: jmx_test_instance
+        name: jmx_test_instance2
         conf:
             - include:
                bean: org.datadog.jmxfetch.test:type=SimpleTestJavaApp,scope=Co|olScope,host=localhost,component=
@@ -25,7 +25,7 @@ init_config:
 
 instances:
     -   process_name_regex: .*surefire.*
-        name: jmx_test_instance
+        name: jmx_test_instance3
         conf:
             - include:
                bean: org.datadog.jmxfetch.test:type=SimpleTestJavaApp,scope=Co|olScope,host=localhost,component=


### PR DESCRIPTION
this pr:
1. adds a cleanup for instances and their telemetry bean
2. renames some of the instance names in our test yaml so that they are unique

now, when you run `mvn test -Dtest=TestApp | grep InstanceAlreadyExistsException` , there are no exceptions