### PR TITLE
Improves the error message printed in bean retrieval exception

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -601,7 +601,7 @@ public class Instance {
                 // we should not continue
                 throw e;
             } catch (Exception e) {
-                log.warn("Cannot get bean attributes or class name: {}", e.getMessage());
+                log.warn("Cannot get attributes or class name for bean {}: ", beanName, e);
                 continue;
             }
 


### PR DESCRIPTION
The specific error here should be helpful to understand where this originates from, as the current `getMessage` does not give enough context to debug the problem.

In java < 14, this can be particularly unhelpful as `NullPointerExceptions` will have `null` as the message. [ref1](https://stackoverflow.com/a/8237225) [ref2](https://openjdk.org/jeps/358)

