### PR TITLE
Always save the unit test reports for easy debugging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,6 +29,7 @@ run_unit_tests:
 
   artifacts:
     expire_in: 1 mos
+    when: always
     paths:
       - ./target/surefire-reports/*.txt
 


### PR DESCRIPTION
By default gitlab only saves artifacts for successful runs, but we're interested in saving failed test results as well.