### PR TITLE
Adds sdkman conf file and usage instructions

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,8 @@
+# Enable auto-env through the sdkman_auto_env config
+# Add key=value pairs of SDKs to use below
+#
+# Java version currently tracking what is present in -jmx agent builds
+# Agent is currently installing 'openjdk-11-jre-headless' from debian
+# See https://github.com/DataDog/datadog-agent/blob/3b6f07cb7d097837a7b9247c6119ead3309116ab/Dockerfiles/agent/Dockerfile#L136
+# and https://packages.debian.org/sid/openjdk-11-jre-headless
+java=11.0.21-amzn

--- a/README.md
+++ b/README.md
@@ -61,6 +61,13 @@ JMXFetch uses [Lombok](https://projectlombok.org/) to modify classes and generat
 You may need to [enable annotation processors](https://projectlombok.org/setup/overview) to compile in your IDE.
 
 ## Useful Developer Settings
+
+### JDK version management
+[`sdkman`](https://sdkman.io/install) is recommended to manage multiple versions of java.
+If you are an sdkman user, there is a config file present in this project with
+the recommended JDK version for development, use `sdk env` to activate it.
+
+
 ### Enabling file line numbers in log messages
 If you set the system property `-Djmxfetch.filelinelogging=true`, this will enable all log output to
 include the line number which emitted a given log.


### PR DESCRIPTION
SDKMan seems to be one of the better version managers around, especially for java. I was previously using `asdf`, but sdkman seems more feature-ful and is used elsewhere in the org.

Added a brief instruction and pins the java version to what we run with in the `-jmx` images.