### PR TITLE
AMLII-1358 - Adding support for Generational ZGC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changelog
 =========
-# Next / TBD
+# 0.49.1 / TBD
+* [FEATURE] Add ZGC Major and Minor Cycles and ZGC Major and Minor Pauses beans support out of the box (Generational ZGC support) [#502][]
 
 # 0.49.0 / 2023-11-10
 * [FEATURE] Adds more per-instance telemetry data around bean matching
@@ -761,6 +762,7 @@ Changelog
 [#449]: https://github.com/DataDog/jmxfetch/issues/449
 [#469]: https://github.com/DataDog/jmxfetch/issues/469
 [#477]: https://github.com/DataDog/jmxfetch/issues/477
+[#502]: https://github.com/DataDog/jmxfetch/issues/502
 [@alz]: https://github.com/alz
 [@aoking]: https://github.com/aoking
 [@arrawatia]: https://github.com/arrawatia

--- a/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
+++ b/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
@@ -147,3 +147,49 @@
       CollectionTime:
         alias: jvm.gc.zgc_pauses_collection_time
         metric_type: counter
+
+# Z Garbage Collector with ZGenerational
+- include:
+    domain: java.lang
+    type: GarbageCollector
+    name: ZGC Major Cycles
+    attribute:
+      CollectionCount:
+        alias: jvm.gc.zgc_cycles_collection_count
+        metric_type: counter
+      CollectionTime:
+        alias: jvm.gc.zgc_cycles_collection_time
+        metric_type: counter
+- include:
+    domain: java.lang
+    type: GarbageCollector
+    name: ZGC Major Pauses
+    attribute:
+      CollectionCount:
+        alias: jvm.gc.zgc_pauses_collection_count
+        metric_type: counter
+      CollectionTime:
+        alias: jvm.gc.zgc_pauses_collection_time
+        metric_type: counter
+- include:
+    domain: java.lang
+    type: GarbageCollector
+    name: ZGC Minor Cycles
+    attribute:
+      CollectionCount:
+        alias: jvm.gc.zgc_cycles_collection_count
+        metric_type: counter
+      CollectionTime:
+        alias: jvm.gc.zgc_cycles_collection_time
+        metric_type: counter
+- include:
+    domain: java.lang
+    type: GarbageCollector
+    name: ZGC Minor Pauses
+    attribute:
+      CollectionCount:
+        alias: jvm.gc.zgc_pauses_collection_count
+        metric_type: counter
+      CollectionTime:
+        alias: jvm.gc.zgc_pauses_collection_time
+        metric_type: counter

--- a/src/test/java/org/datadog/jmxfetch/TestGCMetrics.java
+++ b/src/test/java/org/datadog/jmxfetch/TestGCMetrics.java
@@ -128,6 +128,26 @@ public class TestGCMetrics extends TestCommon {
         }
     }
 
+    @Test
+    public void testDefaultNewGCMetricsUseGenerationalZGC() throws IOException {
+        try (final MisbehavingJMXServer server = new MisbehavingJMXServer.Builder().withJDKImage(
+            JDK_21).appendJavaOpts("-XX:+UseZGC -XX:+ZGenerational").build()) {
+            final List<Map<String, Object>> actualMetrics = startAndGetMetrics(server, true);
+            assertThat(actualMetrics, hasSize(17));
+            final List<String> gcCycles = Arrays.asList(
+                "ZGC Major Cycles",
+                "ZGC Minor Cycles");
+            assertGCMetric(actualMetrics, "jvm.gc.zgc_cycles_collection_count", gcCycles);
+            assertGCMetric(actualMetrics, "jvm.gc.zgc_cycles_collection_time", gcCycles);
+
+            final List<String> gcPauses = Arrays.asList(
+                "ZGC Major Pauses",
+                "ZGC Minor Pauses");
+            assertGCMetric(actualMetrics, "jvm.gc.zgc_pauses_collection_count", gcPauses);
+            assertGCMetric(actualMetrics, "jvm.gc.zgc_pauses_collection_time", gcPauses);
+        }
+    }
+
     private List<Map<String, Object>> startAndGetMetrics(final MisbehavingJMXServer server,
         final boolean newGCMetrics) throws IOException {
         server.start();
@@ -188,24 +208,27 @@ public class TestGCMetrics extends TestCommon {
                 filteredMetrics.add(actualMetric);
             }
         }
-        assertThat(filteredMetrics, hasSize(gcGenerations.size()));
+        assertThat(
+            String.format("Asserting filtered metrics for '%s' of metric '%s'", gcGenerations.size(), expectedMetric),
+            filteredMetrics, hasSize(gcGenerations.size()));
         for (final String name : gcGenerations) {
-            log.debug("Asserting for metric '{}'", name);
+            log.debug("Asserting for expected metric '{}' with tag 'name:{}'", expectedMetric, name);
             boolean found = false;
             for (Map<String, Object> filteredMetric : filteredMetrics) {
                 final Set<String> mTags = new HashSet<>(
                     Arrays.asList((String[]) (filteredMetric.get("tags"))));
 
                 if(mTags.contains(String.format("name:%s", name))) {
-                    assertThat(mTags, not(empty()));
-                    assertThat(mTags, hasSize(5));
-                    log.debug("mTags '{}' has size: {}\n{}", name, mTags.size(), mTags);
-                    assertThat(mTags, hasItems(
+                    assertThat("Should not be empty", mTags, not(empty()));
+                    assertThat("Should have size 5", mTags, hasSize(5));
+                    assertThat("Has correct tags",
+                        mTags, hasItems(
                         "instance:jmxint_container",
                         "jmx_domain:java.lang",
                         "type:GarbageCollector",
                         String.format("name:%s", name)));
                     found = true;
+                    break;
                 }
             }
             assertThat(String.format("Did not find metric '%s'", name), found, is(true));

--- a/tools/misbehaving-jmx-server/src/main/java/org/datadog/supervisor/App.java
+++ b/tools/misbehaving-jmx-server/src/main/java/org/datadog/supervisor/App.java
@@ -1,5 +1,6 @@
 package org.datadog.supervisor;
 
+import io.javalin.http.HttpStatus;
 import java.io.File;
 import java.io.IOException;
 import java.net.ConnectException;
@@ -89,6 +90,10 @@ public class App {
             event.serverStarted(() -> {
                 log.info("Supervisor HTTP Server Started. Waiting for initialization payload POST to /init");
             });
+        });
+
+        app.get("/healthy", ctx -> {
+            ctx.status(HttpStatus.OK);
         });
 
         app.get("/ready", ctx -> {


### PR DESCRIPTION
Starting with JDK 21, multi-generation support has been added to ZGC (see [here](https://inside.java/2023/10/09/sip084/)).

This PR adds a new mappings to the new GC default JMX metrics and creates the following metrics:

- two `jvm.gc.zgc_cycles_collection_count` - each with different `name` tags (`ZGC Major Cycles` and `ZGC Minor Cycles`)
- two `jvm.gc.zgc_cycles_collection_time` - each with different `name` tags (`ZGC Major Cycles` and `ZGC Minor Cycles`)
- two `jvm.gc.zgc_pauses_collection_count` - each with different `name` tags (`ZGC Major Pauses` and `ZGC Pauses Cycles`)
- two `jvm.gc.zgc_pauses_collection_time` - each with different `name` tags (`ZGC Pauses Cycles` and `ZGC Pauses Cycles`)

Example:
![image](https://github.com/DataDog/jmxfetch/assets/717815/d5454450-f7ba-490f-8e00-fd130dfb437e)
