### PR TITLE
Adding Maven cache to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,12 +2,37 @@ version: 2
 lint_steps: &lint_steps
   steps:
     - checkout
+    - restore_cache:
+        name: Restore Maven cache
+        keys:
+          # when pom.xml file changes, use increasingly general patterns to restore cache
+          # Linting has own cache as deps not downloaded during test phases. If doesn't exist will
+          # fall back on any available cache.
+          - &maven-cache maven-cache-{{ .Branch }}-{{ checksum "pom.xml" }}-lint
+          - maven-cache-{{ .Branch }}-
+          - maven-cache-
     - run: ./mvnw verify -B -Dhttps.protocols=TLSv1.2 -DskipTests
+    - save_cache:
+        key: *maven-cache
+        paths:
+          - ~/.m2
 build_steps: &build_steps
   steps:
     - checkout
+    - restore_cache:
+        name: Restore Maven cache
+        keys:
+          # when pom.xml file changes, use increasingly general patterns to restore cache
+          - &maven-cache maven-cache-{{ .Branch }}-{{ checksum "pom.xml" }}
+          - maven-cache-{{ .Branch }}-
+          - maven-cache-
     - setup_remote_docker
     - run: ./mvnw test -B -Dhttps.protocols=TLSv1.2 -Dcheckstyle.skip=true -Dtests.log_level=info -Djdk.attach.allowAttachSelf=true
+    - save_cache:
+        when: always # Save even when test fails so we can reuse cache
+        key: *maven-cache
+        paths:
+          - ~/.m2
     - run:
         when: on_fail
         command: for log in target/surefire-reports/*.txt; do  echo "$log ========================" ; cat $log ; done


### PR DESCRIPTION
Noticed some tests failing due to not being able to pull dependencies down. Adding a cache in hope that it will stop that issue coming up again.
Caching doesn't work for the misbehaving JMX server as that is built in Docker and currently no way to share dependencies with the build process in Container Tests.