### PR TITLE
AMLII-1360: Creates telemetry bean for Application-level metrics

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -18,14 +18,13 @@ import org.datadog.jmxfetch.util.LogLevel;
 import org.datadog.jmxfetch.util.MetadataHelper;
 import org.datadog.jmxfetch.util.ServiceCheckHelper;
 
-import java.lang.management.ManagementFactory;
-
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.management.ManagementFactory;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,8 +35,8 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ConcurrentHashMap;
@@ -52,14 +51,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import javax.security.auth.login.FailedLoginException;
-
 import javax.management.InstanceAlreadyExistsException;
 import javax.management.MBeanRegistrationException;
 import javax.management.MBeanServer;
 import javax.management.MalformedObjectNameException;
 import javax.management.NotCompliantMBeanException;
 import javax.management.ObjectName;
+
+import javax.security.auth.login.FailedLoginException;
 
 
 

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -10,22 +10,15 @@ import org.datadog.jmxfetch.tasks.TaskMethod;
 import org.datadog.jmxfetch.tasks.TaskProcessException;
 import org.datadog.jmxfetch.tasks.TaskProcessor;
 import org.datadog.jmxfetch.tasks.TaskStatusHandler;
+import org.datadog.jmxfetch.util.AppTelemetry;
 import org.datadog.jmxfetch.util.ByteArraySearcher;
 import org.datadog.jmxfetch.util.CustomLogger;
 import org.datadog.jmxfetch.util.FileHelper;
 import org.datadog.jmxfetch.util.LogLevel;
 import org.datadog.jmxfetch.util.MetadataHelper;
 import org.datadog.jmxfetch.util.ServiceCheckHelper;
-import org.datadog.jmxfetch.util.AppTelemetry;
 
 import java.lang.management.ManagementFactory;
-
-import javax.management.InstanceAlreadyExistsException;
-import javax.management.NotCompliantMBeanException;
-import javax.management.MBeanRegistrationException;
-import javax.management.MBeanServer;
-import javax.management.MalformedObjectNameException;
-import javax.management.ObjectName;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -58,7 +51,16 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
 import javax.security.auth.login.FailedLoginException;
+
+import javax.management.InstanceAlreadyExistsException;
+import javax.management.MBeanRegistrationException;
+import javax.management.MBeanServer;
+import javax.management.MalformedObjectNameException;
+import javax.management.NotCompliantMBeanException;
+import javax.management.ObjectName;
+
 
 
 @SuppressWarnings("unchecked")
@@ -140,10 +142,13 @@ public class App {
         ObjectName appTelemetryBeanName;
 
         try {
-            appTelemetryBeanName = new ObjectName(appConfig.getJmxfetchTelemetryDomain() + ":name=jmxfetch_app" + ",version=" + MetadataHelper.getVersion());
+            appTelemetryBeanName = new ObjectName(
+                appConfig.getJmxfetchTelemetryDomain() + ":name=jmxfetch_app"
+                + ",version=" + MetadataHelper.getVersion());
         } catch (MalformedObjectNameException e) {
             log.warn(
-                "Could not construct bean name for jmxfetch_telemetry_domain '{}' and name 'JMXFetch'",
+                "Could not construct bean name for jmxfetch_telemetry_domain"
+                + " '{}' and name 'jmxfetch_app'",
                 appConfig.getJmxfetchTelemetryDomain());
             return;
         }

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -225,7 +225,7 @@ public class App {
             return 0;
         }
 
-        log.info("JMX Fetch " + MetadataHelper.getVersion() + " has started");
+        log.info("JMX Fetch " + this.appConfig.getVersion() + " has started");
 
         // set up the config status
         this.appConfig.updateStatus();
@@ -1082,6 +1082,7 @@ public class App {
         config.put("conf",conf);
 
         List<String> tags = new ArrayList<String>();
+        tags.add("version:" + this.appConfig.getVersion());
         config.put("tags", tags);
 
         return config;

--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -24,7 +24,6 @@ import javax.management.InstanceAlreadyExistsException;
 import javax.management.NotCompliantMBeanException;
 import javax.management.MBeanRegistrationException;
 import javax.management.MBeanServer;
-import javax.management.MBeanInfo;
 import javax.management.MalformedObjectNameException;
 import javax.management.ObjectName;
 
@@ -512,7 +511,7 @@ public class App {
                 getMetricsTasks.add(new MetricCollectionTask(instance));
             }
             if (this.appTelemetry != null) {
-                this.appTelemetry.setNumRunningInstances(this.instances.size());
+                this.appTelemetry.setRunningInstanceCount(this.instances.size());
             }
 
             if (!this.collectionProcessor.ready()) {
@@ -1152,9 +1151,8 @@ public class App {
                 instance.cleanUpAsync();
                 this.brokenInstanceMap.put(instance.toString(), instance);
                 if (this.appTelemetry != null) {
-                    this.appTelemetry.setNumBrokenInstances(this.brokenInstanceMap.size());
-                    int numBrokenInstancesTotal = this.appTelemetry.getNumBrokenInstancesTotal();
-                    this.appTelemetry.setNumBrokenInstancesTotal(numBrokenInstancesTotal + 1);
+                    this.appTelemetry.setBrokenInstanceCount(this.brokenInstanceMap.size());
+                    this.appTelemetry.incrementBrokenInstanceEventCount();
                 }
             }
         }
@@ -1177,8 +1175,8 @@ public class App {
                 this.instances.add(instance);
 
                 if (this.appTelemetry != null) {
-                    this.appTelemetry.setNumBrokenInstances(this.brokenInstanceMap.size());
-                    this.appTelemetry.setNumRunningInstances(this.instances.size());
+                    this.appTelemetry.setBrokenInstanceCount(this.brokenInstanceMap.size());
+                    this.appTelemetry.setRunningInstanceCount(this.instances.size());
                 }
 
             } catch (Throwable e) {
@@ -1293,9 +1291,8 @@ public class App {
                 this.brokenInstanceMap.put(instance.toString(), instance);
                 log.debug("Adding broken instance to list: " + instance.getName());
                 if (this.appTelemetry != null) {
-                    this.appTelemetry.setNumBrokenInstances(this.brokenInstanceMap.size());
-                    int numBrokenInstancesTotal = this.appTelemetry.getNumBrokenInstancesTotal();
-                    this.appTelemetry.setNumBrokenInstancesTotal(numBrokenInstancesTotal + 1);
+                    this.appTelemetry.setBrokenInstanceCount(this.brokenInstanceMap.size());
+                    this.appTelemetry.incrementBrokenInstanceEventCount();
                 }
 
                 log.warn(instanceMessage, ee.getCause());
@@ -1305,9 +1302,8 @@ public class App {
                 this.brokenInstanceMap.put(instance.toString(), instance);
 
                 if (this.appTelemetry != null) {
-                    this.appTelemetry.setNumBrokenInstances(this.brokenInstanceMap.size());
-                    int numBrokenInstancesTotal = this.appTelemetry.getNumBrokenInstancesTotal();
-                    this.appTelemetry.setNumBrokenInstancesTotal(numBrokenInstancesTotal + 1);
+                    this.appTelemetry.setBrokenInstanceCount(this.brokenInstanceMap.size());
+                    this.appTelemetry.incrementBrokenInstanceEventCount();
                 }
 
                 instanceStatus = Status.STATUS_ERROR;

--- a/src/main/java/org/datadog/jmxfetch/AppConfig.java
+++ b/src/main/java/org/datadog/jmxfetch/AppConfig.java
@@ -10,6 +10,7 @@ import org.datadog.jmxfetch.reporter.JsonReporter;
 import org.datadog.jmxfetch.reporter.Reporter;
 import org.datadog.jmxfetch.reporter.ReporterFactory;
 import org.datadog.jmxfetch.service.ServiceNameProvider;
+import org.datadog.jmxfetch.util.MetadataHelper;
 import org.datadog.jmxfetch.validator.LogLevelValidator;
 import org.datadog.jmxfetch.validator.PositiveIntegerValidator;
 import org.datadog.jmxfetch.validator.ReporterValidator;
@@ -512,5 +513,9 @@ public class AppConfig {
 
     public int getSocketTimeout() {
         return statsdSocketTimeout;
+    }
+
+    public String getVersion() {
+        return MetadataHelper.getVersion();
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/util/AppTelemetry.java
+++ b/src/main/java/org/datadog/jmxfetch/util/AppTelemetry.java
@@ -1,40 +1,41 @@
 package org.datadog.jmxfetch.util;
 
+import java.util.concurrent.atomic.AtomicInteger;
 
 /** Jmxfetch telemetry JMX MBean. */
 public class AppTelemetry implements AppTelemetryMBean {
-    private int numRunningInstances;
-    private int numBrokenInstances;
-    private int numBrokenInstancesTotal;
+    private AtomicInteger runningInstanceCount;
+    private AtomicInteger brokenInstanceCount;
+    private AtomicInteger brokenInstanceEventCount;
 
     /** Jmxfetch telemetry bean constructor. */
     public AppTelemetry() {
-        numRunningInstances = 0;
-        numBrokenInstances = 0;
-        numBrokenInstancesTotal = 0;
+        runningInstanceCount = new AtomicInteger(0);
+        brokenInstanceCount = new AtomicInteger(0);
+        brokenInstanceEventCount = new AtomicInteger(0);
     }
 
-    public int getNumRunningInstances() {
-        return numRunningInstances;
+    public int getRunningInstanceCount() {
+        return runningInstanceCount.get();
     }
 
-    public int getNumBrokenInstances() {
-        return numBrokenInstances;
+    public int getBrokenInstanceCount() {
+        return brokenInstanceCount.get();
     }
 
-    public int getNumBrokenInstancesTotal() {
-        return numBrokenInstancesTotal;
+    public int getBrokenInstanceEventCount() {
+        return brokenInstanceEventCount.get();
     }
 
-    public void setNumRunningInstances(int count) {
-        numRunningInstances = count;
+    public void setRunningInstanceCount(int count) {
+        this.runningInstanceCount.set(count);
     }
 
-    public void setNumBrokenInstances(int count) {
-        numBrokenInstances = count;
+    public void setBrokenInstanceCount(int count) {
+        brokenInstanceCount.set(count);
     }
 
-    public void setNumBrokenInstancesTotal(int count) {
-        numBrokenInstancesTotal = count;
+    public void incrementBrokenInstanceEventCount() {
+        brokenInstanceEventCount.incrementAndGet();
     }
 }

--- a/src/main/java/org/datadog/jmxfetch/util/AppTelemetry.java
+++ b/src/main/java/org/datadog/jmxfetch/util/AppTelemetry.java
@@ -1,0 +1,40 @@
+package org.datadog.jmxfetch.util;
+
+
+/** Jmxfetch telemetry JMX MBean. */
+public class AppTelemetry implements AppTelemetryMBean {
+    private int numRunningInstances;
+    private int numBrokenInstances;
+    private int numBrokenInstancesTotal;
+
+    /** Jmxfetch telemetry bean constructor. */
+    public AppTelemetry() {
+        numRunningInstances = 0;
+        numBrokenInstances = 0;
+        numBrokenInstancesTotal = 0;
+    }
+
+    public int getNumRunningInstances() {
+        return numRunningInstances;
+    }
+
+    public int getNumBrokenInstances() {
+        return numBrokenInstances;
+    }
+
+    public int getNumBrokenInstancesTotal() {
+        return numBrokenInstancesTotal;
+    }
+
+    public void setNumRunningInstances(int count) {
+        numRunningInstances = count;
+    }
+
+    public void setNumBrokenInstances(int count) {
+        numBrokenInstances = count;
+    }
+
+    public void setNumBrokenInstancesTotal(int count) {
+        numBrokenInstancesTotal = count;
+    }
+}

--- a/src/main/java/org/datadog/jmxfetch/util/AppTelemetryMBean.java
+++ b/src/main/java/org/datadog/jmxfetch/util/AppTelemetryMBean.java
@@ -1,0 +1,11 @@
+package org.datadog.jmxfetch.util;
+
+public interface AppTelemetryMBean {
+
+    int getNumRunningInstances();
+
+    int getNumBrokenInstances();
+
+    int getNumBrokenInstancesTotal();
+
+}

--- a/src/main/java/org/datadog/jmxfetch/util/AppTelemetryMBean.java
+++ b/src/main/java/org/datadog/jmxfetch/util/AppTelemetryMBean.java
@@ -2,10 +2,10 @@ package org.datadog.jmxfetch.util;
 
 public interface AppTelemetryMBean {
 
-    int getNumRunningInstances();
+    int getRunningInstanceCount();
 
-    int getNumBrokenInstances();
+    int getBrokenInstanceCount();
 
-    int getNumBrokenInstancesTotal();
+    int getBrokenInstanceEventCount();
 
 }

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -5,6 +5,8 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
+import org.datadog.jmxfetch.util.AppTelemetry;
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
@@ -43,6 +45,9 @@ public class TestApp extends TestCommon {
                         "nonRegexTag:value");
 
         assertMetric("this.is.100", tags, 10);
+
+        AppTelemetry tlm = app.getAppTelemetryBean();
+        assertEquals(1, tlm.getNumRunningInstances());
     }
 
     /** Tag metrics with MBeans parameters. */
@@ -72,6 +77,9 @@ public class TestApp extends TestCommon {
                         "component");
 
         assertMetric("this.is.100", tags, 7);
+
+        AppTelemetry tlm = app.getAppTelemetryBean();
+        assertEquals(1, tlm.getNumRunningInstances());
     }
 
     /** Tag metrics with MBeans parameters with normalize_bean_param_tags option enabled. */

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -47,7 +47,7 @@ public class TestApp extends TestCommon {
         assertMetric("this.is.100", tags, 10);
 
         AppTelemetry tlm = app.getAppTelemetryBean();
-        assertEquals(1, tlm.getNumRunningInstances());
+        assertEquals(1, tlm.getRunningInstanceCount());
     }
 
     /** Tag metrics with MBeans parameters. */
@@ -79,7 +79,7 @@ public class TestApp extends TestCommon {
         assertMetric("this.is.100", tags, 7);
 
         AppTelemetry tlm = app.getAppTelemetryBean();
-        assertEquals(1, tlm.getNumRunningInstances());
+        assertEquals(1, tlm.getRunningInstanceCount());
     }
 
     /** Tag metrics with MBeans parameters with normalize_bean_param_tags option enabled. */

--- a/src/test/java/org/datadog/jmxfetch/TestApp.java
+++ b/src/test/java/org/datadog/jmxfetch/TestApp.java
@@ -1168,4 +1168,29 @@ public class TestApp extends TestCommon {
 
         assertCoverage();
     }
+
+    @Test
+    public void testTelemetryTags() throws Exception {
+        SimpleTestJavaApp testApp = new SimpleTestJavaApp();
+        registerMBean(testApp, "org.datadog.jmxfetch.test:type=SimpleTestJavaApp");
+
+        when(appConfig.isTargetDirectInstances()).thenReturn(true);
+        when(appConfig.getJmxfetchTelemetry()).thenReturn(true);
+        when(appConfig.getVersion()).thenReturn("MOCKED_VERSION");
+
+        initApplication("jmx_telemetry_tags.yaml");
+
+        run();
+
+        List<String> telemetryTags = Arrays.asList(
+                "instance:jmxfetch_telemetry_instance",
+                "name:jmxfetch_app",
+                "jmx_domain:jmx_fetch",
+                "version:MOCKED_VERSION");
+
+        assertMetric("jmx.jmx_fetch.running_instance_count", 2, telemetryTags, -1);
+
+        // not asserting coverage, this is intended to test the tags present on telemetry
+        // not the set metrics collected
+    }
 }

--- a/src/test/java/org/datadog/jmxfetch/TestCommon.java
+++ b/src/test/java/org/datadog/jmxfetch/TestCommon.java
@@ -109,12 +109,13 @@ public class TestCommon {
     }
 
     /**
-     * Clear instances and their instance telemetry bean after execution of every test.
+     * Tear down instances and application.
      */
     @After
-    public void clearInstances() {
+    public void teardown() {
         if (app != null) {
             app.clearAllInstances();
+            app.stop();
         }
     }
 
@@ -176,7 +177,7 @@ public class TestCommon {
     }
 
     /*
-     * Init JMXFetch with the given YAML configuration template 
+     * Init JMXFetch with the given YAML configuration template
      * The configuration can be specified as a yaml literal with each arg
      * representing one line of the Yaml file
      * Does not support any SD/AD features.
@@ -188,7 +189,7 @@ public class TestCommon {
 
         String confdDirectory = tempFile.getParent().toString();
         String yamlFileName = tempFile.getFileName().toString();
-        
+
         List<String> params = new ArrayList<String>();
         params.add("--reporter");
         params.add("console");

--- a/src/test/resources/jmx_telemetry_tags.yaml
+++ b/src/test/resources/jmx_telemetry_tags.yaml
@@ -1,0 +1,14 @@
+---
+init_config:
+
+instances:
+  - jvm_direct: true
+    refresh_beans: 4
+    collect_default_jvm_metrics: false
+    name: jmx_test_instance
+    tags:
+      - "env:stage"
+      - "newTag:test"
+    conf:
+      - include:
+          domain: org.datadog.jmxfetch.test


### PR DESCRIPTION
This utilizes the existing `jmxfetch_telemetry_instance` that was configured as part of #467  and establishes a similar bean for Application level metrics of interest.

Initially this will be 3 metrics:
- count of currently running instances
- count of currently broken instances
- count of broken instance events that have occurred.

