### PR TITLE
Adds maven-compiler-plugin and turns on linter warnings

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,6 @@
     </developers>
 
     <properties>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
-
         <commons-io.version>2.4</commons-io.version>
         <apache-commons-lang3.version>3.5</apache-commons-lang3.version>
         <java-dogstatsd-client.version>2.10.5</java-dogstatsd-client.version>
@@ -57,6 +54,7 @@
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
+        <maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -257,6 +255,18 @@
                     <attach>true</attach>
                     <!--make it available for jar/war classpath resource -->
                     <addOutputDirectoryToResources>true</addOutputDirectoryToResources>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                    <compilerArgs>
+                        <arg>-Xlint:all</arg>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Currently have mostly unchecked-cast warnings, but a few others mixed in. This change should not go in without fixing the current linter errors _and_ enforcing this via CI