### PR TITLE
Improves surefire test failure output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,8 @@
                     <!-- allowAttachSelf required for tests in jdk9+ ref https://bugs.openjdk.org/browse/JDK-8180425 -->
                     <!-- rmi.server.hostname required for tests in some MacOS configurations -->
                     <argLine>-Djdk.attach.allowAttachSelf=true -Djava.rmi.server.hostname=localhost</argLine>
+                    <useFile>false</useFile>
+                    <trimStackTrace>false</trimStackTrace> <!-- can remove once surefire 3.0 is used. ref: https://issues.apache.org/jira/browse/SUREFIRE-1432 -->
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Before:
```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Running org.datadog.jmxfetch.TestApp
Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.383 sec <<< FAILURE!

Results :

Tests in error:
  testTelemetryTags(org.datadog.jmxfetch.TestApp):

Tests run: 1, Failures: 0, Errors: 1, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
```

After:
```
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 0.492 sec <<< FAILURE!
testTelemetryTags(org.datadog.jmxfetch.TestApp)  Time elapsed: 0.415 sec  <<< FAILURE!
java.lang.AssertionError:
Expected: a collection containing "instance:jmx_telemetry_instance"
     but: was "version:MOCKED_VERSION", was "instance:jmxfetch_telemetry_instance", was "dd.internal.jmx_check_name:jmxfetch_telemetry_check", was "jmx_domain:jmx_fetch", was "name:jmxfetch_app"
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:8)
        at org.datadog.jmxfetch.util.MetricsAssert.assertMetric(MetricsAssert.java:54)
        at org.datadog.jmxfetch.TestCommon.assertMetric(TestCommon.java:261)
        at org.datadog.jmxfetch.TestCommon.assertMetric(TestCommon.java:282)
        at org.datadog.jmxfetch.TestCommon.assertMetric(TestCommon.java:325)
        at org.datadog.jmxfetch.TestApp.testTelemetryTags(TestApp.java:1193)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
        at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
        at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
        at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
        at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
        at org.apache.maven.surefire.junit4.JUnit4TestSet.execute(JUnit4TestSet.java:45)
        at org.apache.maven.surefire.junit4.JUnit4Provider.executeTestSet(JUnit4Provider.java:123)
        at org.apache.maven.surefire.junit4.JUnit4Provider.invoke(JUnit4Provider.java:104)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.apache.maven.surefire.util.ReflectionUtils.invokeMethodWithArray(ReflectionUtils.java:164)
        at org.apache.maven.surefire.booter.ProviderFactory$ProviderProxy.invoke(ProviderFactory.java:110)
        at org.apache.maven.surefire.booter.SurefireStarter.invokeProvider(SurefireStarter.java:172)
        at org.apache.maven.surefire.booter.SurefireStarter.runSuitesInProcessWhenForked(SurefireStarter.java:104)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:70)

Results :

Failed tests:   testTelemetryTags(org.datadog.jmxfetch.TestApp):

Tests run: 1, Failures: 1, Errors: 0, Skipped: 0

[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.363 s
[INFO] Finished at: 2024-01-02T11:36:01-05:00
```

I believe this also makes https://github.com/DataDog/jmxfetch/blob/master/.circleci/config.yml#L38 irrelevant, will save for a future circle-ci cleanup.