### PR TITLE
AMLII-1358 - Updated Generational ZGC to use Major and Minor GC metric names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 # 0.49.1 / TBD
-* [FEATURE] Add ZGC Major and Minor Cycles and ZGC Major and Minor Pauses beans support out of the box (Generational ZGC support) [#502][]
+* [FEATURE] Add ZGC Major and Minor Cycles and ZGC Major and Minor Pauses beans support out of the box (Generational ZGC support) [#509][]
 
 # 0.49.0 / 2023-11-10
 * [FEATURE] Adds more per-instance telemetry data around bean matching
@@ -762,7 +762,7 @@ Changelog
 [#449]: https://github.com/DataDog/jmxfetch/issues/449
 [#469]: https://github.com/DataDog/jmxfetch/issues/469
 [#477]: https://github.com/DataDog/jmxfetch/issues/477
-[#502]: https://github.com/DataDog/jmxfetch/issues/502
+[#509]: https://github.com/DataDog/jmxfetch/issues/509
 [@alz]: https://github.com/alz
 [@aoking]: https://github.com/aoking
 [@arrawatia]: https://github.com/arrawatia

--- a/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
+++ b/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
@@ -1,4 +1,4 @@
-
+---
 # Young Gen Collectors (Minor Collections)
 - include:
     domain: java.lang
@@ -155,10 +155,10 @@
     name: ZGC Major Cycles
     attribute:
       CollectionCount:
-        alias: jvm.gc.zgc_cycles_collection_count
+        alias: jvm.gc.major_collection_count
         metric_type: counter
       CollectionTime:
-        alias: jvm.gc.zgc_cycles_collection_time
+        alias: jvm.gc.major_collection_time
         metric_type: counter
 - include:
     domain: java.lang
@@ -166,10 +166,10 @@
     name: ZGC Major Pauses
     attribute:
       CollectionCount:
-        alias: jvm.gc.zgc_pauses_collection_count
+        alias: jvm.gc.major_collection_count
         metric_type: counter
       CollectionTime:
-        alias: jvm.gc.zgc_pauses_collection_time
+        alias: jvm.gc.major_collection_time
         metric_type: counter
 - include:
     domain: java.lang
@@ -177,10 +177,10 @@
     name: ZGC Minor Cycles
     attribute:
       CollectionCount:
-        alias: jvm.gc.zgc_cycles_collection_count
+        alias: jvm.gc.minor_collection_count
         metric_type: counter
       CollectionTime:
-        alias: jvm.gc.zgc_cycles_collection_time
+        alias: jvm.gc.minor_collection_time
         metric_type: counter
 - include:
     domain: java.lang
@@ -188,8 +188,8 @@
     name: ZGC Minor Pauses
     attribute:
       CollectionCount:
-        alias: jvm.gc.zgc_pauses_collection_count
+        alias: jvm.gc.minor_collection_count
         metric_type: counter
       CollectionTime:
-        alias: jvm.gc.zgc_pauses_collection_time
+        alias: jvm.gc.minor_collection_time
         metric_type: counter

--- a/src/test/java/org/datadog/jmxfetch/TestGCMetrics.java
+++ b/src/test/java/org/datadog/jmxfetch/TestGCMetrics.java
@@ -136,15 +136,15 @@ public class TestGCMetrics extends TestCommon {
             assertThat(actualMetrics, hasSize(17));
             final List<String> gcCycles = Arrays.asList(
                 "ZGC Major Cycles",
-                "ZGC Minor Cycles");
-            assertGCMetric(actualMetrics, "jvm.gc.zgc_cycles_collection_count", gcCycles);
-            assertGCMetric(actualMetrics, "jvm.gc.zgc_cycles_collection_time", gcCycles);
+                "ZGC Major Pauses");
+            assertGCMetric(actualMetrics, "jvm.gc.major_collection_count", gcCycles);
+            assertGCMetric(actualMetrics, "jvm.gc.major_collection_time", gcCycles);
 
             final List<String> gcPauses = Arrays.asList(
-                "ZGC Major Pauses",
+                "ZGC Minor Cycles",
                 "ZGC Minor Pauses");
-            assertGCMetric(actualMetrics, "jvm.gc.zgc_pauses_collection_count", gcPauses);
-            assertGCMetric(actualMetrics, "jvm.gc.zgc_pauses_collection_time", gcPauses);
+            assertGCMetric(actualMetrics, "jvm.gc.minor_collection_count", gcPauses);
+            assertGCMetric(actualMetrics, "jvm.gc.minor_collection_time", gcPauses);
         }
     }
 


### PR DESCRIPTION
This changes the way we map Generational ZGC beans. As this now behaves like previous Garbage collectors that had generations it makes more sense to map them to `Major` and `Minor` GC metrics. This means that:

- `ZGC Major Cycles` and `ZGC Major Pauses` get mapped to `jvm.gc.major_collection_<count/time>`
- `ZGC Minor Cycles` and `ZGC Minor Pauses ` get mapped to `jvm.gc.minor_collection_<count/time>`

The benefit of this is that JVM Metrics dashboard that support `Major` and `Minor` GC metrics will be useable with Generational ZGC.

As we haven't release a new version of JMXFetch, no one should be using the previous mappings in #502.