### PR TITLE
Reorders test after-hooks to avoid erroneous warning log

### DIFF
--- a/src/test/java/org/datadog/jmxfetch/TestCommon.java
+++ b/src/test/java/org/datadog/jmxfetch/TestCommon.java
@@ -99,8 +99,7 @@ public class TestCommon {
      * @throws InstanceNotFoundException
      * @throws MBeanRegistrationException
      */
-    @After
-    public void unregisterMBean() throws MBeanRegistrationException, InstanceNotFoundException {
+    public void unregisterMBeans() throws MBeanRegistrationException, InstanceNotFoundException {
         if (mbs != null) {
             for (ObjectName objectName : objectNames) {
                 mbs.unregisterMBean(objectName);
@@ -116,6 +115,11 @@ public class TestCommon {
         if (app != null) {
             app.clearAllInstances();
             app.stop();
+        }
+        try {
+            unregisterMBeans();
+        } catch (MBeanRegistrationException | InstanceNotFoundException e) {
+            // Ignore
         }
     }
 


### PR DESCRIPTION
In the Application teardown, there is an attempt to un-register the app telemetry mbean. However in the tests, there is a race between the `@After` hook to tear down any mbeans created by the tests and the `@After` hook to tear down the application itself. This is harmless, but produces a warning log when the app tries to un-register the application telemetry bean.

This changes the ordering to always stop the application first, which avoids the erroneous warning log.