### PR TITLE
Adds option to emit logs with millisecond timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,16 @@ If you are an sdkman user, there is a config file present in this project with
 the recommended JDK version for development, use `sdk env` to activate it.
 
 
-### Enabling file line numbers in log messages
-If you set the system property `-Djmxfetch.filelinelogging=true`, this will enable all log output to
-include the line number which emitted a given log.
+### Logging Options
+The logging output is configured in code in `CustomLogger.java`.
+The following system properties will affect the format of the log records.
+
+- `-Djmxfetch.filelinelogging=true`
+    - All log records will include the specific file and line number which emitted
+      that log.
+- `-Djmxfetch.millisecondlogging=true`
+    - All log records will include milliseconds in the timestamp, rather than the default
+      'second' timestamp resolution.
 
 ### Local Testing
 You can utilize the provided testing server `misbehaving-jmx-server` with the

--- a/src/main/java/org/datadog/jmxfetch/util/CustomLogger.java
+++ b/src/main/java/org/datadog/jmxfetch/util/CustomLogger.java
@@ -33,8 +33,13 @@ public class CustomLogger {
 
     // Enable by setting -Djmxfetch.filelinelogging,
     // if true, log record will include the source file and line number
-    private static boolean enableFileLineLogging = 
+    private static boolean enableFileLineLogging =
         System.getProperty("jmxfetch.filelinelogging", "false").equals("true");
+
+    // Enable by setting -Djmxfetch.millisecondLogging,
+    // if true, log record will include milliseconds
+    private static boolean millisecondLogging =
+        System.getProperty("jmxfetch.millisecondLogging", "false").equals("true");
 
     private static final ConcurrentHashMap<String, AtomicInteger> messageCount
             = new ConcurrentHashMap<String, AtomicInteger>();
@@ -63,7 +68,10 @@ public class CustomLogger {
     public static synchronized void setup(LogLevel level, String logLocation,
                              boolean logFormatRfc3339) {
         String target = "CONSOLE";
-        final String dateFormat = logFormatRfc3339 ? DATE_JDK14_LAYOUT_RFC3339 : DATE_JDK14_LAYOUT;
+        String dateFormat = logFormatRfc3339 ? DATE_JDK14_LAYOUT_RFC3339 : DATE_JDK14_LAYOUT;
+        if (millisecondLogging) {
+            dateFormat = dateFormat.replace("ss", "ss.SSS");
+        }
         final SimpleDateFormat dateFormatter = new SimpleDateFormat(dateFormat,
                                                             Locale.getDefault());
 


### PR DESCRIPTION
JMXFetch by default writes logs with second-level resolution. In development, it is sometimes useful to be able to enable higher-resolution timestamps to see the ordering of various operations.

This PR adds an option to add millisecond-resolution timestamps to logs.