### PR TITLE
[AMLII-1828] Cleaning up pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
         <javax.management.j2ee-api.version>1.1.2</javax.management.j2ee-api.version>
         <jcommander.version>1.35</jcommander.version>
         <junit.version>4.13.2</junit.version>
-        <lombok.version>1.18.22</lombok.version>
+        <lombok.version>1.18.32</lombok.version>
         <mockito.version>2.28.2</mockito.version>
         <slf4j.version>1.7.32</slf4j.version>
         <snakeyaml.version>2.0</snakeyaml.version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,6 +43,7 @@
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.9</maven-surefire-plugin.version>
+        <nexus-staging-maven-plugin.version>1.7.0</nexus-staging-maven-plugin.version>
         <!-- Note: using project checkstyle with AOSP style
         find the default google java checkstyle config here -
         <checkstyle.config.location>google_checks.xml</checkstyle.config.location>
@@ -99,7 +100,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <version>${nexus-staging-maven-plugin.version}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>nexus</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
 
         <apache-commons-lang3.version>3.5</apache-commons-lang3.version>
         <commons-io.version>2.4</commons-io.version>
-        <hamcrest-library.version>1.3</hamcrest-library.version>
+        <hamcrest.version>2.2</hamcrest.version>
         <jackson.version>2.12.3</jackson.version>
         <java-dogstatsd-client.version>2.10.5</java-dogstatsd-client.version>
         <javax.management.j2ee-api.version>1.1.2</javax.management.j2ee-api.version>
@@ -216,8 +216,14 @@
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest</artifactId>
+            <version>${hamcrest.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>${hamcrest-library.version}</version>
+            <version>${hamcrest.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
 
-        <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
+        <buildnumber-maven-plugin.version>3.1.0</buildnumber-maven-plugin.version>
         <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <maven-deploy-plugin.version>3.1.2</maven-deploy-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,7 @@
         <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+        <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-surefire-plugin.version>2.9</maven-surefire-plugin.version>
@@ -48,22 +49,22 @@
          -->
         <checkstyle.config.location>style.xml</checkstyle.config.location>
 
-        <commons-io.version>2.4</commons-io.version>
         <apache-commons-lang3.version>3.5</apache-commons-lang3.version>
+        <commons-io.version>2.4</commons-io.version>
+        <hamcrest-library.version>1.3</hamcrest-library.version>
+        <jackson.version>2.12.3</jackson.version>
         <java-dogstatsd-client.version>2.10.5</java-dogstatsd-client.version>
         <javax.management.j2ee-api.version>1.1.2</javax.management.j2ee-api.version>
         <jcommander.version>1.35</jcommander.version>
-        <slf4j.version>1.7.32</slf4j.version>
-        <jackson.version>2.12.3</jackson.version>
-        <snakeyaml.version>2.0</snakeyaml.version>
         <junit.version>4.13.2</junit.version>
+        <lombok.version>1.18.22</lombok.version>
         <mockito.version>2.28.2</mockito.version>
+        <slf4j.version>1.7.32</slf4j.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
+        <testcontainers.version>1.19.8</testcontainers.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.scm.id>github</project.scm.id>
-        <lombok.version>1.18.22</lombok.version>
-        <testcontainers.version>1.19.8</testcontainers.version>
-        <hamcrest-library.version>1.3</hamcrest-library.version>
     </properties>
 
     <profiles>
@@ -111,7 +112,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>${maven-gpg-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
         <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
-        <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+        <maven-deploy-plugin.version>3.1.2</maven-deploy-plugin.version>
         <maven-gpg-plugin.version>3.2.4</maven-gpg-plugin.version>
         <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.scm.id>github</project.scm.id>
         <lombok.version>1.18.22</lombok.version>
-        <testcontainers.version>1.19.3</testcontainers.version>
+        <testcontainers.version>1.19.8</testcontainers.version>
         <hamcrest-library.version>1.3</hamcrest-library.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,32 +35,35 @@
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
 
-        <commons-io.version>2.4</commons-io.version>
-        <apache-commons-lang3.version>3.5</apache-commons-lang3.version>
-        <java-dogstatsd-client.version>2.10.5</java-dogstatsd-client.version>
-        <jcommander.version>1.35</jcommander.version>
-        <slf4j.version>1.7.32</slf4j.version>
-        <jackson.version>2.12.3</jackson.version>
-        <snakeyaml.version>2.0</snakeyaml.version>
+        <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
+        <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
+        <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
         <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+        <maven-javadoc-plugin.version>3.2.0</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-surefire-plugin.version>2.9</maven-surefire-plugin.version>
         <!-- Note: using project checkstyle with AOSP style
         find the default google java checkstyle config here -
         <checkstyle.config.location>google_checks.xml</checkstyle.config.location>
          -->
         <checkstyle.config.location>style.xml</checkstyle.config.location>
 
-
+        <commons-io.version>2.4</commons-io.version>
+        <apache-commons-lang3.version>3.5</apache-commons-lang3.version>
+        <java-dogstatsd-client.version>2.10.5</java-dogstatsd-client.version>
+        <javax.management.j2ee-api.version>1.1.2</javax.management.j2ee-api.version>
+        <jcommander.version>1.35</jcommander.version>
+        <slf4j.version>1.7.32</slf4j.version>
+        <jackson.version>2.12.3</jackson.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
         <junit.version>4.13.2</junit.version>
         <mockito.version>2.28.2</mockito.version>
 
-        <maven-surefire-plugin.version>2.9</maven-surefire-plugin.version>
-        <buildnumber-maven-plugin.version>1.4</buildnumber-maven-plugin.version>
-        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
-        <maven-assembly-plugin.version>3.1.0</maven-assembly-plugin.version>
-
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-
         <project.scm.id>github</project.scm.id>
+        <lombok.version>1.18.22</lombok.version>
+        <testcontainers.version>1.19.3</testcontainers.version>
+        <hamcrest-library.version>1.3</hamcrest-library.version>
     </properties>
 
     <profiles>
@@ -166,7 +169,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>1.18.22</version>
+            <version>${lombok.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -188,7 +191,7 @@
         <dependency>
             <groupId>javax.management.j2ee</groupId>
             <artifactId>javax.management.j2ee-api</artifactId>
-            <version>1.1.2</version>
+            <version>${javax.management.j2ee-api.version}</version>
             <scope>test</scope>
         </dependency>
 
@@ -207,13 +210,13 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.19.3</version>
+            <version>${testcontainers.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
-            <version>1.3</version>
+            <version>${hamcrest-library.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -284,7 +287,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>${maven-javadoc-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>
@@ -325,7 +328,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>${maven-checkstyle-plugin.version}</version>
                 <executions>
                     <execution>
                         <id>checkstyle</id>
@@ -361,7 +364,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>${maven-checkstyle-plugin.version}</version>
                 <reportSets>
                     <reportSet>
                         <reports>


### PR DESCRIPTION
Cleaned up the `pom.xml` and bumped some of the dependencies. Deployments still work after all the changes (see `SNAPSHOT` [here](https://oss.sonatype.org/content/repositories/snapshots/com/datadoghq/jmxfetch/0.49.3-SNAPSHOT/jmxfetch-0.49.3-20240710.153833-10.pom)).