### PR TITLE
`max_returned_metrics`: parse string value with fallback

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -164,7 +164,9 @@ public class Instance {
             try {
                 this.maxReturnedMetrics = Integer.parseInt((String) maxReturnedMetrics);
             } catch (NumberFormatException e) {
-                log.warn("Cannot convert max_returned_metrics to integer in your instance configuration. Defaulting to '{}'.", MAX_RETURNED_METRICS);
+                log.warn(
+                    "Cannot convert max_returned_metrics to integer in your instance configuration. Defaulting to '{}'.",
+                    MAX_RETURNED_METRICS);
                 this.maxReturnedMetrics = MAX_RETURNED_METRICS;
             }
         } else {

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -160,6 +160,13 @@ public class Instance {
         Object maxReturnedMetrics = this.instanceMap.get("max_returned_metrics");
         if (maxReturnedMetrics == null) {
             this.maxReturnedMetrics = MAX_RETURNED_METRICS;
+        } else if (maxReturnedMetrics instanceof String) {
+            try {
+                this.maxReturnedMetrics = Integer.parseInt((String) maxReturnedMetrics);
+            } catch (NumberFormatException e) {
+                log.warn("Cannot convert max_returned_metrics to integer in your instance configuration. Defaulting to '{}'.", MAX_RETURNED_METRICS);
+                this.maxReturnedMetrics = MAX_RETURNED_METRICS;
+            }
         } else {
             this.maxReturnedMetrics = (Integer) maxReturnedMetrics;
         }

--- a/src/test/java/org/datadog/jmxfetch/TestInstance.java
+++ b/src/test/java/org/datadog/jmxfetch/TestInstance.java
@@ -97,6 +97,31 @@ public class TestInstance extends TestCommon {
         }
     }
 
+    @Test
+    public void testParsableMaxReturnedMetrics() throws Exception {
+        SimpleTestJavaApp testApp = new SimpleTestJavaApp();
+        // Populate testApp with a lot of metrics (>350) !
+        testApp.populateHashMap(400);
+        // Exposing a few metrics through JMX
+        registerMBean(testApp, "org.datadog.jmxfetch.test:type=ParsableMaxReturnedMetricsTest");
+        initApplication("jmx_parsable_max_returned_metrics_string.yaml");
+        run();
+
+        List<Map<String, Object>> metrics = getMetrics();
+        assertEquals(429, metrics.size());
+    }
+
+    @Test
+    public void testNonParsableMaxReturnedMetrics() throws Exception {
+        registerMBean(new SimpleTestJavaApp(), "org.datadog.jmxfetch.test:type=NonParsableMaxReturnedMetricsTest");
+        initApplication("jmx_non_parsable_max_returned_metrics_string.yaml");
+        run();
+
+        // Despite non parsable max_returned_metrics, metrics should still be collected.
+        List<Map<String, Object>> metrics = getMetrics();
+        assertEquals(29, metrics.size());
+    }
+
     // assertServiceTags is used by testServiceTagGlobal and testServiceTagInstanceOverride
     private void assertServiceTag(List<String> tagList, List<String> services) throws Exception {
         for (String service: services) {

--- a/src/test/resources/jmx_non_parsable_max_returned_metrics_string.yaml
+++ b/src/test/resources/jmx_non_parsable_max_returned_metrics_string.yaml
@@ -1,0 +1,9 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        max_returned_metrics: "foo"
+        conf:
+            - include:
+               domain: org.datadog.jmxfetch.test

--- a/src/test/resources/jmx_parsable_max_returned_metrics_string.yaml
+++ b/src/test/resources/jmx_parsable_max_returned_metrics_string.yaml
@@ -1,0 +1,9 @@
+init_config:
+
+instances:
+    -   process_name_regex: .*surefire.*
+        name: jmx_test_instance
+        max_returned_metrics: "500"
+        conf:
+            - include:
+               domain: org.datadog.jmxfetch.test


### PR DESCRIPTION
### What does this PR do ?
This PR allows the use of integer string value for the `max_returned_metrics` parameter. If the string cannot be parsed, falls back to default limit instead.

### Motivation
Recent customer case where their JMX configuration would not work once they added `max_returned_metrics`. As they were using k8s annotations, they tried to use a string in the JSON instead of the integer, causing the instance not to be loaded with the error message `Unable to create instance. Please check your yaml file` : 
```json
{
  "instances": [
    {
      "host": "%%host%%",
      "port": 9999,
      "max_returned_metrics": "2000"
    }
  ]
}
```
instead of
```json
{
  "instances": [
    {
      "host": "%%host%%",
      "port": 9999,
      "max_returned_metrics": 2000
    }
  ]
}
```
With this PR, both syntaxes would work.