### PR TITLE
Fixing NullPointerException with jboss_wildfly integration and user/password not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changelog
 =========
 # 0.49.6 / TBC
+* [BUGFIX] Fixed `NullPointerException` on JBoss when user and password not set [#546][]
 
 # 0.49.5 / 2024-10-24
 * [FEATURE] Added support for `UnloadedClassCount` metric [#540][]
@@ -787,6 +788,7 @@ Changelog
 [#531]: https://github.com/DataDog/jmxfetch/issues/531
 [#534]: https://github.com/DataDog/jmxfetch/issues/534
 [#540]: https://github.com/DataDog/jmxfetch/issues/540
+[#546]: https://github.com/DataDog/jmxfetch/issues/546
 [@alz]: https://github.com/alz
 [@aoking]: https://github.com/aoking
 [@arrawatia]: https://github.com/arrawatia

--- a/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
+++ b/src/main/java/org/datadog/jmxfetch/RemoteConnection.java
@@ -59,8 +59,13 @@ public class RemoteConnection extends Connection {
             rmiConnectionTimeout = DEFAULT_RMI_CONNECTION_TIMEOUT;
         }
 
-        user = (String) connectionParams.get("user");
-        password = (String) connectionParams.get("password");
+        if (connectionParams.containsKey("user") && connectionParams.containsKey("password")) {
+            if (connectionParams.get("user") != null && connectionParams.get("password") != null) {
+                user = (String) connectionParams.get("user");
+                password = (String) connectionParams.get("password");
+            }
+        }
+
         jmxUrl = (String) connectionParams.get("jmx_url");
 
         if (connectionParams.containsKey("path")) {
@@ -109,7 +114,13 @@ public class RemoteConnection extends Connection {
             new JmxfetchRmiClientSocketFactory(rmiTimeout, rmiConnectionTimeout, useSsl);
         environment.put("com.sun.jndi.rmi.factory.socket", csf);
         environment.put(RMIConnectorServer.RMI_CLIENT_SOCKET_FACTORY_ATTRIBUTE, csf);
-        environment.put(JMXConnector.CREDENTIALS, new String[] { user, password });
+
+        // Don't set `JMXConnector.CREDENTIALS` if `user` or `password` null as this will cause
+        // a `NullPointerException` when creating a remote connection if null
+        // https://github.com/DataDog/jmxfetch/issues/545
+        if (this.user != null && this.password != null) {
+            environment.put(JMXConnector.CREDENTIALS, new String[] { user, password });
+        }
         return environment;
     }
 


### PR DESCRIPTION
This should fix #545 as we now check if user or password no `null` before setting `jmx.remote.credentials`.

According to the docs, the `CREDENTIALS` attribute specifies the authentication credentials to be used in establishing a connection. They should be a user name **and** password as the corresponding value passed to `CREDENTIALS` is a 2–element string array containing the user name at index 0 and the password at index 1.