### PR TITLE
Encapsulate JsonParser error type

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/App.java
+++ b/src/main/java/org/datadog/jmxfetch/App.java
@@ -2,7 +2,6 @@ package org.datadog.jmxfetch;
 
 import static org.datadog.jmxfetch.Instance.isDirectInstance;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.extern.slf4j.Slf4j;
 
 import org.datadog.jmxfetch.reporter.Reporter;
@@ -15,7 +14,6 @@ import org.datadog.jmxfetch.util.ByteArraySearcher;
 import org.datadog.jmxfetch.util.CustomLogger;
 import org.datadog.jmxfetch.util.FileHelper;
 import org.datadog.jmxfetch.util.LogLevel;
-import org.datadog.jmxfetch.util.MetadataHelper;
 import org.datadog.jmxfetch.util.ServiceCheckHelper;
 
 import java.io.ByteArrayInputStream;
@@ -150,7 +148,7 @@ public class App {
 
         try {
             mbs.registerMBean(bean, appTelemetryBeanName);
-            log.debug("Succesfully registered app telemetry bean");
+            log.debug("Successfully registered app telemetry bean");
         } catch (InstanceAlreadyExistsException
                  | MBeanRegistrationException
                  | NotCompliantMBeanException e) {
@@ -186,7 +184,7 @@ public class App {
 
         try {
             mbs.registerMBean(bean, appTelemetryBeanName);
-            log.debug("Succesfully registered app telemetry bean");
+            log.debug("Successfully registered app telemetry bean");
         } catch (InstanceAlreadyExistsException
          | MBeanRegistrationException
          | NotCompliantMBeanException e) {
@@ -207,7 +205,7 @@ public class App {
 
         try {
             mbs.unregisterMBean(appTelemetryBeanName);
-            log.debug("Succesfully unregistered app telemetry bean");
+            log.debug("Successfully unregistered app telemetry bean");
         } catch (MBeanRegistrationException | InstanceNotFoundException e) {
             log.warn("Could not unregister bean named '{}' for instance: ",
                 appTelemetryBeanName.toString(), e);
@@ -409,7 +407,7 @@ public class App {
 
             if (this.addConfig(name, yaml)) {
                 reinit = true;
-                log.debug("Configuration added succesfully reinit in order");
+                log.debug("Configuration added successfully reinit in order");
             } else {
                 log.debug("Unable to apply configuration.");
             }
@@ -840,7 +838,7 @@ public class App {
                     log.debug("received config for check '" + checkName + "'");
                 }
             }
-        } catch (JsonProcessingException e) {
+        } catch (JsonParser.JsonException e) {
             log.error("error processing JSON response: " + e);
         } catch (IOException e) {
             log.error("unable to collect remote JMX configs: " + e);

--- a/src/main/java/org/datadog/jmxfetch/JsonParser.java
+++ b/src/main/java/org/datadog/jmxfetch/JsonParser.java
@@ -1,5 +1,6 @@
 package org.datadog.jmxfetch;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.jr.ob.JSON;
 
 import java.io.IOException;
@@ -11,10 +12,34 @@ import java.util.Map;
 @SuppressWarnings("unchecked")
 class JsonParser {
 
+    /**
+     * Hide the jackson exception inside the wrapper to avoid a dependency on jackson outside of
+     * this class to distinguish between IO and JSON errors. It's needed for Java Tracer, which
+     * embeds JMXFetch, excluding jackson transitive dependencies that are not needed or exercised
+     * for Java Tracer use cases.
+     */
+    public static final class JsonException extends IOException {
+        private final Exception exception;
+
+        public JsonException(Exception exception) {
+            super();
+            this.exception = exception;
+        }
+
+        @Override
+        public String toString() {
+            return exception.toString();
+        }
+    }
+
     private Map<String, Object> parsedJson;
 
     public JsonParser(InputStream jsonInputStream) throws IOException {
-        parsedJson = JSON.std.mapFrom(new InputStreamReader(jsonInputStream));
+        try {
+            parsedJson = JSON.std.mapFrom(new InputStreamReader(jsonInputStream));
+        } catch (JsonProcessingException ex) {
+            throw new JsonException(ex);
+        }
     }
 
     public JsonParser(JsonParser other) {


### PR DESCRIPTION
Hide the jackson exception inside the wrapper to avoid a dependency on jackson outside of this class to distinguish between IO and JSON errors. It's needed for Java Tracer, which embeds JMXFetch, excluding jackson transitive dependencies that are not needed or exercised for Java Tracer use cases.

This is required for Java Tracer, which has JMXFetch embedded in native builds builds https://github.com/DataDog/dd-trace-java/pull/8569.