### PR TITLE
Migrate from snakeyaml to snakeyaml-engine

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <lombok.version>1.18.32</lombok.version>
         <mockito.version>2.28.2</mockito.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <snakeyaml.version>2.0</snakeyaml.version>
+        <snakeyaml-engine.version>2.9</snakeyaml-engine.version>
         <testcontainers.version>1.19.8</testcontainers.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -186,9 +186,9 @@
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>${snakeyaml.version}</version>
+            <groupId>org.snakeyaml</groupId>
+            <artifactId>snakeyaml-engine</artifactId>
+            <version>${snakeyaml-engine.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.management.j2ee</groupId>

--- a/src/main/java/org/datadog/jmxfetch/Status.java
+++ b/src/main/java/org/datadog/jmxfetch/Status.java
@@ -5,7 +5,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.datadog.jmxfetch.util.InstanceTelemetry;
 import org.datadog.jmxfetch.util.MetadataHelper;
-import org.yaml.snakeyaml.Yaml;
+import org.snakeyaml.engine.v2.api.Dump;
+import org.snakeyaml.engine.v2.api.DumpSettings;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -147,16 +148,17 @@ public class Status {
     }
 
     private String generateYaml() {
-        Map<String, Object> status = new HashMap<String, Object>();
+        Map<String, Object> status = new HashMap<>();
         status.put("info", this.info);
         status.put("timestamp", System.currentTimeMillis());
         status.put("checks", this.instanceStats);
         status.put("errors", this.errors);
-        return new Yaml().dump(status);
+        DumpSettings settings = DumpSettings.builder().build();
+        return new Dump(settings).dumpToString(status);
     }
 
     private String generateJson() throws IOException {
-        Map<String, Object> status = new HashMap<String, Object>();
+        Map<String, Object> status = new HashMap<>();
         status.put("info", this.info);
         status.put("timestamp", System.currentTimeMillis());
         status.put("checks", this.instanceStats);

--- a/src/main/java/org/datadog/jmxfetch/YamlParser.java
+++ b/src/main/java/org/datadog/jmxfetch/YamlParser.java
@@ -1,22 +1,18 @@
 package org.datadog.jmxfetch;
 
-import org.yaml.snakeyaml.Yaml;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
 
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.Map;
 
-@SuppressWarnings("unchecked")
 class YamlParser {
 
-    private Map<Object, Object> parsedYaml;
+    private final Map<Object, Object> parsedYaml;
 
     public YamlParser(InputStream yamlInputStream) {
-        parsedYaml = (Map<Object, Object>) new Yaml().load(yamlInputStream);
-    }
-
-    public YamlParser(YamlParser other) {
-        parsedYaml = new HashMap<Object, Object>((Map<Object, Object>) other.getParsedYaml());
+        LoadSettings settings = LoadSettings.builder().build();
+        parsedYaml = (Map<Object, Object>) new Load(settings).loadFromInputStream(yamlInputStream);
     }
 
     public Object getYamlInstances() {
@@ -25,9 +21,5 @@ class YamlParser {
 
     public Object getInitConfig() {
         return parsedYaml.get("init_config");
-    }
-
-    public Object getParsedYaml() {
-        return parsedYaml;
     }
 }

--- a/src/test/java/org/datadog/jmxfetch/StatusTest.java
+++ b/src/test/java/org/datadog/jmxfetch/StatusTest.java
@@ -6,7 +6,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -14,7 +13,8 @@ import org.datadog.jmxfetch.util.InstanceTelemetry;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.yaml.snakeyaml.Yaml;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
 
 public class StatusTest {
 
@@ -45,12 +45,13 @@ public class StatusTest {
         status.addInstanceStats("fake_check", "fake_instance", 10, 3, "fake_message", Status.STATUS_OK, instance);
         status.flush();
 
-        Yaml yaml = new Yaml();
+        LoadSettings settings = LoadSettings.builder().build(); //TODO
+        Load load = new Load(settings);
         InputStream inputStream = new FileInputStream(tempFilePath);
 
-        HashMap yamlMap = yaml.load(inputStream);
-        HashMap checks = (HashMap) yamlMap.get("checks");
-        HashMap initializedChecks = (HashMap) checks.get("initialized_checks");
+        Map<?, ?> yamlMap = (Map<?, ?>) load.loadFromInputStream(inputStream);
+        Map<?, ?> checks = (Map<?, ?>) yamlMap.get("checks");
+        Map<?, ?> initializedChecks = (Map<?, ?>) checks.get("initialized_checks");
         List<Map<String, Object>> fakeCheck = (List<Map<String, Object>>) initializedChecks.get("fake_check");
         Map<String, Object> stats = fakeCheck.get(0);
         assertEquals("fake_instance", stats.get("instance_name"));


### PR DESCRIPTION
The main motivation is to get rid of using snakeyaml reflection, which is poorly compatible with GraalVM native builds. snakeyaml-engine is a slimmer version of snakeyaml, but without support for JavaBeans that rely heavily on reflection.

This is required for Java Tracer, which has JMXFetch embedded in native builds builds https://github.com/DataDog/dd-trace-java/pull/8569.