### PR TITLE
Add GraalVM Native GC metrics

### DIFF
--- a/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
+++ b/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
@@ -193,6 +193,7 @@
       CollectionTime:
         alias: jvm.gc.minor_collection_time
         metric_type: counter
+
 # IBM J9 gencon
 - include:
     domain: java.lang
@@ -216,6 +217,7 @@
       CollectionTime:
         alias: jvm.gc.major_collection_time
         metric_type: counter
+
 # IBM J9 balanced
 - include:
     domain: java.lang
@@ -232,6 +234,30 @@
     domain: java.lang
     type: GarbageCollector
     name: global garbage collect
+    attribute:
+      CollectionCount:
+        alias: jvm.gc.major_collection_count
+        metric_type: counter
+      CollectionTime:
+        alias: jvm.gc.major_collection_time
+        metric_type: counter
+
+# GraalVM Native
+- include:
+    domain: java.lang
+    type: GarbageCollector
+    name: young generation scavenger
+    attribute:
+      CollectionCount:
+        alias: jvm.gc.minor_collection_count
+        metric_type: counter
+      CollectionTime:
+        alias: jvm.gc.minor_collection_time
+        metric_type: counter
+- include:
+    domain: java.lang
+    type: GarbageCollector
+    name: complete scavenger
     attribute:
       CollectionCount:
         alias: jvm.gc.major_collection_count


### PR DESCRIPTION
GraalVM Native has its own GC metric names:

<img width="249" alt="image" src="https://github.com/user-attachments/assets/ed19ef51-136b-4534-ad6e-12fdac47ebcb" />

With this change, they will be mapped to the appropriate major and minor collections, properly scraped by jmxfetch, and visible in the JVM Metrics dashboard.