### PR TITLE
chore: Add support for ZGC generational memory pools

### DIFF
--- a/src/main/resources/org/datadog/jmxfetch/default-jmx-metrics.yaml
+++ b/src/main/resources/org/datadog/jmxfetch/default-jmx-metrics.yaml
@@ -136,6 +136,14 @@
 - include:
     domain: java.lang
     type: MemoryPool
+    name: ZGC Young Generation
+    attribute:
+      Usage.used:
+        alias: jvm.gc.eden_size
+        metric_type: gauge
+- include:
+    domain: java.lang
+    type: MemoryPool
     name: Survivor Space
     attribute:
       Usage.used:
@@ -185,6 +193,14 @@
     domain: java.lang
     type: MemoryPool
     name: G1 Old Gen
+    attribute:
+      Usage.used:
+        alias: jvm.gc.old_gen_size
+        metric_type: gauge
+- include:
+    domain: java.lang
+    type: MemoryPool
+    name: ZGC Old Generation
     attribute:
       Usage.used:
         alias: jvm.gc.old_gen_size


### PR DESCRIPTION
Read `ZGC Young Generation` to `jvm.gc.eden_size`, and `ZGC Old Generation` to `jvm.gc.old_gen_size`.