### PR TITLE
Revert changes that broke Java 7 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,36 @@ jobs:
     - name: Run lint
       run: ./mvnw verify -B -Dhttps.protocols=TLSv1.2 -DskipTests
 
+  jdk7-verification:
+    name: JDK 7 verification
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+      
+    - name: Set up JDK 8
+      uses: actions/setup-java@v4
+      with:
+        java-version: '8'
+        distribution: 'temurin'
+        
+    - name: Cache Maven packages
+      uses: actions/cache@v4
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-m2-${{ github.ref }}-${{ hashFiles('**/pom.xml') }}-jdk7
+        restore-keys: |
+          ${{ runner.os }}-m2-${{ github.ref }}-
+          ${{ runner.os }}-m2-
+          
+    - name: Build JMXFetch
+      run: ./mvnw clean package -DskipTests
+
+    - name: Run using JDK 7
+      run: docker run -i --rm -v $(pwd):/app -w /app openjdk:7-jdk java -jar ./target/jmxfetch-0.49.9-SNAPSHOT-jar-with-dependencies.jar --help
+
   test:
     name: Test (OpenJDK ${{ matrix.java-version }})
     runs-on: ubuntu-latest

--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <lombok.version>1.18.38</lombok.version>
         <mockito.version>2.28.2</mockito.version>
         <slf4j.version>1.7.32</slf4j.version>
-        <snakeyaml-engine.version>2.9</snakeyaml-engine.version>
+        <snakeyaml.version>2.0</snakeyaml.version>
         <testcontainers.version>1.19.8</testcontainers.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -217,9 +217,9 @@
             <version>${slf4j.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.snakeyaml</groupId>
-            <artifactId>snakeyaml-engine</artifactId>
-            <version>${snakeyaml-engine.version}</version>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.management.j2ee</groupId>

--- a/src/main/java/org/datadog/jmxfetch/Instance.java
+++ b/src/main/java/org/datadog/jmxfetch/Instance.java
@@ -5,8 +5,9 @@ import org.datadog.jmxfetch.reporter.Reporter;
 import org.datadog.jmxfetch.service.ConfigServiceNameProvider;
 import org.datadog.jmxfetch.service.ServiceNameProvider;
 import org.datadog.jmxfetch.util.InstanceTelemetry;
-import org.snakeyaml.engine.v2.api.Load;
-import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.yaml.snakeyaml.Yaml;
+
+
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -42,12 +43,11 @@ public class Instance {
     public static final String JVM_DIRECT = "jvm_direct";
     public static final String ATTRIBUTE = "Attribute: ";
 
-    private static final ThreadLocal<Load> YAML =
-        new ThreadLocal<Load>() {
+    private static final ThreadLocal<Yaml> YAML =
+        new ThreadLocal<Yaml>() {
             @Override
-            public Load initialValue() {
-                LoadSettings settings = LoadSettings.builder().build();
-                return new Load(settings);
+            public Yaml initialValue() {
+                return new Yaml();
             }
         };
 
@@ -295,9 +295,9 @@ public class Instance {
     }
 
     private void loadDefaultConfig(String configResourcePath) {
-        InputStream is = this.getClass().getResourceAsStream(configResourcePath);
-        List<Map<String, Object>> defaultConf = (List<Map<String, Object>>)
-                YAML.get().loadFromInputStream(is);
+        List<Map<String, Object>> defaultConf =
+                (List<Map<String, Object>>)
+                        YAML.get().load(this.getClass().getResourceAsStream(configResourcePath));
         for (Map<String, Object> conf : defaultConf) {
             configurationList.add(new Configuration(conf));
         }
@@ -321,7 +321,7 @@ public class Instance {
                     yamlInputStream = new FileInputStream(yamlPath);
                     List<Map<String, Object>> confs =
                             (List<Map<String, Object>>)
-                                    YAML.get().loadFromInputStream(yamlInputStream);
+                                    YAML.get().load(yamlInputStream);
                     for (Map<String, Object> conf : confs) {
                         configurationList.add(new Configuration(conf));
                     }
@@ -360,7 +360,7 @@ public class Instance {
                     try {
                         Map<String, List<Map<String, Object>>> topYaml =
                                 (Map<String, List<Map<String, Object>>>)
-                                        YAML.get().loadFromInputStream(inputStream);
+                                        YAML.get().load(inputStream);
                         List<Map<String, Object>> jmxConf =
                                 topYaml.get("jmx_metrics");
                         if (jmxConf != null) {

--- a/src/main/java/org/datadog/jmxfetch/Status.java
+++ b/src/main/java/org/datadog/jmxfetch/Status.java
@@ -5,8 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.datadog.jmxfetch.util.InstanceTelemetry;
 import org.datadog.jmxfetch.util.MetadataHelper;
-import org.snakeyaml.engine.v2.api.Dump;
-import org.snakeyaml.engine.v2.api.DumpSettings;
+import org.yaml.snakeyaml.Yaml;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -148,17 +147,16 @@ public class Status {
     }
 
     private String generateYaml() {
-        Map<String, Object> status = new HashMap<>();
+        Map<String, Object> status = new HashMap<String, Object>();
         status.put("info", this.info);
         status.put("timestamp", System.currentTimeMillis());
         status.put("checks", this.instanceStats);
         status.put("errors", this.errors);
-        DumpSettings settings = DumpSettings.builder().build();
-        return new Dump(settings).dumpToString(status);
+        return new Yaml().dump(status);
     }
 
     private String generateJson() throws IOException {
-        Map<String, Object> status = new HashMap<>();
+        Map<String, Object> status = new HashMap<String, Object>();
         status.put("info", this.info);
         status.put("timestamp", System.currentTimeMillis());
         status.put("checks", this.instanceStats);

--- a/src/main/java/org/datadog/jmxfetch/YamlParser.java
+++ b/src/main/java/org/datadog/jmxfetch/YamlParser.java
@@ -1,18 +1,22 @@
 package org.datadog.jmxfetch;
 
-import org.snakeyaml.engine.v2.api.Load;
-import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.yaml.snakeyaml.Yaml;
 
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.Map;
 
+@SuppressWarnings("unchecked")
 class YamlParser {
 
-    private final Map<Object, Object> parsedYaml;
+    private Map<Object, Object> parsedYaml;
 
     public YamlParser(InputStream yamlInputStream) {
-        LoadSettings settings = LoadSettings.builder().build();
-        parsedYaml = (Map<Object, Object>) new Load(settings).loadFromInputStream(yamlInputStream);
+        parsedYaml = (Map<Object, Object>) new Yaml().load(yamlInputStream);
+    }
+
+    public YamlParser(YamlParser other) {
+        parsedYaml = new HashMap<Object, Object>((Map<Object, Object>) other.getParsedYaml());
     }
 
     public Object getYamlInstances() {
@@ -21,5 +25,9 @@ class YamlParser {
 
     public Object getInitConfig() {
         return parsedYaml.get("init_config");
+    }
+
+    public Object getParsedYaml() {
+        return parsedYaml;
     }
 }

--- a/src/test/java/org/datadog/jmxfetch/StatusTest.java
+++ b/src/test/java/org/datadog/jmxfetch/StatusTest.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -13,8 +14,7 @@ import org.datadog.jmxfetch.util.InstanceTelemetry;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-import org.snakeyaml.engine.v2.api.Load;
-import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.yaml.snakeyaml.Yaml;
 
 public class StatusTest {
 
@@ -45,13 +45,12 @@ public class StatusTest {
         status.addInstanceStats("fake_check", "fake_instance", 10, 3, "fake_message", Status.STATUS_OK, instance);
         status.flush();
 
-        LoadSettings settings = LoadSettings.builder().build(); //TODO
-        Load load = new Load(settings);
+        Yaml yaml = new Yaml();
         InputStream inputStream = new FileInputStream(tempFilePath);
 
-        Map<?, ?> yamlMap = (Map<?, ?>) load.loadFromInputStream(inputStream);
-        Map<?, ?> checks = (Map<?, ?>) yamlMap.get("checks");
-        Map<?, ?> initializedChecks = (Map<?, ?>) checks.get("initialized_checks");
+        HashMap yamlMap = yaml.load(inputStream);
+        HashMap checks = (HashMap) yamlMap.get("checks");
+        HashMap initializedChecks = (HashMap) checks.get("initialized_checks");
         List<Map<String, Object>> fakeCheck = (List<Map<String, Object>>) initializedChecks.get("fake_check");
         Map<String, Object> stats = fakeCheck.get(0);
         assertEquals("fake_instance", stats.get("instance_name"));


### PR DESCRIPTION
This reverts commit 5241d7d09f9ebbfd137c475bc1fd0cb5eab1d269 and adds a CI test to make sure the final artifact built supports Java 7.