### PR TITLE
chore: Starting dev cycle by returning version to a SNAPSHOT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       run: ./mvnw clean package -DskipTests
 
     - name: Run using JDK 7
-      run: docker run -i --rm -v $(pwd):/app -w /app azul/zulu-openjdk:7-latest java -jar ./target/jmxfetch-0.52.0-jar-with-dependencies.jar --help
+      run: docker run -i --rm -v $(pwd):/app -w /app azul/zulu-openjdk:7-latest java -jar ./target/jmxfetch-0.52.1-SNAPSHOT-jar-with-dependencies.jar --help
 
   test:
     name: Test (OpenJDK ${{ matrix.java-version }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Changelog
 =========
+# 0.52.1 / TBC
+
 # 0.52.0 / 2026-04-13
 * [FEATURE] Add `key_property` support for `dynamic_tags` to extract tag values from JMX bean name key properties [#601][]
 * [FEATURE] Add JMX metrics mappings for Generational Shenandoah GC [#596][] (Thanks [@krrg][])

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ otherwise the subsequent publishes will fail.
 
 ```
 Get help on usage:
-java -jar jmxfetch-0.52.0-jar-with-dependencies.jar --help
+java -jar jmxfetch-0.52.1-SNAPSHOT-jar-with-dependencies.jar --help
 ```
 
 ## Updating Maven Wrapper

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.datadoghq</groupId>
     <artifactId>jmxfetch</artifactId>
-    <version>0.52.0</version>
+    <version>0.52.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>jmxfetch</name>


### PR DESCRIPTION
## Summary
- Bumps version from `0.52.0` to `0.52.1-SNAPSHOT` in `pom.xml`, `README.md`, and `.github/workflows/test.yml`
- Adds `# 0.52.1 / TBC` placeholder to `CHANGELOG.md`

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)