### PR TITLE
feat(ai): Adding some "skills" to streamline creating releases

### DIFF
--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -60,9 +60,9 @@ jmxfetch-$ARGUMENTS-jar-with-dependencies.jar
 ```
 # X.Y.Z / TBC
 ```
-to:
+to (using today's date in `YYYY-MM-DD` format):
 ```
-# $ARGUMENTS / TBC
+# $ARGUMENTS / YYYY-MM-DD
 ```
 
 **Entries**: under the new heading, add one line per user-facing merged PR using this format:

--- a/.claude/skills/prepare-release/SKILL.md
+++ b/.claude/skills/prepare-release/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: prepare-release
+description: Prepares a jmxfetch release by bumping the version in pom.xml, README.md, and test.yml, and populating the CHANGELOG.md entry. Pass the new version as the argument (e.g. /prepare-release 0.52.0).
+allowed-tools: Read Edit Bash(git log *) Bash(git diff *) Bash(git add *) Bash(git commit *)
+argument-hint: <new-version>
+---
+
+You are preparing a jmxfetch release. The new version is: **$ARGUMENTS**
+
+## Step 1 — Gather current state
+
+Read these four files to understand what needs to change:
+
+1. **`pom.xml`** — find the current `<version>` tag (line ~8). It will look like `X.Y.Z-SNAPSHOT`.
+2. **`CHANGELOG.md`** — find the top `# X.Y.Z / TBC` placeholder heading, review its current entries (if any), and note the last set of `[#NNN]:` link definitions and `[@handle]:` contributor lines at the bottom.
+3. **`README.md`** — find the jar filename reference in the "Running" section (~line 184).
+4. **`.github/workflows/test.yml`** — find the jar filename in the JDK 7 verification step (~line 65).
+
+Also run:
+```bash
+git log --oneline $(git describe --tags --abbrev=0 2>/dev/null || git rev-list --max-parents=0 HEAD)..HEAD
+```
+to list all commits since the last tag — use this to identify merged PRs and any external contributors that need CHANGELOG entries and link definitions.
+
+## Step 2 — Update all four files
+
+### `pom.xml`
+Replace:
+```xml
+<version>CURRENT-SNAPSHOT</version>
+```
+With:
+```xml
+<version>$ARGUMENTS</version>
+```
+
+### `README.md`
+Replace the jar filename in the "Running" section:
+```
+jmxfetch-CURRENT-SNAPSHOT-jar-with-dependencies.jar
+```
+With:
+```
+jmxfetch-$ARGUMENTS-jar-with-dependencies.jar
+```
+
+### `.github/workflows/test.yml`
+Replace the jar filename in the JDK 7 `docker run` command:
+```
+jmxfetch-CURRENT-SNAPSHOT-jar-with-dependencies.jar
+```
+With:
+```
+jmxfetch-$ARGUMENTS-jar-with-dependencies.jar
+```
+
+### `CHANGELOG.md`
+
+**Heading**: rename the top placeholder:
+```
+# X.Y.Z / TBC
+```
+to:
+```
+# $ARGUMENTS / TBC
+```
+
+**Entries**: under the new heading, add one line per user-facing merged PR using this format:
+```
+* [TYPE] Description [#NNN][]
+```
+Types: `FEATURE`, `IMPROVEMENT`, `BUGFIX`, `SECURITY`, `OTHER`.
+Skip CI, infra, dependency bump, and test-only PRs — only include changes that affect users.
+For external contributors add ` (Thanks [@handle][])` at the end of the line.
+
+**Link definitions**: add new `[#NNN]:` entries in the sorted block near the bottom of the file (before the `[@handle]:` lines):
+```
+[#NNN]: https://github.com/DataDog/jmxfetch/issues/NNN
+```
+Use `/pull/NNN` instead of `/issues/NNN` for PRs that are pull-request-only (no linked issue).
+
+**Contributor handles**: add new `[@handle]:` entries at the very end of the file:
+```
+[@handle]: https://github.com/handle
+```
+
+## Step 3 — Review and commit
+
+Run:
+```bash
+git diff
+```
+to review the full changeset, then stage and commit:
+```bash
+git add pom.xml README.md .github/workflows/test.yml CHANGELOG.md
+git commit -m "chore: Preparing $ARGUMENTS release"
+```
+
+## Reference: CHANGELOG entry types
+
+| Type | When to use |
+|---|---|
+| `FEATURE` | New capability exposed to users |
+| `IMPROVEMENT` | Enhancement to existing behaviour or new config option |
+| `BUGFIX` | Fixes incorrect behaviour |
+| `SECURITY` | Dependency bump or fix for a CVE |
+| `OTHER` | Everything else worth noting (deprecations, removals) |

--- a/.claude/skills/start-dev-cycle/SKILL.md
+++ b/.claude/skills/start-dev-cycle/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: start-dev-cycle
+description: Starts a new jmxfetch development cycle by bumping to the next SNAPSHOT version in pom.xml, README.md, and test.yml, and adding a new CHANGELOG.md placeholder. Pass the next snapshot version as the argument (e.g. /start-dev-cycle 0.52.1-SNAPSHOT).
+allowed-tools: Read Edit Bash(git add *) Bash(git commit *) Bash(git push *) Bash(gh pr create *)
+argument-hint: <next-snapshot-version>
+---
+
+You are starting a new jmxfetch development cycle. The new SNAPSHOT version is: **$ARGUMENTS**
+
+## Step 1 — Read current state
+
+Read these four files to confirm the current version references before changing them:
+
+1. **`pom.xml`** — current `<version>` tag (~line 8)
+2. **`README.md`** — jar filename in the "Running" section (~line 184)
+3. **`.github/workflows/test.yml`** — jar filename in the JDK 7 verification step (~line 65)
+4. **`CHANGELOG.md`** — the top heading (first `# X.Y.Z / ...` line)
+
+## Step 2 — Update all four files
+
+### `pom.xml`
+Replace the current `<version>` with the new SNAPSHOT:
+```xml
+<version>$ARGUMENTS</version>
+```
+
+### `README.md`
+Replace the jar filename in the "Running" section:
+```
+jmxfetch-$ARGUMENTS-jar-with-dependencies.jar
+```
+
+### `.github/workflows/test.yml`
+Replace the jar filename in the JDK 7 `docker run` command:
+```
+jmxfetch-$ARGUMENTS-jar-with-dependencies.jar
+```
+
+### `CHANGELOG.md`
+Add a new placeholder section at the very top (after `Changelog\n=========`):
+```
+# X.Y.Z / TBC
+
+```
+Where `X.Y.Z` is the version from `$ARGUMENTS` with `-SNAPSHOT` stripped.
+
+## Step 3 — Commit, push and open PR
+
+Stage and commit all four files:
+```bash
+git add pom.xml README.md .github/workflows/test.yml CHANGELOG.md
+git commit -m "chore: Starting dev cycle by returning version to a SNAPSHOT"
+```
+
+Push the branch and open a PR against `master`:
+```bash
+git push -u origin HEAD
+gh pr create \
+  --title "chore: Starting dev cycle by returning version to a SNAPSHOT" \
+  --body "Bumps version to \`$ARGUMENTS\` and adds \`CHANGELOG.md\` placeholder for the next release."
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,6 +223,15 @@ This updates `pom.xml`, `README.md`, `.github/workflows/test.yml`, and `CHANGELO
 (version bump, jar filename references, changelog entries, link definitions) and commits
 with `chore: Preparing X.Y.Z release`.
 
+After the release PR merges, start the next dev cycle with the `/start-dev-cycle` skill:
+
+```
+/start-dev-cycle 0.52.1-SNAPSHOT
+```
+
+This bumps all version references to the next SNAPSHOT and adds a new `# X.Y.Z / TBC`
+placeholder to `CHANGELOG.md`.
+
 ## Important Notes
 
 - Target compatibility is Java 1.7, so avoid Java 8+ language features

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,18 @@ src/test/java/org/datadog/jmxfetch/
 - **IDE Setup**: Enable annotation processors for Lombok support
 - **Maven Wrapper**: Always use `./mvnw` instead of system Maven
 
+## Release
+
+To prepare a release, use the `/prepare-release` skill:
+
+```
+/prepare-release 0.52.0
+```
+
+This updates `pom.xml`, `README.md`, `.github/workflows/test.yml`, and `CHANGELOG.md`
+(version bump, jar filename references, changelog entries, link definitions) and commits
+with `chore: Preparing X.Y.Z release`.
+
 ## Important Notes
 
 - Target compatibility is Java 1.7, so avoid Java 8+ language features


### PR DESCRIPTION
The `prepare-release` skill was used to create the entries for the [0.52.0 release](https://github.com/DataDog/jmxfetch/blob/master/CHANGELOG.md#0520--2026-04-13). The PR #611 was created using the `start-dev-cycle` skill.