### PR TITLE
fix(deps): bump java-dogstatsd-client from 2.10.5 to 2.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Changelog
 =========
 # 0.52.1 / TBC
+* [BUGFIX] Bump `java-dogstatsd-client` from 2.10.5 to 2.13.1 to fix jmxfetch crash on AIX ppc64 (`invalid type: ssize_t` in jnr-ffi 2.1.12, fixed in 2.1.16) [#615][]
 
 # 0.52.0 / 2026-04-13
 * [FEATURE] Add `key_property` support for `dynamic_tags` to extract tag values from JMX bean name key properties [#601][]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 # 0.52.1 / TBC
-* [BUGFIX] Bump `java-dogstatsd-client` from 2.10.5 to 2.13.1 to fix jmxfetch crash on AIX ppc64 (`invalid type: ssize_t` in jnr-ffi 2.1.12, fixed in 2.1.16) [#615][]
+* [BUGFIX] Bump `java-dogstatsd-client` from 2.10.5 to 2.13.1 to fix jmxfetch on AIX ppc64 [#615][]
 
 # 0.52.0 / 2026-04-13
 * [FEATURE] Add `key_property` support for `dynamic_tags` to extract tag values from JMX bean name key properties [#601][]

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <apache-commons-lang3.version>3.5</apache-commons-lang3.version>
         <commons-io.version>2.4</commons-io.version>
         <hamcrest.version>2.2</hamcrest.version>
-        <java-dogstatsd-client.version>2.10.5</java-dogstatsd-client.version>
+        <java-dogstatsd-client.version>2.13.1</java-dogstatsd-client.version>
         <javax.management.j2ee-api.version>1.1.2</javax.management.j2ee-api.version>
         <jcommander.version>1.35</jcommander.version>
         <junit.version>4.13.2</junit.version>


### PR DESCRIPTION
Bumps `java-dogstatsd-client` from 2.10.5 to 2.13.1.

This pulls in `jnr-unixsocket` 0.36 -> `jnr-ffi` 2.1.16, which adds `platform/ppc64/aix/TypeAliases.class` (missing in 2.1.12). Without it, jmxfetch crashes on AIX ppc64 with `invalid type: ssize_t` when initializing the DogStatsD UDS reporter.
https://github.com/jnr/jnr-ffi/pull/190

`jnr-unixsocket` 0.36 still targets Java 7 (the jump to Java 8 happens at 0.38.0).

Validated on AIX 7.3 / IBM J9 JDK 8.