### PR TITLE
Emit ZGenerational Pauses beans under distinct aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ Changelog
 =========
 # 0.52.1 / TBC
 * [BUGFIX] Bump `java-dogstatsd-client` from 2.10.5 to 2.13.1 to fix jmxfetch on AIX ppc64 [#615][]
+* [FEATURE] Emit ZGenerational Pauses beans under distinct aliases so STW pause time can be observed independently from concurrent cycle duration
 
 # 0.52.0 / 2026-04-13
 * [FEATURE] Add `key_property` support for `dynamic_tags` to extract tag values from JMX bean name key properties [#601][]

--- a/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
+++ b/src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml
@@ -194,6 +194,36 @@
         alias: jvm.gc.minor_collection_time
         metric_type: counter
 
+# Additional distinct aliases for ZGenerational Pauses beans so that STW pause
+# time can be distinguished from concurrent cycle duration. The rules above map
+# both Cycles and Pauses to the same major/minor_collection_* metric names for
+# dashboard compatibility (see #509); because both use metric_type: counter, the
+# resulting metric is dominated by cycle time and pause time is not observable
+# on its own. The rules below emit the Pauses beans under distinct aliases,
+# following the same naming pattern used for non-generational ZGC Pauses above.
+- include:
+    domain: java.lang
+    type: GarbageCollector
+    name: ZGC Major Pauses
+    attribute:
+      CollectionCount:
+        alias: jvm.gc.zgc_major_pauses_collection_count
+        metric_type: counter
+      CollectionTime:
+        alias: jvm.gc.zgc_major_pauses_collection_time
+        metric_type: counter
+- include:
+    domain: java.lang
+    type: GarbageCollector
+    name: ZGC Minor Pauses
+    attribute:
+      CollectionCount:
+        alias: jvm.gc.zgc_minor_pauses_collection_count
+        metric_type: counter
+      CollectionTime:
+        alias: jvm.gc.zgc_minor_pauses_collection_time
+        metric_type: counter
+
 # IBM J9 gencon
 - include:
     domain: java.lang

--- a/src/test/java/org/datadog/jmxfetch/TestGCMetrics.java
+++ b/src/test/java/org/datadog/jmxfetch/TestGCMetrics.java
@@ -163,7 +163,7 @@ public class TestGCMetrics extends TestCommon {
         try (final MisbehavingJMXServer server = new MisbehavingJMXServer.Builder().withJDKImage(
             JDK_21).appendJavaOpts("-XX:+UseZGC -XX:+ZGenerational").build()) {
             final List<Map<String, Object>> actualMetrics = startAndGetMetrics(server, true);
-            assertThat(actualMetrics, hasSize(17));
+            assertThat(actualMetrics, hasSize(21));
             final List<String> gcCycles = Arrays.asList(
                 "ZGC Major Cycles",
                 "ZGC Major Pauses");
@@ -175,6 +175,17 @@ public class TestGCMetrics extends TestCommon {
                 "ZGC Minor Pauses");
             assertGCMetric(actualMetrics, "jvm.gc.minor_collection_count", gcPauses);
             assertGCMetric(actualMetrics, "jvm.gc.minor_collection_time", gcPauses);
+
+            // Distinct pause-only aliases so STW pause time can be observed
+            // independently from concurrent cycle duration.
+            assertGCMetric(actualMetrics,
+                "jvm.gc.zgc_major_pauses_collection_count", "ZGC Major Pauses", "counter");
+            assertGCMetric(actualMetrics,
+                "jvm.gc.zgc_major_pauses_collection_time", "ZGC Major Pauses", "counter");
+            assertGCMetric(actualMetrics,
+                "jvm.gc.zgc_minor_pauses_collection_count", "ZGC Minor Pauses", "counter");
+            assertGCMetric(actualMetrics,
+                "jvm.gc.zgc_minor_pauses_collection_time", "ZGC Minor Pauses", "counter");
         }
     }
 


### PR DESCRIPTION
## Summary

Add two `include` rules that map the `ZGC Major Pauses` and `ZGC Minor Pauses` MBeans to distinct metric aliases:

- `jvm.gc.zgc_major_pauses_collection_count` / `_time`
- `jvm.gc.zgc_minor_pauses_collection_count` / `_time`

The existing mapping to `jvm.gc.major_collection_*` / `jvm.gc.minor_collection_*` from #509 stays unchanged. The two new rules are purely additive — dashboards and consumers of the existing metrics are unaffected.

The naming pattern mirrors the existing non-generational ZGC Pauses aliases (`jvm.gc.zgc_pauses_collection_*`) already in the same file.

## Motivation

PR #509 mapped both `ZGC Major/Minor Cycles` **and** `ZGC Major/Minor Pauses` to the shared `major/minor_collection_*` aliases so the standard JVM Metrics dashboard would be usable with generational ZGC. That trade-off makes sense for dashboard compatibility.

The side effect, though, is that STW pause time gets hidden. Because both sets of MBeans use `metric_type: counter`, their `CollectionTime` values are summed by the backend, and `jvm.gc.major_collection_time` on generational ZGC becomes:

```
delta(ZGC Major Cycles.CollectionTime)  +  delta(ZGC Major Pauses.CollectionTime)
```

Cycle time (concurrent, hundreds of ms per cycle) dominates and pause time (STW, typically <1ms per pause) is not observable in the combined counter. STW pause time is the primary signal for GC-caused latency impact, so having it invisible is a real gap.

Concretely: a Java service using generational ZGC on JDK 21+ can only observe pause behavior via secondary signals (e.g. request p99 latency at the proxy layer). There's no direct JMX-side pause metric to graph or alert on.

The non-generational ZGC entries in this same file already avoid the conflation by using distinct `zgc_cycles_*` / `zgc_pauses_*` aliases. This PR extends the same pattern to the generational variant.

## What changes

- **`src/main/resources/org/datadog/jmxfetch/new-gc-default-jmx-metrics.yaml`** — two new `include` rules, one for `ZGC Major Pauses` and one for `ZGC Minor Pauses`, emitting under the distinct aliases.
- **`src/test/java/org/datadog/jmxfetch/TestGCMetrics.java`** — update `testDefaultNewGCMetricsUseGenerationalZGC` to expect 21 metrics (up from 17) and assert the four new metric names.
- **`CHANGELOG.md`** — one-line entry under the current `0.52.1 / TBC` section.

## Backward compatibility

Fully backward-compatible:
- No existing rule is modified.
- Every metric emitted before is still emitted (same alias, same tags, same values).
- Only new metrics are added.

Downstream users (dashboards, monitors, custom consumers) that rely on `jvm.gc.major_collection_time` / `_count` on generational ZGC keep seeing the same numbers. Users who want STW pause visibility get new metrics to graph.

## Test plan

- [x] `TestGCMetrics.testDefaultNewGCMetricsUseGenerationalZGC` updated to assert the four new metric names alongside the existing ones (17 → 21 metrics).
- [ ] CI runs the test against `JDK_21` with `-XX:+UseZGC -XX:+ZGenerational`.

Happy to iterate on naming or structure — I copied the non-generational ZGC pattern (`zgc_pauses_collection_*`) for consistency, but if you'd prefer something shorter (e.g. `jvm.gc.zgc_major_pauses.time`) I can adjust.