### PR TITLE
Update JavaVersion parsing to ignore EA / other version suffixes

### DIFF
--- a/src/main/java/org/datadog/jmxfetch/util/JavaVersion.java
+++ b/src/main/java/org/datadog/jmxfetch/util/JavaVersion.java
@@ -24,6 +24,11 @@ public final class JavaVersion {
     }
 
     private static int parseMajorJavaVersion(String str) {
+        int indexOfDash = str.indexOf('-');
+        if (indexOfDash >= 0) {
+            str = str.substring(0, indexOfDash);
+        }
+
         int value = 0;
         for (int i = 0; i < str.length(); i++) {
             char ch = str.charAt(i);
@@ -35,6 +40,8 @@ public final class JavaVersion {
                 } else {
                     break;
                 }
+            } else if (ch == '+') {
+                break;
             } else {
                 throw new NumberFormatException();
             }


### PR DESCRIPTION
Ignore `-ea`, `+1`, etc. suffixes when parsing for the Java major version.

For example, without this, the `dd-trace-java` JMXFetch tests fail on the JDK 27 EA build ([failed job](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-java/-/jobs/1835093863)).