### PR TITLE
chore: Preparing 0.52.1 release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       run: ./mvnw clean package -DskipTests
 
     - name: Run using JDK 7
-      run: docker run -i --rm -v $(pwd):/app -w /app azul/zulu-openjdk:7-latest java -jar ./target/jmxfetch-0.52.1-SNAPSHOT-jar-with-dependencies.jar --help
+      run: docker run -i --rm -v $(pwd):/app -w /app azul/zulu-openjdk:7-latest java -jar ./target/jmxfetch-0.52.1-jar-with-dependencies.jar --help
 
   test:
     name: Test (OpenJDK ${{ matrix.java-version }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 Changelog
 =========
-# 0.52.1 / TBC
+# 0.52.1 / 2026-07-31
 * [BUGFIX] Bump `java-dogstatsd-client` from 2.10.5 to 2.13.1 to fix jmxfetch on AIX ppc64 [#615][]
+* [BUGFIX] Ignore `-ea` and other version suffixes when parsing the Java major version [#617][]
 
 # 0.52.0 / 2026-04-13
 * [FEATURE] Add `key_property` support for `dynamic_tags` to extract tag values from JMX bean name key properties [#601][]
@@ -826,6 +827,8 @@ Changelog
 [#596]: https://github.com/DataDog/jmxfetch/issues/596
 [#597]: https://github.com/DataDog/jmxfetch/issues/597
 [#601]: https://github.com/DataDog/jmxfetch/pull/601
+[#615]: https://github.com/DataDog/jmxfetch/pull/615
+[#617]: https://github.com/DataDog/jmxfetch/pull/617
 [@alz]: https://github.com/alz
 [@aoking]: https://github.com/aoking
 [@arrawatia]: https://github.com/arrawatia

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ otherwise the subsequent publishes will fail.
 
 ```
 Get help on usage:
-java -jar jmxfetch-0.52.1-SNAPSHOT-jar-with-dependencies.jar --help
+java -jar jmxfetch-0.52.1-jar-with-dependencies.jar --help
 ```
 
 ## Updating Maven Wrapper

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.datadoghq</groupId>
     <artifactId>jmxfetch</artifactId>
-    <version>0.52.1-SNAPSHOT</version>
+    <version>0.52.1</version>
     <packaging>jar</packaging>
 
     <name>jmxfetch</name>


### PR DESCRIPTION
## Summary
- Bump version to 0.52.1 in `pom.xml`, `README.md`, and `.github/workflows/test.yml`
- Add CHANGELOG entries for #615 and #617

## Test plan
- [ ] CI passes on all JDK versions