### PR TITLE
chore: Starting dev cycle by returning version to a SNAPSHOT

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,7 @@ jobs:
       run: ./mvnw clean package -DskipTests
 
     - name: Run using JDK 7
-      run: docker run -i --rm -v $(pwd):/app -w /app azul/zulu-openjdk:7-latest java -jar ./target/jmxfetch-0.52.1-jar-with-dependencies.jar --help
+      run: docker run -i --rm -v $(pwd):/app -w /app azul/zulu-openjdk:7-latest java -jar ./target/jmxfetch-0.52.2-SNAPSHOT-jar-with-dependencies.jar --help
 
   test:
     name: Test (OpenJDK ${{ matrix.java-version }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 Changelog
 =========
+# 0.52.2 / TBC
+
 # 0.52.1 / 2026-07-31
 * [BUGFIX] Bump `java-dogstatsd-client` from 2.10.5 to 2.13.1 to fix jmxfetch on AIX ppc64 [#615][]
 * [BUGFIX] Ignore `-ea` and other version suffixes when parsing the Java major version [#617][]

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ otherwise the subsequent publishes will fail.
 
 ```
 Get help on usage:
-java -jar jmxfetch-0.52.1-jar-with-dependencies.jar --help
+java -jar jmxfetch-0.52.2-SNAPSHOT-jar-with-dependencies.jar --help
 ```
 
 ## Updating Maven Wrapper

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.datadoghq</groupId>
     <artifactId>jmxfetch</artifactId>
-    <version>0.52.1</version>
+    <version>0.52.2-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>jmxfetch</name>


### PR DESCRIPTION
Bumps version to `0.52.2-SNAPSHOT` and adds `CHANGELOG.md` placeholder for the next release.